### PR TITLE
MYC-1266: Chat Page Updates When Switching Artists

### DIFF
--- a/components/Artists/Artist.tsx
+++ b/components/Artists/Artist.tsx
@@ -2,6 +2,7 @@ import { useArtistProvider } from "@/providers/ArtistProvider";
 import { ArtistRecord } from "@/types/Artist";
 import ImageWithFallback from "../ImageWithFallback";
 import DropDown from "./DropDown";
+import { usePathname, useRouter } from "next/navigation";
 
 const Artist = ({
   artist,
@@ -10,10 +11,24 @@ const Artist = ({
   artist: ArtistRecord;
   isVisibleDropDown: boolean;
 }) => {
-  const { setSelectedArtist, setMenuVisibleArtistId } = useArtistProvider();
+  const { setSelectedArtist, setMenuVisibleArtistId, selectedArtist } = useArtistProvider();
+  const pathname = usePathname();
+  const { push } = useRouter();
 
   const handleClick = () => {
     setMenuVisibleArtistId(null);
+    
+    // Only proceed with redirection if we're actually switching artists
+    if (selectedArtist?.account_id !== artist.account_id) {
+      // UUID pattern: 8-4-4-4-12 hexadecimal characters
+      const uuidPattern = /^\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+      const isChatPage = uuidPattern.test(pathname);
+      
+      if (isChatPage || pathname.includes("/funnels")) {
+        push("/");
+      }
+    }
+    
     setSelectedArtist(artist);
   };
 

--- a/components/Header/Artist.tsx
+++ b/components/Header/Artist.tsx
@@ -23,11 +23,21 @@ const Artist = ({
   const isSelectedArtist = selectedArtist?.account_id === artist?.account_id;
   const pathname = usePathname();
   const { push } = useRouter();
+  
   const handleClick = () => {
     toggleDropDown();
-    if (pathname.includes("/funnels") && selectedArtist) {
-      if (selectedArtist.account_id !== artist?.account_id) push("/");
+    
+    // Only proceed with redirection if we're actually switching artists
+    if (selectedArtist?.account_id !== artist?.account_id) {
+      // UUID pattern: 8-4-4-4-12 hexadecimal characters
+      const uuidPattern = /^\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+      const isChatPage = uuidPattern.test(pathname);
+      
+      if (isChatPage || pathname.includes("/funnels")) {
+        push("/");
+      }
     }
+    
     setSelectedArtist(artist);
   };
 


### PR DESCRIPTION
### Problem
When a user is on a chat page (with a UUID in the URL) and switches artists, they remain on the chat page with the new artist selected. This creates inconsistent behavior since the chat content is specific to the original artist.

### Solution
- Added logic to detect when a user is on a chat page using a UUID pattern regex
- Implemented redirection to the root page when switching artists on a chat page
- Ensured the redirection only happens when actually switching artists (not when clicking the already selected artist)

### Testing
- Verified that switching artists on a chat page correctly redirects to the root page
- Confirmed that switching artists on the root page keeps the user on the root page
- Tested creating new chats with different artists selected

### Changes
- Updated `components/Header/Artist.tsx` to add chat page detection and redirection logic
- Updated `components/Artists/Artist.tsx` with the same logic for consistency