### PR TITLE
[Cursor] Add artist_id to rooms for better chat filtering

### DIFF
--- a/app/api/room/create/route.tsx
+++ b/app/api/room/create/route.tsx
@@ -5,6 +5,7 @@ export async function GET(req: NextRequest) {
   const topic = req.nextUrl.searchParams.get("topic");
   const account_id = req.nextUrl.searchParams.get("account_id");
   const report_id = req.nextUrl.searchParams.get("report_id");
+  const artist_id = req.nextUrl.searchParams.get("artist_id");
 
   if (!topic || !account_id) {
     return Response.json(
@@ -18,6 +19,7 @@ export async function GET(req: NextRequest) {
       account_id,
       topic,
       report_id: report_id || undefined,
+      artist_id: artist_id || undefined,
     });
 
     return Response.json(result, { status: 200 });

--- a/hooks/useChat.tsx
+++ b/hooks/useChat.tsx
@@ -7,22 +7,28 @@ import { useConversationsProvider } from "@/providers/ConverstaionsProvider";
 import { usePromptsProvider } from "@/providers/PromptsProvider";
 import { useEffect, useState } from "react";
 import { v4 as uuidV4 } from "uuid";
+import { useArtistProvider } from "@/providers/ArtistProvider";
 
 const useChat = () => {
   const { userData, isPrepared } = useUserProvider();
   const { push } = useRouter();
   const { chat_id: chatId, agent_id: agentId } = useParams();
-  const { input, appendAiChat } = useMessagesProvider();
+  const { input, appendAiChat, setInput } = useMessagesProvider();
   const { addConversation } = useConversationsProvider();
   const { messages, pending } = useMessagesProvider();
   const { getPrompts } = usePromptsProvider();
-  const [appendActive, setAppendActive] = useState<any>(null);
+  const { selectedArtist } = useArtistProvider();
+  const [appendActive, setAppendActive] = useState<Message | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
   const createNewRoom = async (content: string) => {
     if (chatId) return;
     setIsLoading(true);
-    const room = await createRoom(userData.id, content);
+    const room = await createRoom(
+      userData.id, 
+      content, 
+      selectedArtist?.account_id
+    );
     addConversation(room);
     push(`/${room.id}`);
   };
@@ -41,6 +47,8 @@ const useChat = () => {
       content: input,
       role: "user",
     });
+    // Clear input immediately after submission
+    setInput("");
   };
 
   useEffect(() => {

--- a/hooks/useConversations.tsx
+++ b/hooks/useConversations.tsx
@@ -6,17 +6,30 @@ import { Conversation } from "@/types/Chat";
 import useArtistAgents from "./useArtistAgents";
 import { ArtistAgent } from "@/lib/supabase/getArtistAgents";
 
+// Define a more specific type that includes artist_id
+interface ConversationWithArtist extends Omit<Conversation, 'memories'> {
+  artist_id?: string;
+  memories: Array<{ artist_id: string }> | undefined;
+}
+
+interface ArtistAgentWithArtist extends ArtistAgent {
+  artist_id?: string;
+  memories?: Array<{ artist_id: string }>;
+}
+
+type ConversationItem = ConversationWithArtist | ArtistAgentWithArtist;
+
 const useConversations = () => {
   const { userData } = useUserProvider();
   const { selectedArtist } = useArtistProvider();
   const [allConverstaions, setAllConverstaions] = useState<
-    Array<Conversation | ArtistAgent>
+    Array<ConversationItem>
   >([]);
   const [quotaExceeded, setQuotaExceeded] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const { agents } = useArtistAgents();
 
-  const addConversation = (conversation: any) => {
+  const addConversation = (conversation: ConversationItem) => {
     setAllConverstaions([conversation, ...allConverstaions]);
   };
 
@@ -30,19 +43,27 @@ const useConversations = () => {
 
   const conversations = useMemo(() => {
     const filtered = allConverstaions.filter(
-      (item: Conversation | ArtistAgent) =>
-        (item as any)?.memories &&
-        (item as any)?.memories?.some(
-          (memory: { artist_id: string }) =>
-            memory.artist_id === selectedArtist?.account_id,
-        ),
+      (item: ConversationItem) => {
+        // Check if the item has artist_id directly matching selectedArtist's account_id
+        const directArtistMatch = item.artist_id === selectedArtist?.account_id;
+        
+        // Legacy check for memories containing artist_id that matches selectedArtist's account_id
+        const memoryArtistMatch = item.memories && 
+          item.memories.some(
+            (memory: { artist_id: string }) => 
+              memory.artist_id === selectedArtist?.account_id
+          );
+        
+        // Return true if either condition matches
+        return directArtistMatch || memoryArtistMatch;
+      }
     );
     return filtered;
   }, [selectedArtist, allConverstaions]);
 
   const fetchConversations = async () => {
     const data = await getConversations(userData.id);
-    setAllConverstaions([...data, ...agents]);
+    setAllConverstaions([...data, ...agents] as ConversationItem[]);
     setIsLoading(false);
   };
 

--- a/hooks/useMessages.tsx
+++ b/hooks/useMessages.tsx
@@ -28,6 +28,7 @@ const useMessages = () => {
     status,
     setMessages,
     reload: reloadAiChat,
+    setInput,
   } = useChat({
     api: `/api/chat`,
     headers: {
@@ -42,8 +43,14 @@ const useMessages = () => {
       if (chatId) {
         createMemory(message, chatId, selectedArtist?.account_id || "");
       }
+      setInput("");
     },
   });
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    handleAiChatSubmit(e);
+    setInput("");
+  };
 
   useEffect(() => {
     const fetch = async () => {
@@ -64,9 +71,10 @@ const useMessages = () => {
   return {
     reloadAiChat,
     appendAiChat,
-    handleAiChatSubmit,
+    handleAiChatSubmit: handleSubmit,
     handleInputChange,
     input,
+    setInput,
     setMessages,
     messages,
     pending: status === "streaming" || status === "submitted",

--- a/lib/createRoom.tsx
+++ b/lib/createRoom.tsx
@@ -1,12 +1,17 @@
 import getAiTitle from "./getAiTitle";
 
-const createRoom = async (account_id: string, content: string) => {
+const createRoom = async (account_id: string, content: string, artist_id?: string) => {
   try {
     const title = await getAiTitle(content);
     const topic = title.replaceAll(`\"`, "");
-    const response = await fetch(
-      `/api/room/create?account_id=${account_id}&topic=${encodeURIComponent(topic)}`,
-    );
+    
+    // Construct the URL with artist_id parameter if available
+    let url = `/api/room/create?account_id=${account_id}&topic=${encodeURIComponent(topic)}`;
+    if (artist_id) {
+      url += `&artist_id=${artist_id}`;
+    }
+    
+    const response = await fetch(url);
     const data = await response.json();
     return data.new_room;
   } catch (error) {

--- a/lib/supabase/createRoomWithReport.ts
+++ b/lib/supabase/createRoomWithReport.ts
@@ -8,12 +8,14 @@ interface CreateRoomParams {
   account_id: string;
   topic: string;
   report_id?: string;
+  artist_id?: string;
 }
 
 export const createRoomWithReport = async ({
   account_id,
   topic,
   report_id,
+  artist_id,
 }: CreateRoomParams): Promise<{
   new_room: Room & { memories: []; rooms_reports: string[] };
   error: PostgrestError | null;
@@ -24,6 +26,7 @@ export const createRoomWithReport = async ({
       .insert({
         account_id,
         topic,
+        artist_id,
       })
       .select("*")
       .single();


### PR DESCRIPTION
[Cursor] Add artist_id to rooms for better chat filtering

This PR adds support for associating chat rooms directly with artists:

- Added artist_id parameter to createRoomWithReport function
- Updated API route to accept artist_id param
- Modified createRoom to pass selectedArtist account_id
- Enhanced useConversations to filter by artist_id
- Fixed chat input not clearing after submission bug

These changes ensure that:
1. New chat rooms are created with the proper artist_id
2. Recent chats are correctly filtered by the selected artist
3. Backward compatibility is maintained for existing rooms
