### PR TITLE
feat: send opencode run params for sandbox prompts

### DIFF
--- a/lib/sandboxes/createSandbox.ts
+++ b/lib/sandboxes/createSandbox.ts
@@ -15,7 +15,7 @@ interface CreateSandboxResponse {
 }
 
 export async function createSandbox(
-  command: string,
+  prompt: string,
   accessToken: string
 ): Promise<Sandbox[]> {
   const response = await fetch(`${NEW_API_BASE_URL}/api/sandboxes`, {
@@ -24,7 +24,10 @@ export async function createSandbox(
       "Content-Type": "application/json",
       Authorization: `Bearer ${accessToken}`,
     },
-    body: JSON.stringify({ command }),
+    body: JSON.stringify({
+      command: "opencode",
+      args: ["run", prompt],
+    }),
   });
 
   const data: CreateSandboxResponse = await response.json();


### PR DESCRIPTION
## Summary
- Updates `createSandbox` to send `command: "opencode"` with `args: ["run", prompt]` instead of sending the raw prompt as `command`
- Users type natural language prompts (e.g. "build a hello world app") and the Chat UI constructs the correct params for the API/task to execute `opencode run "build a hello world app"` in the sandbox

## Test plan
- [ ] Type a prompt in the `/sandboxes` textarea (e.g. "build a hello world app")
- [ ] Verify the API receives `{ command: "opencode", args: ["run", "build a hello world app"] }`
- [ ] Verify the task executes `opencode run "build a hello world app"` in the sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced the sandbox creation mechanism to support structured command handling and improved flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->