### PR TITLE
fix: require user approval before sending emails in agent prompts - M…

### DIFF
--- a/public/agents.json
+++ b/public/agents.json
@@ -128,19 +128,19 @@
   {
     "title": "Podcast Guest Acquisition",
     "description": "Find the right creators to feature on your podcast, build relationships, and send outreach emails that spark collaborations.",
-    "prompt": "Find 10 creators in unexpected niches (e.g., glitch fashion, gaming modders, TikTok historians, sports crossovers) who share audience overlap with my brand. For each creator: find their email. If no contact is found, skip them and find a different creator. Draft a personalized email inviting them to be a guest on my podcast. Reference their work, explain why the collaboration makes sense, and suggest a creative topic idea for the episode. Then send the email and cc me. Repeat until 10 emails have been sent.",
+    "prompt": "Find 10 creators in unexpected niches (e.g., glitch fashion, gaming modders, TikTok historians, sports crossovers) who share audience overlap with my brand. For each creator: find their email. If no contact is found, skip them and find a different creator. Draft a personalized email inviting them to be a guest on my podcast. Reference their work, explain why the collaboration makes sense, and suggest a creative topic idea for the episode. Show me all the drafted emails and get my approval before sending any outreach emails.",
     "tags": ["Podcasts", "Outreach"]
   },
   {
     "title": "Niche Community Infiltration",
     "description": "Find overlooked communities that align with your audience, then pitch tailored collaborations to build cultural relevance.",
-    "prompt": "Identify 5 hyper-niche communities (e.g., glitch art Discords, solarpunk Reddit threads, biohacking forums, VR modding groups) that share values with my brand. For each: find the moderator/admin contact email. If none, skip and find another. Draft a non corporate outreach email offering to guest-speak, co-host an AMA, or co-create content for their community. Then send the email and cc me. Repeat until 5 emails have been sent.",
+    "prompt": "Identify 5 hyper-niche communities (e.g., glitch art Discords, solarpunk Reddit threads, biohacking forums, VR modding groups) that share values with my brand. For each: find the moderator/admin contact email. If none, skip and find another. Draft a non corporate outreach email offering to guest-speak, co-host an AMA, or co-create content for their community. Show me all the drafted emails and get my approval before sending any outreach emails.",
     "tags": ["Community", "Outreach"]
   },
   {
     "title": "Ghibli YouTube Thumbnail Generation",
     "description": "Find a strong video with low CTR, create a Ghibli-style thumbnail, and upload it.",
-    "prompt": "Analyze my YouTube channel to identify a video with strong content but low click-through rate that needs thumbnail improvements. Create an eye-catching, brand-aligned thumbnail (ghiblified style) with clear focal points, minimal text, and high contrast colors. Upload the new thumbnail to YouTube.",
+    "prompt": "Analyze my YouTube channel to identify a video with strong content but low click-through rate that needs thumbnail improvements. Create an eye-catching, brand-aligned thumbnail (ghiblified style) with clear focal points, minimal text, and high contrast colors. Show me the thumbail emage and get approval before uploading to YouTube.",
     "tags": ["YouTube", "Content", "Social", "Assistant"] 
   }
 ] 


### PR DESCRIPTION
…odified Podcast Guest Acquisition and Niche Community Infiltration prompts to show drafted emails and get approval before sending - Prevents agents from automatically taking actions without user consent