### PR TITLE
MYC-1356: clear input field after message submission

### DIFF
--- a/hooks/useChat.tsx
+++ b/hooks/useChat.tsx
@@ -13,7 +13,7 @@ const useChat = () => {
   const { userData, isPrepared } = useUserProvider();
   const { push } = useRouter();
   const { chat_id: chatId, agent_id: agentId } = useParams();
-  const { input, appendAiChat } = useMessagesProvider();
+  const { input, appendAiChat, handleInputChange } = useMessagesProvider();
   const { addConversation } = useConversationsProvider();
   const { messages, pending } = useMessagesProvider();
   const { getPrompts } = usePromptsProvider();
@@ -47,6 +47,7 @@ const useChat = () => {
       content: input,
       role: "user",
     });
+    handleInputChange({ target: { value: '' } } as React.ChangeEvent<HTMLTextAreaElement>);
   };
 
   useEffect(() => {


### PR DESCRIPTION
Problem
The chat input field was not clearing after message submission, causing confusion for users who had to manually clear the field before typing a new message.

Solution
Modified the handleSubmit function in the useChat hook to reset the input field after a message is successfully submitted:
Added handleInputChange to the destructured imports from useMessagesProvider
Added a line to reset the input field by calling handleInputChange with an empty string after the message is appended

Testing
Manually verified that:
The input field now clears properly after sending a message
The message submission process works as expected
No side effects were introduced by this change