### PR TITLE
MYC-1328-Artist-Automatically-Switches-During-Chat-Creation

### DIFF
--- a/hooks/usePrompts.tsx
+++ b/hooks/usePrompts.tsx
@@ -16,6 +16,8 @@ const usePrompts = () => {
 
   useEffect(() => {
     if (isLoading) return;
+    
+    // Set artist-specific prompts for new chat
     if (selectedArtist && isNewChat) {
       setPrompts([
         `Who are ${selectedArtist?.name || ""}'s most engaged fans?`,
@@ -23,12 +25,16 @@ const usePrompts = () => {
       ]);
       return;
     }
-    if (artists.length) {
+    
+    // Only set the selected artist if we're on the home page
+    // This prevents resetting the artist when navigating to a chat page
+    if (artists.length && pathname === "/") {
       setSelectedArtist(artists[0]);
       return;
     }
+    
     setPrompts(SUGGESTIONS);
-  }, [selectedArtist, isNewChat, artists, isLoading]);
+  }, [selectedArtist, isNewChat, artists, isLoading, pathname, setSelectedArtist]);
 
   const getPrompts = async (content: string, isTikTokAnalysis?: boolean) => {
     const isFunnelReport = content === "Funnel Report";

--- a/hooks/usePrompts.tsx
+++ b/hooks/usePrompts.tsx
@@ -17,7 +17,6 @@ const usePrompts = () => {
   useEffect(() => {
     if (isLoading) return;
     
-    // Set artist-specific prompts for new chat
     if (selectedArtist && isNewChat) {
       setPrompts([
         `Who are ${selectedArtist?.name || ""}'s most engaged fans?`,
@@ -26,8 +25,6 @@ const usePrompts = () => {
       return;
     }
     
-    // Only set the selected artist if we're on the home page
-    // This prevents resetting the artist when navigating to a chat page
     if (artists.length && pathname === "/") {
       setSelectedArtist(artists[0]);
       return;


### PR DESCRIPTION
Fixed issue where selected artists would reset during chat creation. Now artists only reset on the home page, ensuring your selected artist stays active when starting a new conversation.