### PR TITLE
MYC-1304: Change Root Route to Initial Chat Interface

### DIFF
--- a/app/autopilot/page.tsx
+++ b/app/autopilot/page.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import AutoPilot from "@/components/AutoPilot";
+import { AutopilotProvider } from "@/providers/AutopilotProvider";
+import { useFirstArtistRedirect } from "@/hooks/useFirstArtistRedirect";
+
+const AutoPilotPage = () => {
+  useFirstArtistRedirect();
+
+  return (
+    <AutopilotProvider>
+      <AutoPilot />
+    </AutopilotProvider>
+  );
+};
+
+export default AutoPilotPage; 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,17 +1,16 @@
 "use client";
 
-import AutoPilot from "@/components/AutoPilot";
-import { AutopilotProvider } from "@/providers/AutopilotProvider";
+import ChatSkeleton from "@/components/Chat/ChatSkeleton";
+import InitialChat from "@/components/Chat/InitialChat";
+import { useChatProvider } from "@/providers/ChatProvider";
 import { useFirstArtistRedirect } from "@/hooks/useFirstArtistRedirect";
 
-const AutoPilotPage = () => {
+const HomePage = () => {
   useFirstArtistRedirect();
-
-  return (
-    <AutopilotProvider>
-      <AutoPilot />
-    </AutopilotProvider>
-  );
+  const { isLoading } = useChatProvider();
+  
+  if (isLoading) return <ChatSkeleton />;
+  return <InitialChat />;
 };
 
-export default AutoPilotPage;
+export default HomePage;

--- a/components/SideMenu/SideMenu.tsx
+++ b/components/SideMenu/SideMenu.tsx
@@ -40,7 +40,7 @@ const SideMenu = ({
       <button
         type="button"
         onClick={() => {
-          push("/");
+          push("/autopilot");
           toggleModal();
         }}
         className="flex gap-3 items-center mb-3 mt-4"

--- a/components/Sidebar/Menu.tsx
+++ b/components/Sidebar/Menu.tsx
@@ -15,7 +15,7 @@ const Menu = ({ toggleMenuExpanded }: { toggleMenuExpanded: () => void }) => {
   const itemClasses = "flex gap-3 items-center rounded-md px-3 py-2";
   const isAgents = pathname.includes("/agents");
   const isSegments = pathname.includes("/segments");
-  const isAutopilot = pathname === "/";
+  const isAutopilot = pathname === "/autopilot";
 
   const goToItem = (link?: string) => {
     if (isPrepared()) {
@@ -38,7 +38,7 @@ const Menu = ({ toggleMenuExpanded }: { toggleMenuExpanded: () => void }) => {
       <button
         className={`${itemClasses} ${isAutopilot && activeClasses} md:mt-2`}
         type="button"
-        onClick={() => push("/")}
+        onClick={() => push("/autopilot")}
       >
         <MenuItemIcon name="dashboard" />
         Autopilot

--- a/components/Sidebar/MiniMenu.tsx
+++ b/components/Sidebar/MiniMenu.tsx
@@ -30,7 +30,7 @@ const MiniMenu = ({
         <button
           type="button"
           className=" p-2 rounded-md mt-2"
-          onClick={() => push("/")}
+          onClick={() => push("/autopilot")}
         >
           <Icon name="dashboard" />
         </button>
@@ -44,7 +44,7 @@ const MiniMenu = ({
         <button
           type="button"
           className=" p-2 rounded-md"
-          onClick={() => goToItem("agents")}
+          onClick={() => goToItem("segments")}
         >
           <Icon name="segments" />
         </button>

--- a/hooks/usePrompts.tsx
+++ b/hooks/usePrompts.tsx
@@ -12,14 +12,14 @@ const usePrompts = () => {
   const [currentQuestion, setCurrentQuestion] = useState<Message | null>(null);
   const pathname = usePathname();
   const { funnelRawReportContent } = useFunnelReportProvider();
-  const isNewChat = pathname.includes("/new");
+  const isNewChat = pathname.includes("/new") || pathname === "/";
 
   useEffect(() => {
     if (isLoading) return;
     if (selectedArtist && isNewChat) {
       setPrompts([
-        `Who are ${selectedArtist?.name || ""}’s most engaged fans?`,
-        `Analyze ${selectedArtist?.name || ""}’s TikTok posts from this week.`,
+        `Who are ${selectedArtist?.name || ""}'s most engaged fans?`,
+        `Analyze ${selectedArtist?.name || ""}'s TikTok posts from this week.`,
       ]);
       return;
     }


### PR DESCRIPTION
This PR changes the root route (/) to display the chat interface instead of Autopilot, creating a more intuitive user experience.

Changes:
- Changed root route (/) to display the chat interface instead of Autopilot
- Created new route (/autopilot) for the Autopilot functionality
- Updated all navigation components to point to the new routes
- Fixed suggestion boxes to appear correctly on the root path

This change improves the user experience by making the chat interface the default page while keeping the Autopilot functionality accessible through a dedicated route.