### PR TITLE
MYC-1264: Update references to memories.artist_id to use rooms.artist_id

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -9,7 +9,6 @@ export async function POST(req: Request) {
   try {
     const body = await req.json();
     const messages = body.messages as Message[];
-    const artist_id = body.artistId;
     const room_id = body.roomId;
     const segment_id = body.segmentId;
 
@@ -22,7 +21,6 @@ export async function POST(req: Request) {
     if (room_id) {
       await createMemories({
         room_id,
-        artist_id,
         content: lastMessage,
       });
     }

--- a/app/api/memories/create/route.ts
+++ b/app/api/memories/create/route.ts
@@ -3,7 +3,6 @@ import supabase from "@/lib/supabase/serverClient";
 export async function POST(req: Request) {
   const body = await req.json();
   const content = body.content;
-  const artist_id = body.artist_id;
   const room_id = body.room_id;
 
   try {
@@ -11,7 +10,6 @@ export async function POST(req: Request) {
       .from("memories")
       .insert({
         content,
-        artist_id,
         room_id,
       })
       .select("*")

--- a/app/api/room/get/route.tsx
+++ b/app/api/room/get/route.tsx
@@ -7,7 +7,7 @@ export async function GET(req: NextRequest) {
   try {
     const { data: rooms, error } = await supabase
       .from("rooms")
-      .select("*, memories(artist_id), room_reports(report_id)")
+      .select("*, memories(*), room_reports(report_id)")
       .eq("account_id", account_id);
 
     return Response.json({ rooms: rooms || [], error }, { status: 200 });

--- a/hooks/useConversations.tsx
+++ b/hooks/useConversations.tsx
@@ -16,7 +16,7 @@ const useConversations = () => {
   const [isLoading, setIsLoading] = useState(true);
   const { agents } = useArtistAgents();
 
-  const addConversation = (conversation: any) => {
+  const addConversation = (conversation: Conversation | ArtistAgent) => {
     setAllConverstaions([conversation, ...allConverstaions]);
   };
 
@@ -31,11 +31,7 @@ const useConversations = () => {
   const conversations = useMemo(() => {
     const filtered = allConverstaions.filter(
       (item: Conversation | ArtistAgent) =>
-        (item as any)?.memories &&
-        (item as any)?.memories?.some(
-          (memory: { artist_id: string }) =>
-            memory.artist_id === selectedArtist?.account_id,
-        ),
+        'artist_id' in item && item.artist_id === selectedArtist?.account_id
     );
     return filtered;
   }, [selectedArtist, allConverstaions]);

--- a/hooks/useMessages.tsx
+++ b/hooks/useMessages.tsx
@@ -40,7 +40,7 @@ const useMessages = () => {
     },
     onFinish: (message: Message) => {
       if (chatId) {
-        createMemory(message, chatId, selectedArtist?.account_id || "");
+        createMemory(message, chatId);
       }
     },
   });

--- a/lib/createMemory.tsx
+++ b/lib/createMemory.tsx
@@ -1,5 +1,5 @@
 // eslint-disable-next-line
-const createMemory = async (message: any, roomId: string, artistId: string) => {
+const createMemory = async (message: any, roomId: string) => {
   try {
     const response = await fetch("/api/memories/create", {
       method: "POST",
@@ -9,7 +9,6 @@ const createMemory = async (message: any, roomId: string, artistId: string) => {
       body: JSON.stringify({
         content: message,
         room_id: roomId,
-        artist_id: artistId,
       }),
     });
 

--- a/lib/supabase/createMemories.tsx
+++ b/lib/supabase/createMemories.tsx
@@ -1,7 +1,11 @@
 import supabase from "./serverClient";
 
-// eslint-disable-next-line
-const createMemories = async (memory: any) => {
+interface MemoryInput {
+  room_id: string;
+  content: unknown;
+}
+
+const createMemories = async (memory: MemoryInput) => {
   try {
     await supabase.from("memories").insert(memory).select("*");
   } catch (error) {

--- a/types/Chat.tsx
+++ b/types/Chat.tsx
@@ -2,8 +2,12 @@ export type Conversation = {
   topic: string;
   id: string;
   account_id: string;
+  artist_id: string;
   memories: Array<{
-    artist_id: string;
+    id: string;
+    content: unknown;
+    room_id: string;
+    created_at: string;
   }>;
   room_reports: Array<{
     report_id: string;


### PR DESCRIPTION
This PR updates code references to reflect the database schema change where the `artist_id` field was moved from the `memories` table to the `rooms` table.

Changes:
- Removed `artist_id` from memory creation and storage
- Updated API routes to no longer use `memories.artist_id`
- Updated the conversation filtering logic to use `rooms.artist_id`
- Updated type definitions to reflect the schema change

This PR depends on the database migration that was already applied (MYC-1299).