### PR TITLE
MYC-1265: Migrate room creation to use rooms.artist_id

### DIFF
--- a/app/api/room/create/route.tsx
+++ b/app/api/room/create/route.tsx
@@ -5,6 +5,7 @@ export async function GET(req: NextRequest) {
   const topic = req.nextUrl.searchParams.get("topic");
   const account_id = req.nextUrl.searchParams.get("account_id");
   const report_id = req.nextUrl.searchParams.get("report_id");
+  const artist_id = req.nextUrl.searchParams.get("artist_id");
 
   if (!topic || !account_id) {
     return Response.json(
@@ -18,6 +19,7 @@ export async function GET(req: NextRequest) {
       account_id,
       topic,
       report_id: report_id || undefined,
+      artist_id: artist_id || undefined,
     });
 
     return Response.json(result, { status: 200 });

--- a/app/segment/[segmentId]/page.tsx
+++ b/app/segment/[segmentId]/page.tsx
@@ -44,6 +44,7 @@ export default async function Page({ params }: PageProps) {
       account_id: artistAccountId,
       topic: `Segment: ${segment.name}`,
       report_id: reportId,
+      artist_id: artistAccountId,
     });
 
     if (roomError || !new_room) {

--- a/hooks/useChat.tsx
+++ b/hooks/useChat.tsx
@@ -7,6 +7,7 @@ import { useConversationsProvider } from "@/providers/ConverstaionsProvider";
 import { usePromptsProvider } from "@/providers/PromptsProvider";
 import { useEffect, useState } from "react";
 import { v4 as uuidV4 } from "uuid";
+import { useArtistProvider } from "@/providers/ArtistProvider";
 
 const useChat = () => {
   const { userData, isPrepared } = useUserProvider();
@@ -16,13 +17,18 @@ const useChat = () => {
   const { addConversation } = useConversationsProvider();
   const { messages, pending } = useMessagesProvider();
   const { getPrompts } = usePromptsProvider();
-  const [appendActive, setAppendActive] = useState<any>(null);
+  const { selectedArtist } = useArtistProvider();
+  const [appendActive, setAppendActive] = useState<Message | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
   const createNewRoom = async (content: string) => {
     if (chatId) return;
     setIsLoading(true);
-    const room = await createRoom(userData.id, content);
+    const room = await createRoom(
+      userData.id, 
+      content, 
+      selectedArtist?.account_id
+    );
     addConversation(room);
     push(`/${room.id}`);
   };

--- a/lib/createRoom.tsx
+++ b/lib/createRoom.tsx
@@ -1,12 +1,18 @@
 import getAiTitle from "./getAiTitle";
 
-const createRoom = async (account_id: string, content: string) => {
+const createRoom = async (account_id: string, content: string, artist_id?: string) => {
   try {
     const title = await getAiTitle(content);
     const topic = title.replaceAll(`\"`, "");
-    const response = await fetch(
-      `/api/room/create?account_id=${account_id}&topic=${encodeURIComponent(topic)}`,
-    );
+    const url = new URL(`/api/room/create`, window.location.origin);
+    url.searchParams.append("account_id", account_id);
+    url.searchParams.append("topic", topic);
+    
+    if (artist_id) {
+      url.searchParams.append("artist_id", artist_id);
+    }
+    
+    const response = await fetch(url.toString());
     const data = await response.json();
     return data.new_room;
   } catch (error) {

--- a/lib/createRoom.tsx
+++ b/lib/createRoom.tsx
@@ -4,15 +4,13 @@ const createRoom = async (account_id: string, content: string, artist_id?: strin
   try {
     const title = await getAiTitle(content);
     const topic = title.replaceAll(`\"`, "");
-    const url = new URL(`/api/room/create`, window.location.origin);
-    url.searchParams.append("account_id", account_id);
-    url.searchParams.append("topic", topic);
+    let apiUrl = `/api/room/create?account_id=${encodeURIComponent(account_id)}&topic=${encodeURIComponent(topic)}`;
     
     if (artist_id) {
-      url.searchParams.append("artist_id", artist_id);
+      apiUrl += `&artist_id=${encodeURIComponent(artist_id)}`;
     }
     
-    const response = await fetch(url.toString());
+    const response = await fetch(apiUrl);
     const data = await response.json();
     return data.new_room;
   } catch (error) {

--- a/lib/supabase/createRoomWithReport.ts
+++ b/lib/supabase/createRoomWithReport.ts
@@ -8,12 +8,14 @@ interface CreateRoomParams {
   account_id: string;
   topic: string;
   report_id?: string;
+  artist_id?: string;
 }
 
 export const createRoomWithReport = async ({
   account_id,
   topic,
   report_id,
+  artist_id,
 }: CreateRoomParams): Promise<{
   new_room: Room & { memories: []; rooms_reports: string[] };
   error: PostgrestError | null;
@@ -24,6 +26,7 @@ export const createRoomWithReport = async ({
       .insert({
         account_id,
         topic,
+        artist_id,
       })
       .select("*")
       .single();


### PR DESCRIPTION
This PR updates the room creation logic to work with the new database structure where artist_id is in the rooms table. This enables all new chats to work correctly with the updated database schema.

**Changes:**
- Updated `createRoom` function to accept an `artist_id` parameter
- Updated room creation API to accept `artist_id` as a query parameter
- Updated `createRoomWithReport` function to include `artist_id` in the database insert
- Updated `useChat` hook to pass the selected artist's account_id as the `artist_id`
- Updated segment page to include the `artist_id` parameter in the `createRoomWithReport` call

This PR depends on the database migration that was already applied (MYC-1299).