### PR TITLE
MYC-1317: Move login logic to root page following DRY principles

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,9 +4,11 @@ import ChatSkeleton from "@/components/Chat/ChatSkeleton";
 import InitialChat from "@/components/Chat/InitialChat";
 import { useChatProvider } from "@/providers/ChatProvider";
 import { useFirstArtistRedirect } from "@/hooks/useFirstArtistRedirect";
+import useLoginRedirect from "@/hooks/useLoginRedirect";
 
 const HomePage = () => {
   useFirstArtistRedirect();
+  useLoginRedirect();
   const { isLoading } = useChatProvider();
   
   if (isLoading) return <ChatSkeleton />;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,11 +4,11 @@ import ChatSkeleton from "@/components/Chat/ChatSkeleton";
 import InitialChat from "@/components/Chat/InitialChat";
 import { useChatProvider } from "@/providers/ChatProvider";
 import { useFirstArtistRedirect } from "@/hooks/useFirstArtistRedirect";
-import useLoginRedirect from "@/hooks/useLoginRedirect";
+import useAutoLogin from "@/hooks/useAutoLogin";
 
 const HomePage = () => {
   useFirstArtistRedirect();
-  useLoginRedirect();
+  useAutoLogin();
   const { isLoading } = useChatProvider();
   
   if (isLoading) return <ChatSkeleton />;

--- a/components/AutoPilot/AutoPilot.tsx
+++ b/components/AutoPilot/AutoPilot.tsx
@@ -7,12 +7,12 @@ import Events from "./Events";
 import Approvals from "./Approvals";
 import { useUserProvider } from "@/providers/UserProvder";
 import { Skeleton } from "@/components/ui/skeleton";
-import useLoginRedirect from "@/hooks/useLoginRedirect";
+import useAutoLogin from "@/hooks/useAutoLogin";
 
 const AutoPilot = () => {
   const { selectedArtist } = useArtistProvider();
   const { email } = useUserProvider();
-  useLoginRedirect();
+  useAutoLogin();
   const showSkeleton = !selectedArtist || !email;
 
   return (

--- a/components/AutoPilot/AutoPilot.tsx
+++ b/components/AutoPilot/AutoPilot.tsx
@@ -7,22 +7,13 @@ import Events from "./Events";
 import Approvals from "./Approvals";
 import { useUserProvider } from "@/providers/UserProvder";
 import { Skeleton } from "@/components/ui/skeleton";
-import { usePrivy } from "@privy-io/react-auth";
-import { useEffect, useRef } from "react";
+import useLoginRedirect from "@/hooks/useLoginRedirect";
 
 const AutoPilot = () => {
   const { selectedArtist } = useArtistProvider();
   const { email } = useUserProvider();
-  const { login } = usePrivy();
-  const hasTriedLogin = useRef(false);
+  useLoginRedirect();
   const showSkeleton = !selectedArtist || !email;
-
-  useEffect(() => {
-    if (!email && !hasTriedLogin.current) {
-      hasTriedLogin.current = true;
-      login();
-    }
-  }, [email, login]);
 
   return (
     <div className="grow font-mono p-3 md:p-4 rounded-lg flex flex-col">

--- a/hooks/useAutoLogin.tsx
+++ b/hooks/useAutoLogin.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef } from "react";
 import { usePrivy } from "@privy-io/react-auth";
 import { useUserProvider } from "@/providers/UserProvder";
 
-export function useLoginRedirect() {
+export function useAutoLogin() {
   const { login } = usePrivy();
   const { email } = useUserProvider();
   const hasTriedLogin = useRef(false);
@@ -15,8 +15,6 @@ export function useLoginRedirect() {
       login();
     }
   }, [email, login]);
-
-  return { isLoggedIn: !!email };
 }
 
-export default useLoginRedirect; 
+export default useAutoLogin; 

--- a/hooks/useLoginRedirect.tsx
+++ b/hooks/useLoginRedirect.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { usePrivy } from "@privy-io/react-auth";
+import { useUserProvider } from "@/providers/UserProvder";
+
+export function useLoginRedirect() {
+  const { login } = usePrivy();
+  const { email } = useUserProvider();
+  const hasTriedLogin = useRef(false);
+
+  useEffect(() => {
+    if (!email && !hasTriedLogin.current) {
+      hasTriedLogin.current = true;
+      login();
+    }
+  }, [email, login]);
+
+  return { isLoggedIn: !!email };
+}
+
+export default useLoginRedirect; 


### PR DESCRIPTION
## What Changed
Created a reusable `useLoginRedirect` hook that centralizes login logic and applied it to the root page.

## Why
- Improves code organization by extracting login logic from the AutoPilot component
- Follows DRY principles by reusing the same login logic across multiple pages
- Ensures users are prompted to login when landing on the root page
- Makes future login-related changes easier to maintain

## Testing
- Verified that users not signed in are prompted to login when landing on the root page
- Confirmed existing login functionality in AutoPilot page continues to work as expected