### PR TITLE
P1: Add Room Report HTML Support to /instant/[chatID] Route

### DIFF
--- a/app/instant/[roomId]/page.tsx
+++ b/app/instant/[roomId]/page.tsx
@@ -1,3 +1,4 @@
+import { getRoomReports } from "@/lib/supabase/getRoomReports";
 import { Chat } from "@/components/VercelChat/chat";
 
 interface PageProps {
@@ -8,10 +9,14 @@ interface PageProps {
 
 export default async function InstantChatRoom({ params }: PageProps) {
   const { roomId } = await params;
+  console.log(`[InstantChatRoom] Fetching reports for roomId: ${roomId}`);
+
+  const reports = await getRoomReports(roomId);
+  console.log(`[InstantChatRoom] Reports result:`, reports);
 
   return (
     <div className="flex flex-col size-full items-center">
-      <Chat roomId={roomId} />
+      <Chat roomId={roomId} reportId={reports?.report_id} />
     </div>
   );
 }

--- a/app/instant/[roomId]/page.tsx
+++ b/app/instant/[roomId]/page.tsx
@@ -9,10 +9,7 @@ interface PageProps {
 
 export default async function InstantChatRoom({ params }: PageProps) {
   const { roomId } = await params;
-  console.log(`[InstantChatRoom] Fetching reports for roomId: ${roomId}`);
-
   const reports = await getRoomReports(roomId);
-  console.log(`[InstantChatRoom] Reports result:`, reports);
 
   return (
     <div className="flex flex-col size-full items-center">

--- a/components/VercelChat/chat.tsx
+++ b/components/VercelChat/chat.tsx
@@ -31,7 +31,7 @@ export function Chat({ roomId, reportId }: ChatProps) {
     deps: [messages.length, roomId],
   });
 
-  if (isLoading || (!!roomId && messages.length === 0)) {
+  if (isLoading || (!!roomId && messages.length === 0 && !reportId)) {
     return <ChatSkeleton />;
   }
 

--- a/components/VercelChat/chat.tsx
+++ b/components/VercelChat/chat.tsx
@@ -8,12 +8,14 @@ import { useVercelChat } from "@/hooks/useVercelChat";
 import ChatGreeting from "../Chat/ChatGreeting";
 import ChatPrompt from "../Chat/ChatPrompt";
 import useVisibilityDelay from "@/hooks/useVisibilityDelay";
+import { ChatReport } from "../Chat/ChatReport";
 
 interface ChatProps {
   roomId?: string;
+  reportId?: string;
 }
 
-export function Chat({ roomId }: ChatProps) {
+export function Chat({ roomId, reportId }: ChatProps) {
   const {
     messages,
     status,
@@ -54,7 +56,9 @@ export function Chat({ roomId }: ChatProps) {
       )}
     >
       {messages.length > 0 || !!roomId ? (
-        <Messages messages={messages} status={status} />
+        <Messages messages={messages} status={status}>
+          {reportId && <ChatReport reportId={reportId} />}
+        </Messages>
       ) : (
         <div className="w-full">
           <ChatGreeting isVisible={isVisible} />

--- a/components/VercelChat/messages.tsx
+++ b/components/VercelChat/messages.tsx
@@ -116,9 +116,10 @@ export function TextMessagePart({ text }: TextMessagePartProps) {
 interface MessagesProps {
   messages: Array<UIMessage>;
   status: UseChatHelpers["status"];
+  children?: React.ReactNode;
 }
 
-export function Messages({ messages, status }: MessagesProps) {
+export function Messages({ messages, status, children }: MessagesProps) {
   const messagesRef = useRef<HTMLDivElement>(null);
   const messagesLength = useMemo(() => messages.length, [messages]);
 
@@ -133,6 +134,7 @@ export function Messages({ messages, status }: MessagesProps) {
       className="flex flex-col gap-8 overflow-y-scroll items-center w-full"
       ref={messagesRef}
     >
+      {children || null}
       {messages.map((message) => (
         <div
           key={message.id}


### PR DESCRIPTION
    actual: The /instant/[chatID] route does not display HTML room reports that are available in the /[chatID] route.
    required:
    Implement HTML room report display functionality in the /instant/[chatID] route
    Reference the implementation in /[chatID] route as the pattern to follow
    Ensure visual and functional parity of room reports between both routes
    Maintain all existing functionality of the /instant/[chatID] route