### PR TITLE
Enforce uniqueness in post_comments table

### DIFF
--- a/supabase/migrations/20250709004417_add_unique_constraint_post_comments.sql
+++ b/supabase/migrations/20250709004417_add_unique_constraint_post_comments.sql
@@ -6,7 +6,7 @@
 -- This step is necessary before adding the unique constraint
 DELETE FROM "public"."post_comments" 
 WHERE "id" NOT IN (
-    SELECT MIN("id") 
+    SELECT (MIN("id"::text))::uuid 
     FROM "public"."post_comments" 
     GROUP BY "post_id", "social_id", "comment", "commented_at"
 );


### PR DESCRIPTION
Add unique constraint to `post_comments` table to prevent duplicate entries based on `post_id`, `social_id`, `comment`, and `commented_at`.

This migration first removes existing duplicate records (keeping the one with the earliest `id`) to ensure the unique constraint can be applied successfully without errors.

---

[Slack Thread](https://voicefirsttech.slack.com/archives/C05QQQS3AH0/p1752021730340789?thread_ts=1752021730.340789&cid=C05QQQS3AH0)