### PR TITLE
[chat] Fire-and-forget sandbox setup on login

### DIFF
--- a/hooks/useUser.tsx
+++ b/hooks/useUser.tsx
@@ -7,6 +7,7 @@ import { uploadFile } from "@/lib/arweave/uploadFile";
 import { useAccount } from "wagmi";
 import { toast } from "sonner";
 import { AccountWithDetails } from "@/lib/supabase/accounts/getAccountWithDetails";
+import { triggerSandboxSetup } from "@/lib/sandbox/triggerSandboxSetup";
 
 const useUser = () => {
   const { login, user, logout } = usePrivy();
@@ -139,6 +140,9 @@ const useUser = () => {
 
       const data = await response.json();
       setUserData(data.data);
+      if (data.data?.account_id) {
+        triggerSandboxSetup(data.data.account_id);
+      }
       setImage(data.data?.image || "");
       setInstruction(data.data?.instruction || "");
       setName(data?.data?.name || "");

--- a/lib/sandbox/__tests__/triggerSandboxSetup.test.ts
+++ b/lib/sandbox/__tests__/triggerSandboxSetup.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { triggerSandboxSetup } from "../triggerSandboxSetup";
+
+const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  global.fetch = mockFetch;
+});
+
+describe("triggerSandboxSetup", () => {
+  it("calls POST /api/sandboxes/setup with account_id", () => {
+    triggerSandboxSetup("acc_123");
+
+    expect(mockFetch).toHaveBeenCalledWith("/api/sandboxes/setup", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ account_id: "acc_123" }),
+    });
+  });
+
+  it("does not throw when fetch rejects", () => {
+    mockFetch.mockRejectedValueOnce(new Error("Network error"));
+    expect(() => triggerSandboxSetup("acc_123")).not.toThrow();
+  });
+});

--- a/lib/sandbox/triggerSandboxSetup.ts
+++ b/lib/sandbox/triggerSandboxSetup.ts
@@ -1,0 +1,13 @@
+/**
+ * Fire-and-forget call to trigger sandbox provisioning for an account.
+ * The API handler is idempotent — it returns early if already provisioned.
+ *
+ * @param accountId - The account ID to provision a sandbox for
+ */
+export function triggerSandboxSetup(accountId: string): void {
+  fetch("/api/sandboxes/setup", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ account_id: accountId }),
+  }).catch(() => {});
+}


### PR DESCRIPTION
## Summary
Trigger sandbox provisioning on every login so customers always have a ready sandbox by the time they first use `prompt_sandbox`.

## Changes
- **New:** `lib/sandbox/triggerSandboxSetup.ts` — fire-and-forget POST to `/api/sandboxes/setup`
- **Edit:** `hooks/useUser.tsx` — call `triggerSandboxSetup()` after account data loads
- **New:** `lib/sandbox/__tests__/triggerSandboxSetup.test.ts` (2 tests)

## Notes
- The API handler is idempotent (early-exit if already provisioned)
- Race condition (user sends message before setup finishes) handled by existing fallback in `promptSandboxStreaming`

## Linear
MYC-4419

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Sandbox environments are now automatically provisioned when users authenticate with their accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->