### PR TITLE
Refactor chat setup to include email in request body and user data

### DIFF
--- a/hooks/useVercelChat.ts
+++ b/hooks/useVercelChat.ts
@@ -31,7 +31,7 @@ export function useVercelChat({
   initialMessages,
   attachments = [],
 }: UseVercelChatProps) {
-  const { userData } = useUserProvider();
+  const { userData, email } = useUserProvider();
   const { selectedArtist } = useArtistProvider();
   const { roomId } = useParams();
   const userId = userData?.id;
@@ -53,10 +53,11 @@ export function useVercelChat({
         roomId: id,
         artistId,
         accountId: userId,
+        email,
         model,
       },
     }),
-    [id, artistId, userId, model]
+    [id, artistId, userId, email, model]
   );
 
   const { messages, status, stop, sendMessage, setMessages, regenerate } =

--- a/lib/chat/setupChatRequest.ts
+++ b/lib/chat/setupChatRequest.ts
@@ -2,7 +2,6 @@ import generateUUID from "@/lib/generateUUID";
 import { getMcpTools } from "@/lib/tools/getMcpTools";
 import attachRichFiles from "@/lib/chat/attachRichFiles";
 import getSystemPrompt from "@/lib/prompts/getSystemPrompt";
-import { getAccountEmails } from "@/lib/supabase/account_emails/getAccountEmails";
 import { MAX_MESSAGES } from "./const";
 import { type ChatRequest, type ChatConfig } from "./types";
 import { AnthropicProviderOptions } from "@ai-sdk/anthropic";
@@ -12,16 +11,7 @@ import getPrepareStepResult from "./toolChains/getPrepareStepResult";
 import { filterExcludedTools } from "./filterExcludedTools";
 
 export async function setupChatRequest(body: ChatRequest): Promise<ChatConfig> {
-  let { email } = body;
-  const { accountId, artistId, model, excludeTools } = body;
-
-  if (!email && accountId) {
-    const emails = await getAccountEmails(accountId);
-    if (emails.length > 0 && emails[0].email) {
-      email = emails[0].email;
-    }
-  }
-
+  const { accountId, artistId, model, excludeTools, email } = body;
   const tools = filterExcludedTools(getMcpTools(), excludeTools);
 
   const messagesWithRichFiles = await attachRichFiles(body.messages, {


### PR DESCRIPTION
- Updated useVercelChat hook to retrieve email from user provider
- Modified setupChatRequest function to directly accept email from the request body
- Removed redundant email fetching logic from setupChatRequest