### PR TITLE
MYC-1329: Fix issue with chat displaying messages from multiple artists

### DIFF
--- a/app/api/memories/get/route.ts
+++ b/app/api/memories/get/route.ts
@@ -3,8 +3,27 @@ import { NextRequest } from "next/server";
 
 export async function GET(req: NextRequest) {
   const roomId = req.nextUrl.searchParams.get("roomId");
+  const artistId = req.nextUrl.searchParams.get("artistId");
 
   try {
+    // If artistId is provided, verify room belongs to this artist
+    if (artistId) {
+      // First, check if the room belongs to the specified artist
+      const { data: roomData, error: roomError } = await supabase
+        .from("rooms")
+        .select("id")
+        .eq("id", roomId)
+        .eq("artist_id", artistId)
+        .single();
+
+      // If no matching room was found, return empty data
+      if (roomError || !roomData) {
+        console.log(`[memories/get] Room ${roomId} not found for artist ${artistId}`);
+        return Response.json({ data: [], error: null }, { status: 200 });
+      }
+    }
+
+    // Fetch memories for the room
     const { data, error } = await supabase
       .from("memories")
       .select("*")

--- a/hooks/useMessages.tsx
+++ b/hooks/useMessages.tsx
@@ -50,12 +50,15 @@ const useMessages = () => {
       if (!userData?.id) return;
       if (!chatId) return;
       setIsLoading(true);
-      const initialMessages = await getInitialMessages(chatId);
+      const initialMessages = await getInitialMessages(
+        chatId,
+        selectedArtist?.account_id
+      );
       setMessages(initialMessages);
       setIsLoading(false);
     };
     fetch();
-  }, [chatId, userData, setMessages]);
+  }, [chatId, userData, setMessages, selectedArtist?.account_id]);
 
   if (segmentError) {
     console.error("[useMessages] Error fetching segment:", segmentError);

--- a/lib/supabase/getInitialMessages.tsx
+++ b/lib/supabase/getInitialMessages.tsx
@@ -1,6 +1,11 @@
-const getInitialMessages = async (chatId: string) => {
+const getInitialMessages = async (chatId: string, artistId?: string) => {
   try {
-    const response = await fetch(`/api/memories/get?roomId=${chatId}`);
+    let url = `/api/memories/get?roomId=${chatId}`;
+    if (artistId) {
+      url += `&artistId=${artistId}`;
+    }
+    
+    const response = await fetch(url);
     const data = await response.json();
 
     const memories = data?.data || [];


### PR DESCRIPTION
## Problem
When a user switches between artists and creates new chats, messages from previous artists sometimes appear in the new chat session. This creates confusion as users see conversations with different artists mixed together.

## Solution
Added artist verification to ensure chat messages are only displayed for the currently selected artist:

- Modified `getInitialMessages` to accept the current artist ID
- Updated the memories API endpoint to verify room ownership
- Added filtering to prevent messages from other artists showing in the current chat

## Testing
1. Start on the root page and select Artist A (e.g., Teddy Swims)
2. Create a chat with a specific message
3. Return to the root page
4. Switch to Artist B (e.g., Chillpill)
5. Create a new chat with a different message
6. Verify only the message for Artist B appears (no messages from Artist A)