### PR TITLE
Create migration to preserve Spotify URL case

### DIFF
--- a/supabase/migrations/20250623205635_fix_spotify_url_case_sensitivity.sql
+++ b/supabase/migrations/20250623205635_fix_spotify_url_case_sensitivity.sql
@@ -1,0 +1,25 @@
+-- Migration: Fix Spotify URL case sensitivity in socials.profile_url
+-- This migration updates the clean_socials_profile_url trigger function to preserve
+-- case sensitivity for Spotify URLs while maintaining existing cleaning behavior
+-- for all other social platforms.
+
+-- Update the cleaning function to preserve Spotify URL case sensitivity
+CREATE OR REPLACE FUNCTION clean_socials_profile_url()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- Remove protocol (http://, https://) from the start
+  NEW.profile_url := regexp_replace(NEW.profile_url, '^https?://', '');
+  -- Remove leading www. from the start
+  NEW.profile_url := regexp_replace(NEW.profile_url, '^www\.', '');
+  -- Remove any trailing slash
+  NEW.profile_url := regexp_replace(NEW.profile_url, '/+$', '');
+  
+  -- Convert to lowercase ONLY if URL does not contain 'spotify'
+  -- This preserves case sensitivity for Spotify artist IDs
+  IF NEW.profile_url NOT ILIKE '%spotify%' THEN
+    NEW.profile_url := lower(NEW.profile_url);
+  END IF;
+  
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
A new migration file, `supabase/migrations/20250623205635_fix_spotify_url_case_sensitivity.sql`, was created to address the issue of Spotify profile URLs being incorrectly lowercased.

The problem stemmed from the existing `clean_socials_profile_url()` PostgreSQL function, which applied a blanket lowercase conversion to all `profile_url` values in the `socials` table, breaking case-sensitive Spotify artist IDs.

The new migration updates this function to:
*   Continue removing protocols (http/https), "www" prefixes, and trailing slashes from all URLs.
*   Introduce a conditional lowercase conversion: `profile_url` values are now converted to lowercase *only if* they do not contain the substring "spotify" (case-insensitive check).
*   This ensures that Spotify URLs retain their original casing, preserving the validity of artist IDs, while other social platform URLs continue to be normalized to lowercase.

The change maintains existing cleaning behavior for non-Spotify URLs while specifically preventing data corruption for Spotify links.