### PR TITLE
MYC-1318: Fix mobile sidebar z-index bug by removing z-20 class from SegmentButton

### DIFF
--- a/components/Funnels/SegmentButton.tsx
+++ b/components/Funnels/SegmentButton.tsx
@@ -9,7 +9,7 @@ const SegmentButton = ({ segment, onGenerateReport }: SegmentButtonProps) => {
   return (
     <button
       onClick={() => onGenerateReport(segment.id, segment.name)}
-      className="bg-white border-2 border-black rounded-[10px] pl-5 pr-4 h-16 z-20 flex items-center gap-2 justify-between
+      className="bg-white border-2 border-black rounded-[10px] pl-5 pr-4 h-16 flex items-center gap-2 justify-between
         transition-all text-[15px] font-medium text-black hover:bg-black hover:text-white active:bg-white/80"
     >
       <div className="flex flex-col items-start">


### PR DESCRIPTION
**Problem**
Segment cards appeared on top of sidebars on mobile.

**Solution**
Removed z-20 class from SegmentButton component.

**Changes**
Single-line change in components/Funnels/SegmentButton.tsx

**Testing**
Verified on mobile - segment cards now stay behind sidebars.