### PR TITLE
MYC-1355: prevent messages from displaying in wrong rooms 

### DIFF
--- a/hooks/useMessages.tsx
+++ b/hooks/useMessages.tsx
@@ -29,6 +29,7 @@ const useMessages = () => {
     setMessages,
     reload: reloadAiChat,
   } = useChat({
+    id: chatId,
     api: `/api/chat`,
     headers: {
       "X-CSRF-Token": csrfToken,
@@ -44,6 +45,12 @@ const useMessages = () => {
       }
     },
   });
+
+  useEffect(() => {
+    if (!chatId) {
+      setMessages([]);
+    }
+  }, [chatId, setMessages]);
 
   useEffect(() => {
     const fetch = async () => {


### PR DESCRIPTION
## Problem
Messages from previous chats were appearing in newly created chats.

## Bug Reproduction Steps
1. Open any existing chat and view messages
2. Click "New Chat"
3. Type and submit a message in the new chat (e.g., "Test message")
4. Bug: After submission, messages from the previous chat incorrectly appear along with your new message
5. Note: This only happens during new chat creation, not when navigating between existing chats

## Solution
- Added chat-specific isolation using AI SDK's `id` prop in `useMessages` hook
- Added cleanup effect for new chat creation
- Minimal solution that leverages existing architecture

## Testing Steps to Verify Fix
1. Create Chat One:
   - Click "New Chat"
   - Send a message: "This is Chat One"
   - Verify only this message appears

2. Create Chat Two:
   - Navigate to Chat One first
   - Click "New Chat"
   - Send a message: "This is Chat Two"
   - Verify ONLY "This is Chat Two" appears
   - Verify no messages from Chat One appear

3. Test Navigation:
   - Go to Recent Chats
   - Click between different chats
   - Verify each chat shows only its own messages
   - Create another new chat
   - Send a message
   - Verify it starts and stays clean

All test scenarios pass ✅