### PR TITLE
Add message limit to chat API

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -31,6 +31,8 @@ const corsHeaders = {
   "Access-Control-Allow-Credentials": "true",
 };
 
+const MAX_MESSAGES = 55;
+
 // Handle OPTIONS preflight requests
 export async function OPTIONS() {
   return new Response(null, {
@@ -84,7 +86,7 @@ export async function POST(request: NextRequest) {
         const result = streamText({
           model: myProvider.languageModel(selectedModelId),
           system,
-          messages: messagesWithRichFiles,
+          messages: messagesWithRichFiles.slice(-MAX_MESSAGES),
           maxSteps: 111,
           experimental_transform: smoothStream({ chunking: "word" }),
           experimental_generateMessageId: generateUUID,


### PR DESCRIPTION
* Introduce MAX_MESSAGES constant to limit the number of messages processed in the POST request to 55

* Update message handling to slice messagesWithRichFiles to the last MAX_MESSAGES