### PR TITLE
MYC-1286: Create Artist Knowledge Base

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -5,6 +5,7 @@ import initializeAgent from "@/lib/agent/initializeAgent";
 import { HumanMessage, BaseMessage } from "@langchain/core/messages";
 import getTransformedStream from "@/lib/agent/getTransformedStream";
 import getLangchainMemories from "@/lib/agent/getLangchainMemories";
+import { getKnowledgeBaseContext } from "@/lib/agent/getKnowledgeBaseContext";
 
 export async function POST(req: Request) {
   try {
@@ -36,7 +37,16 @@ export async function POST(req: Request) {
       previousMessages = await getLangchainMemories(room_id, 100);
     }
 
-    const currentMessage = new HumanMessage(question);
+    let messageText = question;
+    
+    if (room_id) {
+      const knowledgeContent = await getKnowledgeBaseContext(room_id);
+      if (knowledgeContent) {
+        messageText += `\n\n-----ARTIST KNOWLEDGE BASE-----\n${knowledgeContent}\n-----END KNOWLEDGE BASE-----\n\nPlease use the information from the knowledge base if relevant to answering my question.`;
+      }
+    }
+    
+    const currentMessage = new HumanMessage(messageText);
     const allMessages: BaseMessage[] = [...previousMessages, currentMessage];
 
     const messageInput = {

--- a/hooks/useArtistSetting.tsx
+++ b/hooks/useArtistSetting.tsx
@@ -65,11 +65,32 @@ const useArtistSetting = () => {
           const name = file.name;
           const type = file.type;
           const { uri } = await uploadFile(file);
-          temp.push({
+          
+          const fileData: {
+            name: string;
+            url: string;
+            type: string;
+            content?: string;
+          } = {
             name,
             url: uri,
             type,
-          });
+          };
+          
+          const isTextFile = type.startsWith("text/") || 
+                             type === "application/json" ||
+                             (/\.(txt|md|json)$/i).test(name);
+            
+          if (isTextFile) {
+            try {
+              const textContent = await file.text();
+              fileData.content = textContent;
+            } catch (textError) {
+              console.error("Failed to extract text from file:", textError);
+            }
+          }
+          
+          temp.push(fileData);
         }
       }
       setBases(temp);

--- a/lib/agent/getKnowledgeBaseContext.ts
+++ b/lib/agent/getKnowledgeBaseContext.ts
@@ -7,8 +7,6 @@ interface KnowledgeBaseEntry {
   content?: string;
 }
 
-/**
- */
 export async function getKnowledgeBaseContext(roomId: string): Promise<string> {
   try {
     const { data: room } = await supabase
@@ -34,7 +32,6 @@ export async function getKnowledgeBaseContext(roomId: string): Promise<string> {
     return textFiles.length > 0 
       ? textFiles.map(file => `--- ${file.name} ---\n${file.content}`).join("\n\n")
       : "";
-      
   } catch (error) {
     console.error("[getKnowledgeBaseContext]", error);
     return "";

--- a/lib/agent/getKnowledgeBaseContext.ts
+++ b/lib/agent/getKnowledgeBaseContext.ts
@@ -1,0 +1,44 @@
+import supabase from "@/lib/supabase/serverClient";
+
+interface KnowledgeBaseEntry {
+  url: string;
+  name: string;
+  type: string;
+  content?: string;
+}
+
+/**
+ */
+export async function getKnowledgeBaseContext(roomId: string): Promise<string> {
+  try {
+    const { data: room } = await supabase
+      .from("rooms")
+      .select("artist_id")
+      .eq("id", roomId)
+      .single();
+    
+    if (!room?.artist_id) return "";
+
+    const { data: accountInfo } = await supabase
+      .from("account_info")
+      .select("knowledges")
+      .eq("account_id", room.artist_id)
+      .single();
+    
+    if (!accountInfo?.knowledges?.length) return "";
+    
+    const textFiles = (accountInfo.knowledges as KnowledgeBaseEntry[]).filter(file => 
+      file.content && ["text/plain", "text/markdown", "application/json"].includes(file.type)
+    );
+    
+    return textFiles.length > 0 
+      ? textFiles.map(file => `--- ${file.name} ---\n${file.content}`).join("\n\n")
+      : "";
+      
+  } catch (error) {
+    console.error("[getKnowledgeBaseContext]", error);
+    return "";
+  }
+}
+
+export default getKnowledgeBaseContext; 

--- a/lib/agent/getKnowledgeBaseContext.ts
+++ b/lib/agent/getKnowledgeBaseContext.ts
@@ -1,31 +1,14 @@
-import supabase from "@/lib/supabase/serverClient";
-
-interface KnowledgeBaseEntry {
-  url: string;
-  name: string;
-  type: string;
-  content?: string;
-}
+import { getArtistIdForRoom, getKnowledgeEntries } from "@/lib/supabase/getArtistKnowledge";
 
 export async function getKnowledgeBaseContext(roomId: string): Promise<string> {
   try {
-    const { data: room } = await supabase
-      .from("rooms")
-      .select("artist_id")
-      .eq("id", roomId)
-      .single();
-    
-    if (!room?.artist_id) return "";
+    const artistId = await getArtistIdForRoom(roomId);
+    if (!artistId) return "";
 
-    const { data: accountInfo } = await supabase
-      .from("account_info")
-      .select("knowledges")
-      .eq("account_id", room.artist_id)
-      .single();
+    const knowledges = await getKnowledgeEntries(artistId);
+    if (!knowledges.length) return "";
     
-    if (!accountInfo?.knowledges?.length) return "";
-    
-    const textFiles = (accountInfo.knowledges as KnowledgeBaseEntry[]).filter(file => 
+    const textFiles = knowledges.filter(file => 
       file.content && ["text/plain", "text/markdown", "application/json"].includes(file.type)
     );
     

--- a/lib/supabase/getArtistKnowledge.ts
+++ b/lib/supabase/getArtistKnowledge.ts
@@ -1,0 +1,30 @@
+import supabase from "./serverClient";
+
+export interface KnowledgeBaseEntry {
+  url: string;
+  name: string;
+  type: string;
+  content?: string;
+}
+
+export async function getArtistIdForRoom(roomId: string): Promise<string | null> {
+  const { data, error } = await supabase
+    .from("rooms")
+    .select("artist_id")
+    .eq("id", roomId)
+    .single();
+  
+  if (error || !data?.artist_id) return null;
+  return data.artist_id;
+}
+
+export async function getKnowledgeEntries(artistId: string): Promise<KnowledgeBaseEntry[]> {
+  const { data, error } = await supabase
+    .from("account_info")
+    .select("knowledges")
+    .eq("account_id", artistId)
+    .single();
+  
+  if (error || !data?.knowledges) return [];
+  return data.knowledges;
+} 


### PR DESCRIPTION
### Description

This PR enables users to upload text files into their artists' knowledge base via Artist Settings, ensuring the AI provides more accurate, consistent, and customized responses based on specific artist information.

### Testing Instructions

- Select an Artist

- Open Artist Settings

- Upload a text file with some unique information (e.g., "The secret password is blueberry")

- Save the artist profile

- Start a new chat with this artist

- Ask about the information in your text file (e.g., "What's the secret password?")

- Verify the AI's response includes the information from your text file

### Technical Details

- Text content is extracted and stored in the knowledges array in the account_info table

- Content is formatted and added to user messages during chat

- Only text-based files are supported in this implementation