### PR TITLE
MYC-1328: Stop automatic artist switching during chat creation

### DIFF
--- a/hooks/usePrompts.tsx
+++ b/hooks/usePrompts.tsx
@@ -6,8 +6,7 @@ import { useArtistProvider } from "@/providers/ArtistProvider";
 import { useFunnelReportProvider } from "@/providers/FunnelReportProvider";
 
 const usePrompts = () => {
-  const { selectedArtist, artists, setSelectedArtist, isLoading } =
-    useArtistProvider();
+  const { selectedArtist, isLoading } = useArtistProvider();
   const [prompts, setPrompts] = useState<string[]>([]);
   const [currentQuestion, setCurrentQuestion] = useState<Message | null>(null);
   const pathname = usePathname();
@@ -23,12 +22,8 @@ const usePrompts = () => {
       ]);
       return;
     }
-    if (artists.length) {
-      setSelectedArtist(artists[0]);
-      return;
-    }
     setPrompts(SUGGESTIONS);
-  }, [selectedArtist, isNewChat, artists, isLoading]);
+  }, [selectedArtist, isNewChat, isLoading]);
 
   const getPrompts = async (content: string, isTikTokAnalysis?: boolean) => {
     const isFunnelReport = content === "Funnel Report";


### PR DESCRIPTION
## Problem
When creating a new chat with a non-default artist selected (e.g., Chillpill), the app would automatically switch back to the first artist in the list. This happened because `usePrompts.tsx` had logic that would automatically select the first artist when no artist was selected, but this logic was triggering incorrectly during chat creation.

## Solution
Modified `usePrompts.tsx` to:
- Remove the auto-selection of first artist
- Remove `artists` and `setSelectedArtist` from the hook
- Keep the user's explicitly selected artist

## Changes
- Single file change: `hooks/usePrompts.tsx`
- Removed 7 lines, added 2 lines
- No new dependencies added
- No database changes required

## Testing
To verify this fix:
1. Select a non-default artist (e.g., Chillpill)
2. Create a new chat via /new (not via root) [separate ticket fixes root new chats redirection bug]
3. Verify the selected artist remains the same
4. Create multiple /new chats to ensure the artist selection persists

## Other Bugs (Open Tickets)
- Chat shows messages from other rooms.
- Chats created from / redirect back to / instead of room.
- Chat input box does not clear text after submit 
