### PR TITLE
MYC-1233: Fix Artist Switching Bug in Chat Application

### DIFF
--- a/app/api/room/create/route.tsx
+++ b/app/api/room/create/route.tsx
@@ -5,6 +5,7 @@ export async function GET(req: NextRequest) {
   const topic = req.nextUrl.searchParams.get("topic");
   const account_id = req.nextUrl.searchParams.get("account_id");
   const report_id = req.nextUrl.searchParams.get("report_id");
+  const artist_id = req.nextUrl.searchParams.get("artist_id");
 
   if (!topic || !account_id) {
     return Response.json(
@@ -18,6 +19,7 @@ export async function GET(req: NextRequest) {
       account_id,
       topic,
       report_id: report_id || undefined,
+      artist_id: artist_id || undefined,
     });
 
     return Response.json(result, { status: 200 });

--- a/app/new/page.tsx
+++ b/app/new/page.tsx
@@ -2,12 +2,20 @@
 
 import ChatSkeleton from "@/components/Chat/ChatSkeleton";
 import InitialChat from "@/components/Chat/InitialChat";
+import ArtistSyncForChat from "@/components/Chat/ArtistSyncForChat";
 import { useChatProvider } from "@/providers/ChatProvider";
 
 const NewChatPage = () => {
   const { isLoading } = useChatProvider();
+  
   if (isLoading) return <ChatSkeleton />;
-  return <InitialChat />;
+  
+  return (
+    <>
+      <ArtistSyncForChat />
+      <InitialChat />
+    </>
+  );
 };
 
 export default NewChatPage;

--- a/components/Chat/ArtistSyncForChat.tsx
+++ b/components/Chat/ArtistSyncForChat.tsx
@@ -86,6 +86,60 @@ const ArtistSyncForChat = () => {
     }
   };
 
+  // Function to validate and clean up stored artist data
+  const validateStoredArtistData = () => {
+    try {
+      // Check localStorage for stored artist
+      const storedArtist = localStorage.getItem("RECOUP_ARTIST");
+      if (storedArtist) {
+        const artistData = JSON.parse(storedArtist);
+        
+        // Check if this artist exists in our current artists list
+        const artistExists = artists.some(
+          (artist) => artist.account_id === artistData.account_id
+        );
+        
+        // If the artist doesn't exist in our current list, remove it from localStorage
+        if (!artistExists) {
+          console.log("Stored artist no longer exists in artists list, removing from localStorage:", artistData.name);
+          localStorage.removeItem("RECOUP_ARTIST");
+          
+          // If this was the selected artist, clear it
+          if (selectedArtist && selectedArtist.account_id === artistData.account_id) {
+            console.log("Clearing selected artist as it no longer exists");
+            setSelectedArtist(null);
+          }
+        }
+      }
+      
+      // Check localStorage for room artist data
+      const storedRoomArtist = localStorage.getItem("RECOUP_ROOM_ARTIST");
+      if (storedRoomArtist) {
+        const roomArtistData = JSON.parse(storedRoomArtist);
+        
+        // Check if this artist exists in our current artists list
+        const artistExists = artists.some(
+          (artist) => artist.account_id === roomArtistData.artistId
+        );
+        
+        // If the artist doesn't exist in our current list, remove it from localStorage
+        if (!artistExists) {
+          console.log("Stored room artist no longer exists in artists list, removing from localStorage");
+          localStorage.removeItem("RECOUP_ROOM_ARTIST");
+        }
+      }
+    } catch (e) {
+      console.error("Error validating stored artist data:", e);
+    }
+  };
+
+  // Add this effect to validate stored artist data when artists are loaded
+  useEffect(() => {
+    if (artists.length > 0) {
+      validateStoredArtistData();
+    }
+  }, [artists]);
+
   // First effect: Make sure artists are loaded
   useEffect(() => {
     if (artists.length === 0) {

--- a/components/Chat/ArtistSyncForChat.tsx
+++ b/components/Chat/ArtistSyncForChat.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+import { useEffect, useState, useRef } from "react";
+import { useParams } from "next/navigation";
+import { useArtistProvider } from "@/providers/ArtistProvider";
+import { createClient } from '@supabase/supabase-js';
+
+/**
+ * This component ensures that the selected artist matches the artist_id of the current chat room.
+ * It prevents automatic artist switching when navigating to a chat page,
+ * but allows manual artist switching by the user.
+ */
+const ArtistSyncForChat = () => {
+  const { chat_id } = useParams();
+  const { selectedArtist, setSelectedArtist, artists, getArtists } = useArtistProvider();
+  const [isLoading, setIsLoading] = useState(false);
+  const [retryCount, setRetryCount] = useState(0);
+  const [lastSyncedArtistId, setLastSyncedArtistId] = useState<string | null>(null);
+  const manualSwitchRef = useRef<boolean>(false);
+  const initialSyncDoneRef = useRef<boolean>(false);
+  const previousArtistIdRef = useRef<string | null>(null);
+
+  console.log("==== ArtistSyncForChat MOUNTED ====");
+  console.log("Current chat_id:", chat_id);
+  console.log("Current selectedArtist:", selectedArtist?.name, selectedArtist?.account_id);
+  console.log("Available artists:", artists.map(a => ({ name: a.name, id: a.account_id })));
+
+  // These environment variables are publicly accessible in the browser
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string;
+  
+  // Fallback to hardcoded values if environment variables are unavailable
+  const finalUrl = supabaseUrl || 'https://pmxxzslzlnqttcnwsrsc.supabase.co';
+  const supabase = createClient(finalUrl, supabaseAnonKey);
+
+  // Track artist changes to detect manual switches
+  useEffect(() => {
+    if (!selectedArtist || !previousArtistIdRef.current) {
+      previousArtistIdRef.current = selectedArtist?.account_id || null;
+      return;
+    }
+
+    // If artist changed and it wasn't due to our sync process
+    if (selectedArtist.account_id !== previousArtistIdRef.current && initialSyncDoneRef.current) {
+      console.log("Manual artist switch detected:", selectedArtist.name);
+      manualSwitchRef.current = true;
+      
+      // Update the room artist data in localStorage to reflect manual switch
+      try {
+        const roomArtistData = {
+          roomId: chat_id,
+          artistId: selectedArtist.account_id
+        };
+        localStorage.setItem("RECOUP_ROOM_ARTIST", JSON.stringify(roomArtistData));
+        console.log("Updated room artist data after manual switch:", roomArtistData);
+        
+        // Update lastSyncedArtistId to prevent further syncing
+        setLastSyncedArtistId(selectedArtist.account_id);
+        
+        // Update the room's artist_id in the database
+        updateRoomArtistId(chat_id as string, selectedArtist.account_id);
+      } catch (e) {
+        console.error("Failed to update room artist data after manual switch:", e);
+      }
+    }
+    
+    previousArtistIdRef.current = selectedArtist.account_id;
+  }, [selectedArtist?.account_id, chat_id]);
+
+  // Function to update the room's artist_id in the database
+  const updateRoomArtistId = async (roomId: string, artistId: string) => {
+    try {
+      console.log("Updating room artist_id in database:", { roomId, artistId });
+      const { error } = await supabase
+        .from("rooms")
+        .update({ artist_id: artistId })
+        .eq("id", roomId);
+        
+      if (error) {
+        console.error("Error updating room artist_id:", error);
+      } else {
+        console.log("Room artist_id updated successfully");
+      }
+    } catch (e) {
+      console.error("Failed to update room artist_id:", e);
+    }
+  };
+
+  // First effect: Make sure artists are loaded
+  useEffect(() => {
+    if (artists.length === 0) {
+      console.log("No artists available, fetching artists data...");
+      getArtists();
+    }
+  }, [artists.length, getArtists]);
+
+  // Second effect: Check localStorage for room artist data
+  useEffect(() => {
+    if (!chat_id || !artists.length) return;
+    
+    // Skip if a manual switch has occurred
+    if (manualSwitchRef.current) {
+      console.log("Manual switch detected, skipping localStorage check");
+      return;
+    }
+    
+    try {
+      const storedRoomArtist = localStorage.getItem("RECOUP_ROOM_ARTIST");
+      if (storedRoomArtist) {
+        const roomArtistData = JSON.parse(storedRoomArtist);
+        console.log("Found stored room artist data:", roomArtistData);
+        
+        // Check if this is the same room
+        if (roomArtistData.roomId === chat_id) {
+          console.log("Room ID matches current chat_id");
+          
+          // Find the matching artist
+          const matchingArtist = artists.find(
+            (artist) => artist.account_id === roomArtistData.artistId
+          );
+          
+          if (matchingArtist && (!selectedArtist || selectedArtist.account_id !== matchingArtist.account_id)) {
+            console.log(`Setting artist from localStorage: ${matchingArtist.name}`);
+            setSelectedArtist(matchingArtist);
+            setLastSyncedArtistId(matchingArtist.account_id);
+            initialSyncDoneRef.current = true;
+            return;
+          }
+        }
+      }
+    } catch (e) {
+      console.error("Error checking localStorage for room artist data:", e);
+    }
+  }, [chat_id, artists, selectedArtist, setSelectedArtist]);
+
+  // Third effect: Sync artist with room from Supabase
+  useEffect(() => {
+    console.log("==== ArtistSyncForChat EFFECT TRIGGERED ====");
+    console.log("Effect params - chat_id:", chat_id, "selectedArtist:", selectedArtist?.account_id);
+    console.log("Retry count:", retryCount);
+    console.log("Manual switch flag:", manualSwitchRef.current);
+    console.log("Initial sync done:", initialSyncDoneRef.current);
+    
+    // Skip if we've already synced this artist, if we're still loading, or if a manual switch occurred
+    if (lastSyncedArtistId === selectedArtist?.account_id || manualSwitchRef.current || initialSyncDoneRef.current) {
+      console.log("Already synced this artist, manual switch occurred, or initial sync done - skipping");
+      return;
+    }
+    
+    const syncArtistWithRoom = async () => {
+      if (!chat_id || isLoading || !artists.length) {
+        console.log("Sync skipped - Missing required data:", { 
+          chat_id: !!chat_id, 
+          isLoading, 
+          hasArtists: artists.length > 0 
+        });
+        return;
+      }
+      
+      console.log("Starting artist sync for chat:", chat_id);
+      setIsLoading(true);
+      
+      try {
+        console.log("Fetching room data from Supabase...");
+        // Fetch the room to get its artist_id
+        const { data: room, error } = await supabase
+          .from("rooms")
+          .select("artist_id, topic")
+          .eq("id", chat_id)
+          .single();
+          
+        if (error) {
+          console.error("Error fetching room for artist sync:", error);
+          
+          // If we haven't retried too many times, schedule a retry
+          if (retryCount < 3) {
+            console.log(`Scheduling retry ${retryCount + 1}/3 in 1 second...`);
+            setTimeout(() => {
+              setRetryCount(retryCount + 1);
+            }, 1000);
+          } else {
+            console.log("Max retries reached, giving up on artist sync");
+            initialSyncDoneRef.current = true;
+          }
+          
+          setIsLoading(false);
+          return;
+        }
+        
+        console.log("Room data received:", room);
+        
+        if (room?.artist_id) {
+          console.log("Room has artist_id:", room.artist_id);
+          console.log("Current selectedArtist:", selectedArtist?.account_id);
+          
+          // Store that we've synced this artist
+          setLastSyncedArtistId(room.artist_id);
+          
+          // Store the room artist data in localStorage
+          try {
+            const roomArtistData = {
+              roomId: chat_id,
+              artistId: room.artist_id
+            };
+            localStorage.setItem("RECOUP_ROOM_ARTIST", JSON.stringify(roomArtistData));
+            console.log("Saved room artist data to localStorage:", roomArtistData);
+          } catch (e) {
+            console.error("Failed to save room artist data to localStorage:", e);
+          }
+          
+          // If the room has an artist_id and it's different from the currently selected artist
+          if (!selectedArtist || selectedArtist.account_id !== room.artist_id) {
+            console.log("Artist mismatch detected, finding matching artist...");
+            // Find the artist in the list that matches the room's artist_id
+            const matchingArtist = artists.find(
+              (artist) => artist.account_id === room.artist_id
+            );
+            
+            // If found, set it as the selected artist
+            if (matchingArtist) {
+              console.log(`Syncing artist selection to match chat - FROM: ${selectedArtist?.name} TO: ${matchingArtist.name}`);
+              
+              // Use localStorage as a backup to ensure persistence
+              try {
+                localStorage.setItem("RECOUP_ARTIST", JSON.stringify(matchingArtist));
+                console.log("Saved artist to localStorage as backup");
+              } catch (e) {
+                console.error("Failed to save artist to localStorage:", e);
+              }
+              
+              setSelectedArtist(matchingArtist);
+            } else {
+              console.log("No matching artist found in available artists list");
+            }
+          } else {
+            console.log("Artist already matches chat room, no change needed");
+          }
+        } else {
+          console.log("Room has no artist_id, keeping current selection");
+        }
+        
+        // Mark initial sync as done
+        initialSyncDoneRef.current = true;
+      } catch (error) {
+        console.error("Error in syncArtistWithRoom:", error);
+        initialSyncDoneRef.current = true;
+      } finally {
+        setIsLoading(false);
+        console.log("Artist sync process completed");
+      }
+    };
+
+    syncArtistWithRoom();
+  }, [chat_id, selectedArtist?.account_id, artists, setSelectedArtist, isLoading, retryCount, lastSyncedArtistId]);
+
+  // This is a utility component that doesn't render anything
+  return null;
+};
+
+export default ArtistSyncForChat; 

--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -6,6 +6,7 @@ import Messages from "./Messages";
 import { ScrollTo } from "react-scroll-to";
 import ChatSkeleton from "./ChatSkeleton";
 import { ChatReport } from "./ChatReport";
+import ArtistSyncForChat from "./ArtistSyncForChat";
 
 interface ChatProps {
   reportId?: string;
@@ -18,6 +19,8 @@ const Chat = ({ reportId }: ChatProps) => {
 
   return (
     <div className="size-full flex flex-col items-center justify-center bg-white rounded-xl overflow-hidden flex flex-col px-4 pb-5 md:pt-[14px]">
+      <ArtistSyncForChat />
+      
       <ScrollTo>
         {({ scroll }) => (
           <Messages scroll={scroll}>

--- a/components/Sidebar/RecentChats.tsx
+++ b/components/Sidebar/RecentChats.tsx
@@ -4,7 +4,7 @@ import RecentChatSkeleton from "./RecentChatSkeleton";
 import capitalize from "@/lib/capitalize";
 
 const RecentChats = ({ toggleModal }: { toggleModal: () => void }) => {
-  const { allConverstaions, isLoading } = useConversationsProvider();
+  const { conversations, isLoading } = useConversationsProvider();
   const { handleClick } = useClickChat();
 
   return (
@@ -18,20 +18,26 @@ const RecentChats = ({ toggleModal }: { toggleModal: () => void }) => {
           <RecentChatSkeleton />
         ) : (
           <>
-            {/* eslint-disable-next-line */}
-            {allConverstaions.map((conversation: any, index: number) => (
-              <button
-                className="flex gap-2 items-center"
-                key={index}
-                type="button"
-                onClick={() => handleClick(conversation, toggleModal)}
-              >
-                <p className="text-sm truncate max-w-[200px]">
-                  {conversation?.topic ||
-                    `${capitalize(conversation?.type)} Analysis`}
-                </p>
-              </button>
-            ))}
+            {conversations.length === 0 ? (
+              <p className="text-sm text-grey-dark">No recent chats</p>
+            ) : (
+              <>
+                {/* eslint-disable-next-line */}
+                {conversations.map((conversation: any, index: number) => (
+                  <button
+                    className="flex gap-2 items-center"
+                    key={index}
+                    type="button"
+                    onClick={() => handleClick(conversation, toggleModal)}
+                  >
+                    <p className="text-sm truncate max-w-[200px]">
+                      {conversation?.topic ||
+                        `${capitalize(conversation?.type)} Analysis`}
+                    </p>
+                  </button>
+                ))}
+              </>
+            )}
           </>
         )}
       </div>

--- a/hooks/useChat.tsx
+++ b/hooks/useChat.tsx
@@ -5,8 +5,10 @@ import { useMessagesProvider } from "@/providers/MessagesProvider";
 import createRoom from "@/lib/createRoom";
 import { useConversationsProvider } from "@/providers/ConverstaionsProvider";
 import { usePromptsProvider } from "@/providers/PromptsProvider";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import { v4 as uuidV4 } from "uuid";
+import { useArtistProvider } from "@/providers/ArtistProvider";
+import { ArtistRecord } from "@/types/Artist";
 
 const useChat = () => {
   const { userData, isPrepared } = useUserProvider();
@@ -16,14 +18,61 @@ const useChat = () => {
   const { addConversation } = useConversationsProvider();
   const { messages, pending } = useMessagesProvider();
   const { getPrompts } = usePromptsProvider();
-  const [appendActive, setAppendActive] = useState<any>(null);
+  const { selectedArtist } = useArtistProvider();
+  const [appendActive, setAppendActive] = useState<Message | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const preservedArtistRef = useRef<ArtistRecord | null>(null);
+
+  // Store the current artist when the component mounts
+  useEffect(() => {
+    if (selectedArtist) {
+      console.log("==== useChat: Storing current artist ====", selectedArtist.name);
+      preservedArtistRef.current = selectedArtist;
+      
+      // Also save to localStorage as a backup
+      try {
+        localStorage.setItem("RECOUP_ARTIST", JSON.stringify(selectedArtist));
+        console.log("Saved artist to localStorage from useChat");
+      } catch (e) {
+        console.error("Failed to save artist to localStorage:", e);
+      }
+    }
+  }, [selectedArtist]);
 
   const createNewRoom = async (content: string) => {
     if (chatId) return;
+    
     setIsLoading(true);
+    
+    // Use the preserved artist if available
+    const artistToUse = preservedArtistRef.current || selectedArtist;
+    
+    console.log("==== useChat: Creating new room ====");
+    console.log("Using artist:", artistToUse?.name, artistToUse?.account_id);
+    
+    // Create room with the content
+    // Note: createRoom only accepts account_id and content parameters
     const room = await createRoom(userData.id, content);
+    
+    // If the room has an artist_id field, we'll update it separately
+    // This is a workaround since createRoom doesn't accept artist_id
+    
     addConversation(room);
+    
+    // Store the room's artist_id in localStorage before navigation
+    if (room && artistToUse) {
+      try {
+        const roomArtistData = {
+          roomId: room.id,
+          artistId: artistToUse.account_id
+        };
+        localStorage.setItem("RECOUP_ROOM_ARTIST", JSON.stringify(roomArtistData));
+        console.log("Saved room artist data to localStorage:", roomArtistData);
+      } catch (e) {
+        console.error("Failed to save room artist data to localStorage:", e);
+      }
+    }
+    
     push(`/${room.id}`);
   };
 
@@ -36,6 +85,21 @@ const useChat = () => {
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!isPrepared()) return;
+    
+    // Store the current artist before submission
+    if (selectedArtist) {
+      console.log("==== useChat: Storing artist before submission ====", selectedArtist.name);
+      preservedArtistRef.current = selectedArtist;
+      
+      // Also save to localStorage as a backup
+      try {
+        localStorage.setItem("RECOUP_ARTIST", JSON.stringify(selectedArtist));
+        console.log("Saved artist to localStorage before submission");
+      } catch (e) {
+        console.error("Failed to save artist to localStorage:", e);
+      }
+    }
+    
     append({
       id: uuidV4(),
       content: input,

--- a/hooks/useChat.tsx
+++ b/hooks/useChat.tsx
@@ -50,12 +50,12 @@ const useChat = () => {
     console.log("==== useChat: Creating new room ====");
     console.log("Using artist:", artistToUse?.name, artistToUse?.account_id);
     
-    // Create room with the content
-    // Note: createRoom only accepts account_id and content parameters
-    const room = await createRoom(userData.id, content);
-    
-    // If the room has an artist_id field, we'll update it separately
-    // This is a workaround since createRoom doesn't accept artist_id
+    // Create room with the content and artist_id
+    const room = await createRoom(
+      userData.id, 
+      content, 
+      artistToUse?.account_id
+    );
     
     addConversation(room);
     

--- a/hooks/useFirstArtistRedirect.tsx
+++ b/hooks/useFirstArtistRedirect.tsx
@@ -3,27 +3,43 @@
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { usePrivy } from "@privy-io/react-auth";
+import { useArtistProvider } from "@/providers/ArtistProvider";
 
 export function useFirstArtistRedirect() {
   const router = useRouter();
   const { ready, authenticated, user } = usePrivy();
+  const { selectedArtist, artists, setSelectedArtist } = useArtistProvider();
 
   useEffect(() => {
     async function checkAndRedirect() {
       if (!ready || !authenticated || !user?.email?.address) return;
 
       try {
-        const response = await fetch(
-          `/api/artists?email=${encodeURIComponent(user.email.address)}`,
-        );
-        const data = await response.json();
-
-        if (!response.ok) {
-          throw new Error(data.message || "Failed to fetch artists");
+        // If we already have a selected artist, don't change it
+        if (selectedArtist) {
+          console.log("Artist already selected:", selectedArtist.name);
+          return;
         }
 
-        if (!data.artists || data.artists.length === 0) {
-          router.push("/funnels/wrapped");
+        // Only fetch artists if we don't have any loaded yet
+        if (artists.length === 0) {
+          console.log("Fetching artists for the first time");
+          const response = await fetch(
+            `/api/artists?email=${encodeURIComponent(user.email.address)}`,
+          );
+          const data = await response.json();
+
+          if (!response.ok) {
+            throw new Error(data.message || "Failed to fetch artists");
+          }
+
+          if (!data.artists || data.artists.length === 0) {
+            router.push("/funnels/wrapped");
+          }
+        } else if (!selectedArtist && artists.length > 0) {
+          // Only set the first artist if no artist is currently selected
+          console.log("Setting first artist as selected:", artists[0].name);
+          setSelectedArtist(artists[0]);
         }
       } catch (error) {
         console.error("Error checking artists:", error);
@@ -31,5 +47,5 @@ export function useFirstArtistRedirect() {
     }
 
     checkAndRedirect();
-  }, [ready, authenticated, user?.email?.address, router]);
+  }, [ready, authenticated, user?.email?.address, router, selectedArtist, artists, setSelectedArtist]);
 }

--- a/hooks/usePrompts.tsx
+++ b/hooks/usePrompts.tsx
@@ -16,19 +16,27 @@ const usePrompts = () => {
 
   useEffect(() => {
     if (isLoading) return;
+    
+    // If we have a selected artist and we're on the new chat page, set relevant prompts
     if (selectedArtist && isNewChat) {
       setPrompts([
-        `Who are ${selectedArtist?.name || ""}’s most engaged fans?`,
-        `Analyze ${selectedArtist?.name || ""}’s TikTok posts from this week.`,
+        `Who are ${selectedArtist?.name || ""}'s most engaged fans?`,
+        `Analyze ${selectedArtist?.name || ""}'s TikTok posts from this week.`,
       ]);
       return;
     }
-    if (artists.length) {
+    
+    // Only select the first artist if there's truly no artist selected
+    // AND there's no artist saved in localStorage
+    if (artists.length && !selectedArtist && !localStorage.getItem("RECOUP_ARTIST")) {
+      console.log("No artist selected, selecting first artist as fallback");
       setSelectedArtist(artists[0]);
       return;
     }
+    
+    // Default prompts if no conditions above are met
     setPrompts(SUGGESTIONS);
-  }, [selectedArtist, isNewChat, artists, isLoading]);
+  }, [selectedArtist, isNewChat, artists, isLoading, setSelectedArtist]);
 
   const getPrompts = async (content: string, isTikTokAnalysis?: boolean) => {
     const isFunnelReport = content === "Funnel Report";

--- a/lib/createRoom.tsx
+++ b/lib/createRoom.tsx
@@ -1,12 +1,17 @@
 import getAiTitle from "./getAiTitle";
 
-const createRoom = async (account_id: string, content: string) => {
+const createRoom = async (account_id: string, content: string, artist_id?: string) => {
   try {
     const title = await getAiTitle(content);
     const topic = title.replaceAll(`\"`, "");
-    const response = await fetch(
-      `/api/room/create?account_id=${account_id}&topic=${encodeURIComponent(topic)}`,
-    );
+    
+    // Construct the URL with artist_id parameter if available
+    let url = `/api/room/create?account_id=${account_id}&topic=${encodeURIComponent(topic)}`;
+    if (artist_id) {
+      url += `&artist_id=${artist_id}`;
+    }
+    
+    const response = await fetch(url);
     const data = await response.json();
     return data.new_room;
   } catch (error) {

--- a/lib/supabase/createRoomWithReport.ts
+++ b/lib/supabase/createRoomWithReport.ts
@@ -8,12 +8,14 @@ interface CreateRoomParams {
   account_id: string;
   topic: string;
   report_id?: string;
+  artist_id?: string;
 }
 
 export const createRoomWithReport = async ({
   account_id,
   topic,
   report_id,
+  artist_id,
 }: CreateRoomParams): Promise<{
   new_room: Room & { memories: []; rooms_reports: string[] };
   error: PostgrestError | null;
@@ -24,6 +26,7 @@ export const createRoomWithReport = async ({
       .insert({
         account_id,
         topic,
+        artist_id,
       })
       .select("*")
       .single();


### PR DESCRIPTION
# Fix artist switching issue in chat application

## Problem
The application was randomly switching the selected artist (e.g., from "ChillPill" to "Sidney Swift") when:
- Creating a new chat
- Navigating between chats
- Submitting messages in a chat

## Solution
1. **Added `ArtistSyncForChat` Component**:
   - Syncs the selected artist with the room's artist_id in the database
   - Detects and distinguishes between automatic and manual artist switches
   - Updates the database when manual switches occur
   - Uses localStorage for persistence across page navigations

2. **Enhanced Chat Creation Logic**:
   - Preserves the selected artist during chat creation
   - Stores artist data in localStorage before navigation
   - Ensures the correct artist is associated with new chats

3. **Prevented Unnecessary Artist Switching**:
   - Modified `useFirstArtistRedirect` to respect existing artist selection
   - Updated `usePrompts` to only select the first artist when truly needed
   - Added checks for localStorage to maintain persistence

4. **Fixed RecentChats Component**:
   - Updated to use the correct variable name (`conversations` instead of `allConverstaions`)
   - Added handling for empty conversations

## Testing
The fix has been tested and confirmed to:
- Prevent automatic artist switching
- Allow manual artist switching in both new and existing chats
- Preserve artist selection when navigating between pages
