### PR TITLE
MYC-1402-p0-recent-chat-organization

### DIFF
--- a/app/api/room/delete/route.tsx
+++ b/app/api/room/delete/route.tsx
@@ -1,0 +1,30 @@
+import supabase from "@/lib/supabase/serverClient";
+import { NextRequest } from "next/server";
+
+export async function GET(req: NextRequest) {
+  const room_id = req.nextUrl.searchParams.get("room_id");
+
+  if (!room_id) {
+    return Response.json(
+      { message: "Missing required parameters" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const { error } = await supabase
+      .from("rooms")
+      .delete()
+      .eq("id", room_id);
+
+    return Response.json({ success: !error, error }, { status: 200 });
+  } catch (error) {
+    console.error(error);
+    const message = error instanceof Error ? error.message : "failed";
+    return Response.json({ message }, { status: 400 });
+  }
+}
+
+export const dynamic = "force-dynamic";
+export const fetchCache = "force-no-store";
+export const revalidate = 0; 

--- a/app/api/room/get/route.tsx
+++ b/app/api/room/get/route.tsx
@@ -8,7 +8,8 @@ export async function GET(req: NextRequest) {
     const { data: rooms, error } = await supabase
       .from("rooms")
       .select("*, memories(*), room_reports(report_id)")
-      .eq("account_id", account_id);
+      .eq("account_id", account_id)
+      .order('updated_at', { ascending: false });
 
     return Response.json({ rooms: rooms || [], error }, { status: 200 });
   } catch (error) {

--- a/app/api/room/update/route.tsx
+++ b/app/api/room/update/route.tsx
@@ -1,0 +1,48 @@
+import supabase from "@/lib/supabase/serverClient";
+import { NextRequest } from "next/server";
+
+export async function GET(req: NextRequest) {
+  const room_id = req.nextUrl.searchParams.get("room_id");
+  const topic = req.nextUrl.searchParams.get("topic");
+
+  if (!room_id || !topic) {
+    return Response.json(
+      { message: "Missing required parameters" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    // First, get the current room data to preserve the updated_at timestamp
+    const { data: currentRoom, error: fetchError } = await supabase
+      .from("rooms")
+      .select("updated_at")
+      .eq("id", room_id)
+      .single();
+    
+    if (fetchError) {
+      return Response.json({ error: fetchError.message }, { status: 400 });
+    }
+
+    // Update with preserved timestamp
+    const { data, error } = await supabase
+      .from("rooms")
+      .update({ 
+        topic,
+        updated_at: currentRoom.updated_at // Keep original timestamp when renaming
+      })
+      .eq("id", room_id)
+      .select()
+      .single();
+
+    return Response.json({ room: data, error }, { status: 200 });
+  } catch (error) {
+    console.error(error);
+    const message = error instanceof Error ? error.message : "failed";
+    return Response.json({ message }, { status: 400 });
+  }
+}
+
+export const dynamic = "force-dynamic";
+export const fetchCache = "force-no-store";
+export const revalidate = 0; 

--- a/components/Chat/ChatOptionsMenu.tsx
+++ b/components/Chat/ChatOptionsMenu.tsx
@@ -1,0 +1,160 @@
+import { useState, useRef, useEffect } from "react";
+import { MoreVertical } from "lucide-react";
+import type { MouseEvent as ReactMouseEvent } from "react";
+
+/**
+ * Interface for ChatOptionsMenu props
+ */
+interface ChatOptionsMenuProps {
+  /** Unique identifier for the chat */
+  chatId: string;
+  /** Callback fired when user wants to start renaming a chat */
+  onStartRename: () => void;
+  /** Callback fired when user confirms chat deletion */
+  onDelete: (chatId: string) => Promise<void>;
+}
+
+/**
+ * A dropdown menu component that provides options for managing a chat conversation
+ * such as renaming and deleting. Used in the sidebar for each chat item.
+ */
+export default function ChatOptionsMenu({
+  chatId,
+  onStartRename,
+  onDelete,
+}: ChatOptionsMenuProps) {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
+  const [menuPosition, setMenuPosition] = useState({ top: 0, right: 0 });
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  
+  useEffect(() => {
+    if (isMenuOpen && buttonRef.current) {
+      const rect = buttonRef.current.getBoundingClientRect();
+      setMenuPosition({
+        top: rect.bottom + 4, // Adding 4px gap
+        right: window.innerWidth - rect.right
+      });
+    }
+  }, [isMenuOpen]);
+
+  /**
+   * Toggles the visibility of the options menu dropdown
+   */
+  const toggleMenu = (e: ReactMouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    setIsMenuOpen(!isMenuOpen);
+    if (!isMenuOpen) setIsDeleteConfirmOpen(false);
+  };
+
+  /**
+   * Handles the rename button click, triggering the parent component's rename handler
+   */
+  const handleRename = (e: ReactMouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    setIsMenuOpen(false);
+    onStartRename();
+  };
+
+  /**
+   * Toggles the delete confirmation dialog
+   */
+  const toggleDeleteConfirm = (e: ReactMouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    setIsDeleteConfirmOpen(!isDeleteConfirmOpen);
+    setIsMenuOpen(false);
+  };
+
+  /**
+   * Handles the delete confirmation, triggering the actual delete operation
+   */
+  const confirmDelete = (e: ReactMouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    onDelete(chatId);
+    setIsDeleteConfirmOpen(false);
+  };
+
+  /**
+   * Cancels the delete operation, closing the confirmation dialog
+   */
+  const cancelDelete = (e: ReactMouseEvent) => {
+    e.stopPropagation();
+    setIsDeleteConfirmOpen(false);
+  };
+
+  // Close menu when clicking outside
+  useEffect(() => {
+    const handleClickOutside = () => {
+      if (isMenuOpen) setIsMenuOpen(false);
+    };
+    
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [isMenuOpen]);
+
+  return (
+    <div className="relative" onClick={(e: ReactMouseEvent) => e.stopPropagation()}>
+      <button
+        ref={buttonRef}
+        onClick={toggleMenu}
+        className="p-1 rounded-full hover:bg-slate-100 transition-colors group-hover:opacity-100 opacity-0"
+        aria-label="Chat options"
+        aria-haspopup="menu"
+      >
+        <MoreVertical className="h-4 w-4 text-grey-dark" />
+      </button>
+
+      {isMenuOpen && (
+        <div 
+          className="fixed bg-white shadow-lg rounded-md py-1 z-50 w-36"
+          style={{
+            top: `${menuPosition.top}px`,
+            right: `${menuPosition.right}px`
+          }}
+        >
+          <button
+            className="w-full text-left px-4 py-1 text-sm hover:bg-slate-100 transition-colors"
+            onClick={handleRename}
+          >
+            Rename
+          </button>
+          <button
+            className="w-full text-left px-4 py-1 text-sm text-red-500 hover:bg-slate-100 transition-colors"
+            onClick={toggleDeleteConfirm}
+          >
+            Delete
+          </button>
+        </div>
+      )}
+
+      {isDeleteConfirmOpen && (
+        <div 
+          className="fixed inset-0 z-50 flex items-center justify-center" 
+          onClick={(e: ReactMouseEvent<HTMLDivElement>) => cancelDelete(e)}
+        >
+          <div className="fixed inset-0 bg-black opacity-20" />
+          <div 
+            className="bg-white shadow-lg rounded-md p-2 z-50 w-48 relative"
+            onClick={(e: ReactMouseEvent) => e.stopPropagation()}
+          >
+            <p className="text-xs mb-2">Are you sure you want to delete this chat?</p>
+            <div className="flex justify-end gap-2">
+              <button
+                className="px-2 py-1 text-xs rounded hover:bg-slate-100 transition-colors"
+                onClick={cancelDelete}
+              >
+                Cancel
+              </button>
+              <button
+                className="px-2 py-1 text-xs bg-red-500 text-white rounded hover:bg-red-600 transition-colors"
+                onClick={confirmDelete}
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+} 

--- a/components/Sidebar/RecentChats.tsx
+++ b/components/Sidebar/RecentChats.tsx
@@ -4,7 +4,7 @@ import RecentChatSkeleton from "./RecentChatSkeleton";
 import capitalize from "@/lib/capitalize";
 
 const RecentChats = ({ toggleModal }: { toggleModal: () => void }) => {
-  const { allConversations, isLoading } = useConversationsProvider();
+  const { conversations, isLoading } = useConversationsProvider();
   const { handleClick } = useClickChat();
 
   return (
@@ -19,7 +19,7 @@ const RecentChats = ({ toggleModal }: { toggleModal: () => void }) => {
         ) : (
           <>
             {/* eslint-disable-next-line */}
-            {allConversations.map((conversation: any, index: number) => (
+            {conversations.map((conversation: any, index: number) => (
               <button
                 className="flex gap-2 items-center"
                 key={index}

--- a/components/Sidebar/RecentChats.tsx
+++ b/components/Sidebar/RecentChats.tsx
@@ -1,39 +1,165 @@
+import { useState } from "react";
 import useClickChat from "@/hooks/useClickChat";
 import { useConversationsProvider } from "@/providers/ConversationsProvider";
 import RecentChatSkeleton from "./RecentChatSkeleton";
 import capitalize from "@/lib/capitalize";
+import ChatOptionsMenu from "../Chat/ChatOptionsMenu";
+import { Conversation } from "@/types/Chat";
+import { useParams } from "next/navigation";
 
+/**
+ * A component that displays and manages the list of recent chat conversations
+ * for the currently selected artist. Includes inline rename and delete functionality.
+ */
 const RecentChats = ({ toggleModal }: { toggleModal: () => void }) => {
-  const { conversations, isLoading } = useConversationsProvider();
+  const { conversations, isLoading, fetchConversations } = useConversationsProvider();
   const { handleClick } = useClickChat();
+  const [editingChatId, setEditingChatId] = useState<string | null>(null);
+  const [editedName, setEditedName] = useState("");
+  const params = useParams();
+  const currentChatId = params?.id as string | undefined;
+  
+  /**
+   * Starts the inline renaming process for a chat
+   */
+  const startRenaming = (chatId: string, currentName: string) => {
+    setEditingChatId(chatId);
+    setEditedName(currentName);
+  };
+  
+  /**
+   * Cancels the rename operation and resets the editing state
+   */
+  const cancelRenaming = () => {
+    setEditingChatId(null);
+    setEditedName("");
+  };
+
+  /**
+   * Handles keyboard events during renaming (Enter to save, Escape to cancel)
+   */
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>, chatId: string) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      saveRename(chatId, editedName);
+    } else if (e.key === "Escape") {
+      cancelRenaming();
+    }
+  };
+
+  /**
+   * Updates the chat name in the database and refreshes the conversation list
+   */
+  const saveRename = async (chatId: string, newName: string): Promise<void> => {
+    if (!newName.trim()) {
+      cancelRenaming();
+      return;
+    }
+    
+    try {
+      const response = await fetch(
+        `/api/room/update?room_id=${encodeURIComponent(chatId)}&topic=${encodeURIComponent(newName)}`
+      );
+      
+      if (response.ok) {
+        fetchConversations();
+        cancelRenaming();
+      } else {
+        console.error("Failed to rename chat:", await response.json());
+      }
+    } catch (error) {
+      console.error("Error renaming chat:", error);
+    }
+  };
+
+  /**
+   * Deletes a chat from the database and refreshes the conversation list
+   */
+  const handleDelete = async (chatId: string): Promise<void> => {
+    try {
+      const response = await fetch(
+        `/api/room/delete?room_id=${encodeURIComponent(chatId)}`
+      );
+      
+      if (response.ok) {
+        fetchConversations();
+      } else {
+        console.error("Failed to delete chat:", await response.json());
+      }
+    } catch (error) {
+      console.error("Error deleting chat:", error);
+    }
+  };
 
   return (
-    <div>
+    <div className="flex flex-col mb-4">
       <div className="h-[1px] bg-grey-light w-full mt-1 mb-2 md:mt-2 md:mb-3" />
       <p className="text-sm mb-1 md:mb-2 font-inter text-grey-dark md:px-4">
         Recent Chats
       </p>
-      <div className="max-h-[75px] md:max-h-[140px] overflow-y-auto space-y-1 md:space-y-2 md:px-4">
-        {isLoading ? (
-          <RecentChatSkeleton />
-        ) : (
-          <>
-            {/* eslint-disable-next-line */}
-            {conversations.map((conversation: any, index: number) => (
-              <button
-                className="flex gap-2 items-center"
-                key={index}
-                type="button"
-                onClick={() => handleClick(conversation, toggleModal)}
-              >
-                <p className="text-sm truncate max-w-[200px]">
-                  {conversation?.topic ||
-                    `${capitalize(conversation?.type)} Analysis`}
-                </p>
-              </button>
-            ))}
-          </>
-        )}
+      <div className="relative">
+        <div className="max-h-[350px] overflow-y-auto space-y-0.5 md:space-y-1 md:px-4">
+          {isLoading ? (
+            <RecentChatSkeleton />
+          ) : (
+            <>
+              {conversations.map((conversation, index) => {
+                const conv = conversation as Conversation;
+                const chatName = conv.topic || `${capitalize(conv.artist_id || '')} Analysis`;
+                const isEditing = editingChatId === conv.id;
+                const isActive = currentChatId === conv.id;
+                
+                return (
+                  <div
+                    className={`flex gap-2 items-center w-full group relative rounded-md px-2 py-1 transition-colors ${
+                      isActive 
+                        ? 'bg-grey-light-1' 
+                        : 'hover:bg-grey-light-1'
+                    }`}
+                    key={conv.id || index}
+                  >
+                    {isEditing ? (
+                      <input
+                        type="text"
+                        value={editedName}
+                        onChange={(e) => setEditedName(e.target.value)}
+                        onKeyDown={(e) => handleKeyDown(e, conv.id)}
+                        onBlur={() => saveRename(conv.id, editedName)}
+                        className="text-sm px-2 py-1 border rounded-md w-full max-w-[160px] focus:outline-none"
+                        autoFocus
+                        aria-label="Edit chat name"
+                      />
+                    ) : (
+                      <button
+                        type="button"
+                        className="flex items-center w-full text-left"
+                        onClick={() => handleClick(conv, toggleModal)}
+                      >
+                        <p className={`text-sm truncate max-w-[160px] ${isActive ? 'font-medium' : ''}`}>
+                          {chatName}
+                        </p>
+                      </button>
+                    )}
+                    
+                    {!isEditing && (
+                      <div className="ml-auto">
+                        <ChatOptionsMenu
+                          chatId={conv.id}
+                          onStartRename={() => startRenaming(conv.id, chatName)}
+                          onDelete={handleDelete}
+                        />
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </>
+          )}
+        </div>
+        
+        {/* Fade effect overlays - more subtle */}
+        <div className="absolute top-0 left-0 right-0 h-4 bg-gradient-to-b from-gray-50 to-transparent pointer-events-none z-10"></div>
+        <div className="absolute bottom-0 left-0 right-0 h-4 bg-gradient-to-t from-gray-50 to-transparent pointer-events-none z-10"></div>
       </div>
     </div>
   );

--- a/hooks/useConversations.tsx
+++ b/hooks/useConversations.tsx
@@ -33,7 +33,14 @@ const useConversations = () => {
       (item: Conversation | ArtistAgent) =>
         'artist_id' in item && item.artist_id === selectedArtist?.account_id
     );
-    return filtered;
+    
+    // Sort by updated_at in descending order (most recent first)
+    return filtered.sort((a, b) => {
+      if ('updated_at' in a && 'updated_at' in b) {
+        return new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime();
+      }
+      return 0;
+    });
   }, [selectedArtist, allConversations]);
 
   const fetchConversations = async () => {

--- a/hooks/useConversations.tsx
+++ b/hooks/useConversations.tsx
@@ -29,18 +29,13 @@ const useConversations = () => {
   }, [userData, agents]);
 
   const conversations = useMemo(() => {
-    const filtered = allConversations.filter(
+    // Filter conversations by selected artist
+    return allConversations.filter(
       (item: Conversation | ArtistAgent) =>
         'artist_id' in item && item.artist_id === selectedArtist?.account_id
     );
     
-    // Sort by updated_at in descending order (most recent first)
-    return filtered.sort((a, b) => {
-      if ('updated_at' in a && 'updated_at' in b) {
-        return new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime();
-      }
-      return 0;
-    });
+    // Sorting is now handled at the API level in app/api/room/get/route.tsx
   }, [selectedArtist, allConversations]);
 
   const fetchConversations = async () => {


### PR DESCRIPTION
MYC-1282: Filter and Sort Recent Chats

This PR implements the first phase of the chat management improvements by:
Filtering the Recent Chats list to only show conversations for the currently selected artist (instead of all account chats)
Sorting conversations by recency, with the most recent chats appearing at the top of the list

Changes Made:
Updated components/Sidebar/RecentChats.tsx to use the filtered conversations array instead of allConversations
Modified hooks/useConversations.tsx to sort the filtered conversations by updated_at timestamp in descending order
These changes improve the user experience by showing only relevant chats for the current artist and prioritizing recent conversations, making navigation more intuitive and efficient.
The second phase will implement the rename and delete functionality, which will be added in a subsequent PR.