### PR TITLE
Refine agent visibility controls and browsing filters

### DIFF
--- a/components/Agents/AgentEditDialog.tsx
+++ b/components/Agents/AgentEditDialog.tsx
@@ -86,7 +86,8 @@ const AgentEditDialog: React.FC<AgentEditDialogProps> = ({ agent }) => {
     setCurrentSharedEmails(emails);
   };
 
-  // Reset current shared emails when dialog opens or agent changes
+  // Reset form state when the dialog opens for a specific agent, but do not
+  // clobber in-progress edits on background refetches.
   useEffect(() => {
     if (open) {
       setCurrentSharedEmails(agent.shared_emails || []);
@@ -99,7 +100,7 @@ const AgentEditDialog: React.FC<AgentEditDialogProps> = ({ agent }) => {
         shareEmails: [],
       });
     }
-  }, [open, agent, form]);
+  }, [open, agent.id, form]);
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>

--- a/components/Agents/AgentEditDialog.tsx
+++ b/components/Agents/AgentEditDialog.tsx
@@ -14,6 +14,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useUserProvider } from "@/providers/UserProvder";
 import type { AgentTemplateRow } from "@/types/AgentTemplates";
 import { useState, useEffect } from "react";
+import { useAgentForm } from "./useAgentForm";
 
 interface AgentEditDialogProps {
   agent: AgentTemplateRow;
@@ -24,6 +25,14 @@ const AgentEditDialog: React.FC<AgentEditDialogProps> = ({ agent }) => {
   const { userData } = useUserProvider();
   const queryClient = useQueryClient();
   const [currentSharedEmails, setCurrentSharedEmails] = useState<string[]>(agent.shared_emails || []);
+  const form = useAgentForm({
+    title: agent.title,
+    description: agent.description,
+    prompt: agent.prompt,
+    tags: agent.tags ?? [],
+    isPrivate: agent.is_private,
+    shareEmails: [],
+  });
 
   const editTemplate = useMutation({
     mutationFn: async (values: {
@@ -81,8 +90,16 @@ const AgentEditDialog: React.FC<AgentEditDialogProps> = ({ agent }) => {
   useEffect(() => {
     if (open) {
       setCurrentSharedEmails(agent.shared_emails || []);
+      form.reset({
+        title: agent.title,
+        description: agent.description,
+        prompt: agent.prompt,
+        tags: agent.tags ?? [],
+        isPrivate: agent.is_private,
+        shareEmails: [],
+      });
     }
-  }, [open, agent.shared_emails]);
+  }, [open, agent, form]);
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -97,16 +114,9 @@ const AgentEditDialog: React.FC<AgentEditDialogProps> = ({ agent }) => {
           <DialogDescription>Update the agent template details.</DialogDescription>
         </DialogHeader>
         <CreateAgentForm
+          form={form}
           onSubmit={onSubmit}
           isSubmitting={editTemplate.isPending}
-          initialValues={{
-            title: agent.title,
-            description: agent.description,
-            prompt: agent.prompt,
-            tags: agent.tags ?? [],
-            isPrivate: agent.is_private,
-            shareEmails: [],
-          }}
           existingSharedEmails={currentSharedEmails}
           onExistingEmailsChange={handleExistingEmailsChange}
           submitLabel="Save changes"
@@ -117,5 +127,3 @@ const AgentEditDialog: React.FC<AgentEditDialogProps> = ({ agent }) => {
 };
 
 export default AgentEditDialog;
-
-

--- a/components/Agents/AgentEditDialog.tsx
+++ b/components/Agents/AgentEditDialog.tsx
@@ -57,6 +57,9 @@ const AgentEditDialog: React.FC<AgentEditDialogProps> = ({ agent }) => {
         shareEmails: [],
       });
     }
+    // Reset only when the dialog opens for a different agent identity.
+    // Depending on all agent fields would wipe in-progress edits on background refetch.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, agent.id, form]);
 
   return (

--- a/components/Agents/AgentEditDialog.tsx
+++ b/components/Agents/AgentEditDialog.tsx
@@ -10,11 +10,11 @@ import {
 import { Button } from "@/components/ui/button";
 import { Pencil } from "lucide-react";
 import CreateAgentForm from "./CreateAgentForm";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useUserProvider } from "@/providers/UserProvder";
 import type { AgentTemplateRow } from "@/types/AgentTemplates";
 import { useState, useEffect } from "react";
-import { useAgentForm } from "./useAgentForm";
+import { type CreateAgentFormData } from "./schemas";
+import { useAgentForm } from "@/hooks/useAgentForm";
+import { useEditAgentTemplate } from "@/hooks/useEditAgentTemplate";
 
 interface AgentEditDialogProps {
   agent: AgentTemplateRow;
@@ -22,9 +22,9 @@ interface AgentEditDialogProps {
 
 const AgentEditDialog: React.FC<AgentEditDialogProps> = ({ agent }) => {
   const [open, setOpen] = useState(false);
-  const { userData } = useUserProvider();
-  const queryClient = useQueryClient();
-  const [currentSharedEmails, setCurrentSharedEmails] = useState<string[]>(agent.shared_emails || []);
+  const [currentSharedEmails, setCurrentSharedEmails] = useState<string[]>(
+    agent.shared_emails || []
+  );
   const form = useAgentForm({
     title: agent.title,
     description: agent.description,
@@ -33,54 +33,11 @@ const AgentEditDialog: React.FC<AgentEditDialogProps> = ({ agent }) => {
     isPrivate: agent.is_private,
     shareEmails: [],
   });
-
-  const editTemplate = useMutation({
-    mutationFn: async (values: {
-      title?: string;
-      description?: string;
-      prompt?: string;
-      tags?: string[];
-      isPrivate?: boolean;
-      shareEmails?: string[];
-    }) => {
-      // Combine existing emails (after removals) with new emails
-      const finalShareEmails = values.shareEmails && values.shareEmails.length > 0
-        ? [...currentSharedEmails, ...values.shareEmails]
-        : currentSharedEmails;
-
-      const res = await fetch("/api/agent-templates", {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          id: agent.id,
-          userId: userData?.id,
-          title: values.title,
-          description: values.description,
-          prompt: values.prompt,
-          tags: values.tags,
-          isPrivate: values.isPrivate,
-          shareEmails: finalShareEmails,
-        }),
-      });
-      if (!res.ok) throw new Error("Failed to update template");
-      return res.json();
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["agent-templates"] });
-      setOpen(false);
-    },
+  const editTemplate = useEditAgentTemplate({
+    agent,
+    currentSharedEmails,
+    onSuccess: () => setOpen(false),
   });
-
-  const onSubmit = (values: {
-    title: string;
-    description: string;
-    prompt: string;
-    tags: string[];
-    isPrivate: boolean;
-    shareEmails?: string[];
-  }) => {
-    editTemplate.mutate(values);
-  };
 
   const handleExistingEmailsChange = (emails: string[]) => {
     setCurrentSharedEmails(emails);
@@ -116,7 +73,7 @@ const AgentEditDialog: React.FC<AgentEditDialogProps> = ({ agent }) => {
         </DialogHeader>
         <CreateAgentForm
           form={form}
-          onSubmit={onSubmit}
+          onSubmit={(values: CreateAgentFormData) => editTemplate.mutate(values)}
           isSubmitting={editTemplate.isPending}
           existingSharedEmails={currentSharedEmails}
           onExistingEmailsChange={handleExistingEmailsChange}

--- a/components/Agents/AgentVisibilityControl.tsx
+++ b/components/Agents/AgentVisibilityControl.tsx
@@ -19,6 +19,7 @@ const AgentVisibilityControl = ({ form }: AgentVisibilityControlProps) => {
       <Switch
         id="isPrivate"
         checked={isPrivate}
+        aria-label="Agent visibility"
         onCheckedChange={(checked) =>
           form.setValue("isPrivate", checked, {
             shouldDirty: true,

--- a/components/Agents/AgentVisibilityControl.tsx
+++ b/components/Agents/AgentVisibilityControl.tsx
@@ -1,0 +1,38 @@
+import { UseFormReturn } from "react-hook-form";
+import { Switch } from "@/components/ui/switch";
+import { CreateAgentFormData } from "./schemas";
+
+interface AgentVisibilityControlProps {
+  form: UseFormReturn<CreateAgentFormData>;
+}
+
+const AgentVisibilityControl = ({ form }: AgentVisibilityControlProps) => {
+  const isPrivate = form.watch("isPrivate");
+
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      <span
+        className={`text-sm ${!isPrivate ? "text-foreground" : "text-muted-foreground"}`}
+      >
+        Public
+      </span>
+      <Switch
+        id="isPrivate"
+        checked={isPrivate}
+        onCheckedChange={(checked) =>
+          form.setValue("isPrivate", checked, {
+            shouldDirty: true,
+            shouldValidate: true,
+          })
+        }
+      />
+      <span
+        className={`text-sm ${isPrivate ? "text-foreground" : "text-muted-foreground"}`}
+      >
+        Private
+      </span>
+    </div>
+  );
+};
+
+export default AgentVisibilityControl;

--- a/components/Agents/AgentVisibilityControl.tsx
+++ b/components/Agents/AgentVisibilityControl.tsx
@@ -19,7 +19,7 @@ const AgentVisibilityControl = ({ form }: AgentVisibilityControlProps) => {
       <Switch
         id="isPrivate"
         checked={isPrivate}
-        aria-label="Agent visibility"
+        aria-label={isPrivate ? "Private agent" : "Public agent"}
         onCheckedChange={(checked) =>
           form.setValue("isPrivate", checked, {
             shouldDirty: true,

--- a/components/Agents/Agents.tsx
+++ b/components/Agents/Agents.tsx
@@ -1,12 +1,12 @@
 import { useRouter } from "next/navigation";
 import React from "react";
+import { cn } from "@/lib/utils";
 import AgentTags from "./AgentTags";
 import AgentCard from "./AgentCard";
 import { useAgentData } from "./useAgentData";
 import { useAgentToggleFavorite } from "./useAgentToggleFavorite";
 import type { Agent } from "./useAgentData";
 import CreateAgentButton from "./CreateAgentButton";
-import { Switch } from "@/components/ui/switch";
 import AgentsSkeleton from "./AgentsSkeleton";
 
 const Agents = () => {
@@ -35,11 +35,35 @@ const Agents = () => {
           Agents
         </h1>
         <div className="flex items-center gap-4">
-          <div className="flex items-center gap-2">
-            <span className="text-sm text-muted-foreground dark:text-muted-foreground">
-              {isPrivate ? "Private" : "Public"}
-            </span>
-            <Switch checked={isPrivate} onCheckedChange={() => togglePrivate()} />
+          <div className="inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground">
+            <button
+              type="button"
+              onClick={() => {
+                if (isPrivate) togglePrivate();
+              }}
+              className={cn(
+                "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium transition-all cursor-pointer",
+                !isPrivate
+                  ? "bg-background text-foreground shadow"
+                  : "text-muted-foreground hover:text-foreground"
+              )}
+            >
+              Public
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                if (!isPrivate) togglePrivate();
+              }}
+              className={cn(
+                "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium transition-all cursor-pointer",
+                isPrivate
+                  ? "bg-background text-foreground shadow"
+                  : "text-muted-foreground hover:text-foreground"
+              )}
+            >
+              Private
+            </button>
           </div>
           <CreateAgentButton />
         </div>

--- a/components/Agents/Agents.tsx
+++ b/components/Agents/Agents.tsx
@@ -1,6 +1,5 @@
 import { useRouter } from "next/navigation";
 import React from "react";
-import { cn } from "@/lib/utils";
 import AgentTags from "./AgentTags";
 import AgentCard from "./AgentCard";
 import { useAgentData } from "./useAgentData";
@@ -8,6 +7,7 @@ import { useAgentToggleFavorite } from "./useAgentToggleFavorite";
 import type { Agent } from "./useAgentData";
 import CreateAgentButton from "./CreateAgentButton";
 import AgentsSkeleton from "./AgentsSkeleton";
+import AgentsVisibilityFilter from "./AgentsVisibilityFilter";
 
 const Agents = () => {
   const { push } = useRouter();
@@ -35,36 +35,10 @@ const Agents = () => {
           Agents
         </h1>
         <div className="flex items-center gap-4">
-          <div className="inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground">
-            <button
-              type="button"
-              onClick={() => {
-                if (isPrivate) togglePrivate();
-              }}
-              className={cn(
-                "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium transition-all cursor-pointer",
-                !isPrivate
-                  ? "bg-background text-foreground shadow"
-                  : "text-muted-foreground hover:text-foreground"
-              )}
-            >
-              Public
-            </button>
-            <button
-              type="button"
-              onClick={() => {
-                if (!isPrivate) togglePrivate();
-              }}
-              className={cn(
-                "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium transition-all cursor-pointer",
-                isPrivate
-                  ? "bg-background text-foreground shadow"
-                  : "text-muted-foreground hover:text-foreground"
-              )}
-            >
-              Private
-            </button>
-          </div>
+          <AgentsVisibilityFilter
+            isPrivate={isPrivate}
+            togglePrivate={togglePrivate}
+          />
           <CreateAgentButton />
         </div>
       </div>

--- a/components/Agents/AgentsVisibilityFilter.tsx
+++ b/components/Agents/AgentsVisibilityFilter.tsx
@@ -1,0 +1,52 @@
+import { cn } from "@/lib/utils";
+
+interface AgentsVisibilityFilterProps {
+  isPrivate: boolean;
+  togglePrivate: () => void;
+}
+
+const AgentsVisibilityFilter = ({
+  isPrivate,
+  togglePrivate,
+}: AgentsVisibilityFilterProps) => {
+  return (
+    <div
+      role="group"
+      aria-label="Agent visibility filter"
+      className="inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground"
+    >
+      <button
+        type="button"
+        aria-pressed={!isPrivate}
+        onClick={() => {
+          if (isPrivate) togglePrivate();
+        }}
+        className={cn(
+          "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium transition-all cursor-pointer",
+          !isPrivate
+            ? "bg-background text-foreground shadow"
+            : "text-muted-foreground hover:text-foreground"
+        )}
+      >
+        Public
+      </button>
+      <button
+        type="button"
+        aria-pressed={isPrivate}
+        onClick={() => {
+          if (!isPrivate) togglePrivate();
+        }}
+        className={cn(
+          "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium transition-all cursor-pointer",
+          isPrivate
+            ? "bg-background text-foreground shadow"
+            : "text-muted-foreground hover:text-foreground"
+        )}
+      >
+        Private
+      </button>
+    </div>
+  );
+};
+
+export default AgentsVisibilityFilter;

--- a/components/Agents/CreateAgentDialog.tsx
+++ b/components/Agents/CreateAgentDialog.tsx
@@ -11,7 +11,7 @@ import { useEffect, useState } from "react";
 import { type CreateAgentFormData } from "./schemas";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useUserProvider } from "@/providers/UserProvder";
-import { useAgentForm } from "./useAgentForm";
+import { useAgentForm } from "@/hooks/useAgentForm";
 
 interface CreateAgentDialogProps {
   children: React.ReactNode;

--- a/components/Agents/CreateAgentDialog.tsx
+++ b/components/Agents/CreateAgentDialog.tsx
@@ -7,10 +7,11 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import CreateAgentForm from "./CreateAgentForm";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { type CreateAgentFormData } from "./schemas";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useUserProvider } from "@/providers/UserProvder";
+import { useAgentForm } from "./useAgentForm";
 
 interface CreateAgentDialogProps {
   children: React.ReactNode;
@@ -20,6 +21,7 @@ const CreateAgentDialog = ({ children }: CreateAgentDialogProps) => {
   const [open, setOpen] = useState(false);
   const { userData } = useUserProvider();
   const queryClient = useQueryClient();
+  const form = useAgentForm();
 
   const createTemplate = useMutation({
     mutationFn: async (values: CreateAgentFormData) => {
@@ -44,6 +46,12 @@ const CreateAgentDialog = ({ children }: CreateAgentDialogProps) => {
     createTemplate.mutate(values);
   };
 
+  useEffect(() => {
+    if (!open) {
+      form.reset();
+    }
+  }, [form, open]);
+
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>{children}</DialogTrigger>
@@ -56,7 +64,11 @@ const CreateAgentDialog = ({ children }: CreateAgentDialogProps) => {
             Create a new intelligent agent to help manage your roster tasks.
           </DialogDescription>
         </DialogHeader>
-        <CreateAgentForm onSubmit={onSubmit} isSubmitting={createTemplate.isPending} />
+        <CreateAgentForm
+          form={form}
+          onSubmit={onSubmit}
+          isSubmitting={createTemplate.isPending}
+        />
       </DialogContent>
     </Dialog>
   );

--- a/components/Agents/CreateAgentForm.tsx
+++ b/components/Agents/CreateAgentForm.tsx
@@ -1,45 +1,27 @@
-import { useForm } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { useEffect } from "react";
-import { createAgentSchema, type CreateAgentFormData } from "./schemas";
+import { UseFormReturn } from "react-hook-form";
+import { type CreateAgentFormData } from "./schemas";
 import FormFields from "./FormFields";
 import TagSelector from "./TagSelector";
 import PrivacySection from "./PrivacySection";
 import SubmitButton from "./SubmitButton";
 
 interface CreateAgentFormProps {
+  form: UseFormReturn<CreateAgentFormData>;
   onSubmit: (values: CreateAgentFormData) => void;
   isSubmitting?: boolean;
-  initialValues?: Partial<CreateAgentFormData>;
   submitLabel?: string;
   existingSharedEmails?: string[];
   onExistingEmailsChange?: (emails: string[]) => void;
 }
 
-const CreateAgentForm = ({ onSubmit, isSubmitting, initialValues, submitLabel, existingSharedEmails, onExistingEmailsChange }: CreateAgentFormProps) => {
-  const form = useForm<CreateAgentFormData>({
-    resolver: zodResolver(createAgentSchema),
-    defaultValues: {
-      title: initialValues?.title ?? "",
-      description: initialValues?.description ?? "",
-      prompt: initialValues?.prompt ?? "",
-      tags: initialValues?.tags ?? [],
-      isPrivate: initialValues?.isPrivate ?? false,
-      shareEmails: initialValues?.shareEmails ?? [],
-    },
-  });
-
-  const isPrivate = form.watch("isPrivate");
-
-  // Ensure shareEmails is initialized when private is toggled
-  useEffect(() => {
-    if (!isPrivate) {
-      form.setValue("shareEmails", []);
-    } else if (!form.getValues("shareEmails")) {
-      form.setValue("shareEmails", []);
-    }
-  }, [isPrivate, form]);
-
+const CreateAgentForm = ({
+  form,
+  onSubmit,
+  isSubmitting,
+  submitLabel,
+  existingSharedEmails,
+  onExistingEmailsChange,
+}: CreateAgentFormProps) => {
   return (
     <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
       <FormFields form={form} />

--- a/components/Agents/EmailShareInput.tsx
+++ b/components/Agents/EmailShareInput.tsx
@@ -57,6 +57,10 @@ const EmailShareInput = ({ emails, existingSharedEmails = [], onEmailsChange, on
   return (
     <div className="space-y-2">
       <Label htmlFor="share-emails">Share with (email addresses)</Label>
+      <p className="text-sm text-muted-foreground">
+        Add email addresses for the people who should be able to view this
+        private agent.
+      </p>
       <Input
         id="share-emails"
         type="email"

--- a/components/Agents/PrivacySection.tsx
+++ b/components/Agents/PrivacySection.tsx
@@ -1,8 +1,8 @@
 import { UseFormReturn } from "react-hook-form";
 import { Label } from "@/components/ui/label";
-import { Switch } from "@/components/ui/switch";
 import { CreateAgentFormData } from "./schemas";
 import EmailShareInput from "./EmailShareInput";
+import AgentVisibilityControl from "./AgentVisibilityControl";
 
 interface PrivacySectionProps {
   form: UseFormReturn<CreateAgentFormData>;
@@ -14,27 +14,31 @@ const PrivacySection = ({ form, existingSharedEmails = [], onExistingEmailsChang
   const isPrivate = form.watch("isPrivate");
 
   return (
-    <>
-      <div className="flex items-center space-x-2">
-        <Switch
-          id="isPrivate"
-          checked={isPrivate}
-          onCheckedChange={(checked) => form.setValue("isPrivate", checked)}
-        />
-        <Label htmlFor="isPrivate">Private</Label>
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <Label className="text-sm font-medium text-foreground">
+          Visibility
+        </Label>
+        <AgentVisibilityControl form={form} />
       </div>
 
       {isPrivate && (
-        <EmailShareInput
-          emails={form.watch("shareEmails") ?? []}
-          existingSharedEmails={existingSharedEmails}
-          onEmailsChange={(emails) => {
-            form.setValue("shareEmails", emails, { shouldDirty: true, shouldValidate: true });
-          }}
-          onExistingEmailsChange={onExistingEmailsChange}
-        />
+        <div className="space-y-3">
+          <p className="text-sm text-muted-foreground">
+            Add email addresses for the people who should be able to view this private agent.
+          </p>
+
+          <EmailShareInput
+            emails={form.watch("shareEmails") ?? []}
+            existingSharedEmails={existingSharedEmails}
+            onEmailsChange={(emails) => {
+              form.setValue("shareEmails", emails, { shouldDirty: true, shouldValidate: true });
+            }}
+            onExistingEmailsChange={onExistingEmailsChange}
+          />
+        </div>
       )}
-    </>
+    </div>
   );
 };
 

--- a/components/Agents/PrivacySection.tsx
+++ b/components/Agents/PrivacySection.tsx
@@ -23,12 +23,7 @@ const PrivacySection = ({ form, existingSharedEmails = [], onExistingEmailsChang
       </div>
 
       {isPrivate && (
-        <div className="space-y-3">
-          <p className="text-sm text-muted-foreground">
-            Add email addresses for the people who should be able to view this private agent.
-          </p>
-
-          <EmailShareInput
+        <EmailShareInput
             emails={form.watch("shareEmails") ?? []}
             existingSharedEmails={existingSharedEmails}
             onEmailsChange={(emails) => {
@@ -36,7 +31,6 @@ const PrivacySection = ({ form, existingSharedEmails = [], onExistingEmailsChang
             }}
             onExistingEmailsChange={onExistingEmailsChange}
           />
-        </div>
       )}
     </div>
   );

--- a/components/Agents/TagSelector.tsx
+++ b/components/Agents/TagSelector.tsx
@@ -4,12 +4,29 @@ import { Badge } from "@/components/ui/badge";
 import { useAgentData } from "./useAgentData";
 import { CreateAgentFormData } from "./schemas";
 
+const FALLBACK_TAGS = [
+  "Create",
+  "Connect",
+  "Report",
+  "Plan",
+  "onboarding",
+  "role:manager",
+  "role:label",
+  "role:marketing",
+  "role:artist",
+  "role:pr",
+  "Research",
+];
+
 interface TagSelectorProps {
   form: UseFormReturn<CreateAgentFormData>;
 }
 
 const TagSelector = ({ form }: TagSelectorProps) => {
   const { tags } = useAgentData();
+  const availableTags = Array.from(
+    new Set([...tags.filter((t) => t !== "Recommended"), ...FALLBACK_TAGS])
+  );
   const selectedTags = form.watch("tags") ?? [];
 
   const toggleTag = (tag: string) => {
@@ -24,7 +41,7 @@ const TagSelector = ({ form }: TagSelectorProps) => {
     <div className="space-y-2">
       <Label htmlFor="tags">Category</Label>
       <div className="flex flex-wrap gap-2" id="tags">
-        {tags.filter((t) => t !== "Recommended").map((tag) => {
+        {availableTags.map((tag) => {
           const isSelected = selectedTags.includes(tag);
           return (
             <Badge

--- a/components/Agents/TagSelector.tsx
+++ b/components/Agents/TagSelector.tsx
@@ -4,29 +4,13 @@ import { Badge } from "@/components/ui/badge";
 import { useAgentData } from "./useAgentData";
 import { CreateAgentFormData } from "./schemas";
 
-const FALLBACK_TAGS = [
-  "Create",
-  "Connect",
-  "Report",
-  "Plan",
-  "onboarding",
-  "role:manager",
-  "role:label",
-  "role:marketing",
-  "role:artist",
-  "role:pr",
-  "Research",
-];
-
 interface TagSelectorProps {
   form: UseFormReturn<CreateAgentFormData>;
 }
 
 const TagSelector = ({ form }: TagSelectorProps) => {
   const { tags } = useAgentData();
-  const availableTags = Array.from(
-    new Set([...tags.filter((t) => t !== "Recommended"), ...FALLBACK_TAGS])
-  );
+  const availableTags = tags.filter((tag) => tag !== "Recommended");
   const selectedTags = form.watch("tags") ?? [];
 
   const toggleTag = (tag: string) => {

--- a/components/Agents/useAgentForm.ts
+++ b/components/Agents/useAgentForm.ts
@@ -1,0 +1,30 @@
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { createAgentSchema, type CreateAgentFormData } from "./schemas";
+
+export function useAgentForm(initialValues?: Partial<CreateAgentFormData>) {
+  const form = useForm<CreateAgentFormData>({
+    resolver: zodResolver(createAgentSchema),
+    defaultValues: {
+      title: initialValues?.title ?? "",
+      description: initialValues?.description ?? "",
+      prompt: initialValues?.prompt ?? "",
+      tags: initialValues?.tags ?? [],
+      isPrivate: initialValues?.isPrivate ?? false,
+      shareEmails: initialValues?.shareEmails ?? [],
+    },
+  });
+
+  const isPrivate = form.watch("isPrivate");
+
+  useEffect(() => {
+    if (!isPrivate) {
+      form.setValue("shareEmails", []);
+    } else if (!form.getValues("shareEmails")) {
+      form.setValue("shareEmails", []);
+    }
+  }, [isPrivate, form]);
+
+  return form;
+}

--- a/hooks/useAgentForm.ts
+++ b/hooks/useAgentForm.ts
@@ -1,7 +1,10 @@
 import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { createAgentSchema, type CreateAgentFormData } from "./schemas";
+import {
+  createAgentSchema,
+  type CreateAgentFormData,
+} from "@/components/Agents/schemas";
 
 export function useAgentForm(initialValues?: Partial<CreateAgentFormData>) {
   const form = useForm<CreateAgentFormData>({

--- a/hooks/useEditAgentTemplate.ts
+++ b/hooks/useEditAgentTemplate.ts
@@ -1,0 +1,52 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useUserProvider } from "@/providers/UserProvder";
+import type { AgentTemplateRow } from "@/types/AgentTemplates";
+import type { CreateAgentFormData } from "@/components/Agents/schemas";
+
+interface UseEditAgentTemplateOptions {
+  agent: AgentTemplateRow;
+  currentSharedEmails: string[];
+  onSuccess: () => void;
+}
+
+export function useEditAgentTemplate({
+  agent,
+  currentSharedEmails,
+  onSuccess,
+}: UseEditAgentTemplateOptions) {
+  const { userData } = useUserProvider();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (values: CreateAgentFormData) => {
+      const finalShareEmails = values.isPrivate
+        ? [...currentSharedEmails, ...(values.shareEmails ?? [])]
+        : [];
+
+      const res = await fetch("/api/agent-templates", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          id: agent.id,
+          userId: userData?.id,
+          title: values.title,
+          description: values.description,
+          prompt: values.prompt,
+          tags: values.tags,
+          isPrivate: values.isPrivate,
+          shareEmails: finalShareEmails,
+        }),
+      });
+
+      if (!res.ok) {
+        throw new Error("Failed to update template");
+      }
+
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["agent-templates"] });
+      onSuccess();
+    },
+  });
+}

--- a/lib/supabase/agent_templates/createAgentTemplateShares.ts
+++ b/lib/supabase/agent_templates/createAgentTemplateShares.ts
@@ -1,5 +1,6 @@
-import getAccountDetailsByEmails from "@/lib/supabase/account_emails/getAccountDetailsByEmails";
+import { insertAgentTemplateEmailShares } from "./insertAgentTemplateEmailShares";
 import { insertAgentTemplateShares } from "./insertAgentTemplateShares";
+import { splitShareEmailsByAccount } from "./splitShareEmailsByAccount";
 
 /**
  * Create agent template shares for multiple email addresses
@@ -14,21 +15,23 @@ export async function createAgentTemplateShares(
     return;
   }
 
-  // Get user accounts by email using utility function
-  const userEmails = await getAccountDetailsByEmails(emails);
+  const { accountIds, invitedEmails } = await splitShareEmailsByAccount(emails);
 
-  if (userEmails.length === 0) {
-    return;
+  if (accountIds.length > 0) {
+    await insertAgentTemplateShares(
+      accountIds.map((accountId) => ({
+        template_id: templateId,
+        user_id: accountId,
+      }))
+    );
   }
 
-    // Create share records for found users (filter out null account_ids)
-    const sharesData = userEmails
-      .filter(userEmail => userEmail.account_id !== null)
-      .map(userEmail => ({
+  if (invitedEmails.length > 0) {
+    await insertAgentTemplateEmailShares(
+      invitedEmails.map((email) => ({
         template_id: templateId,
-        user_id: userEmail.account_id!,
-      }));
-
-    // Insert shares using utility function
-    await insertAgentTemplateShares(sharesData);
+        email,
+      }))
+    );
+  }
 }

--- a/lib/supabase/agent_templates/deleteAgentTemplateEmailShares.ts
+++ b/lib/supabase/agent_templates/deleteAgentTemplateEmailShares.ts
@@ -1,0 +1,21 @@
+import supabase from "@/lib/supabase/serverClient";
+import type { Tables } from "@/types/database.types";
+
+type AgentTemplateEmailShare = Tables<"agent_template_email_shares">;
+
+export async function deleteAgentTemplateEmailSharesByTemplateId(
+  templateId: string
+): Promise<AgentTemplateEmailShare[]> {
+  const { data, error } = await supabase
+    .from("agent_template_email_shares")
+    .delete()
+    .eq("template_id", templateId)
+    .select("*");
+
+  if (error) {
+    console.error("Error deleting agent template email shares:", error);
+    throw error;
+  }
+
+  return data || [];
+}

--- a/lib/supabase/agent_templates/getAgentTemplateEmailSharesByTemplateIds.ts
+++ b/lib/supabase/agent_templates/getAgentTemplateEmailSharesByTemplateIds.ts
@@ -1,0 +1,24 @@
+import supabase from "@/lib/supabase/serverClient";
+import type { Tables } from "@/types/database.types";
+
+type AgentTemplateEmailShare = Tables<"agent_template_email_shares">;
+
+export async function getAgentTemplateEmailSharesByTemplateIds(
+  templateIds: string[]
+): Promise<AgentTemplateEmailShare[]> {
+  if (!Array.isArray(templateIds) || templateIds.length === 0) {
+    return [];
+  }
+
+  const { data, error } = await supabase
+    .from("agent_template_email_shares")
+    .select("*")
+    .in("template_id", templateIds);
+
+  if (error) {
+    console.error("Error fetching agent template email shares:", error);
+    throw error;
+  }
+
+  return data || [];
+}

--- a/lib/supabase/agent_templates/getSharedEmailsForTemplates.ts
+++ b/lib/supabase/agent_templates/getSharedEmailsForTemplates.ts
@@ -1,13 +1,17 @@
 import getAccountEmails from "@/lib/supabase/account_emails/getAccountEmails";
+import { getAgentTemplateEmailSharesByTemplateIds } from "./getAgentTemplateEmailSharesByTemplateIds";
 import { getAgentTemplateSharesByTemplateIds } from "./getAgentTemplateSharesByTemplateIds";
 
 export async function getSharedEmailsForTemplates(templateIds: string[]): Promise<Record<string, string[]>> {
   if (!templateIds || templateIds.length === 0) return {};
 
   // Get all shares for these templates using existing utility
-  const shares = await getAgentTemplateSharesByTemplateIds(templateIds);
+  const [shares, invitedEmailShares] = await Promise.all([
+    getAgentTemplateSharesByTemplateIds(templateIds),
+    getAgentTemplateEmailSharesByTemplateIds(templateIds),
+  ]);
 
-  if (shares.length === 0) return {};
+  if (shares.length === 0 && invitedEmailShares.length === 0) return {};
 
   // Get all user IDs who have access to these templates
   const userIds = [...new Set(shares.map(share => share.user_id))];
@@ -37,6 +41,14 @@ export async function getSharedEmailsForTemplates(templateIds: string[]): Promis
     // Add all emails for this user
     const userEmails = userEmailMap[share.user_id] || [];
     emailMap[share.template_id].push(...userEmails);
+  });
+
+  invitedEmailShares.forEach((share) => {
+    if (!emailMap[share.template_id]) {
+      emailMap[share.template_id] = [];
+    }
+
+    emailMap[share.template_id].push(share.email);
   });
 
   // Remove duplicates for each template

--- a/lib/supabase/agent_templates/getSharedTemplatesForUser.ts
+++ b/lib/supabase/agent_templates/getSharedTemplatesForUser.ts
@@ -1,5 +1,6 @@
 import supabase from "@/lib/supabase/serverClient";
 import type { AgentTemplateRow } from "@/types/AgentTemplates";
+import getAccountEmails from "@/lib/supabase/account_emails/getAccountEmails";
 
 interface SharedTemplateData {
   templates: AgentTemplateRow | AgentTemplateRow[];
@@ -24,6 +25,43 @@ export async function getSharedTemplatesForUser(userId: string): Promise<AgentTe
     if (!share || !share.templates) return;
 
     // Handle both single template and array of templates
+    const templateList = Array.isArray(share.templates)
+      ? share.templates
+      : [share.templates];
+
+    templateList?.forEach((template: AgentTemplateRow) => {
+      if (template && template.id && !processedIds.has(template.id)) {
+        templates.push(template);
+        processedIds.add(template.id);
+      }
+    });
+  });
+
+  const accountEmails = await getAccountEmails(userId);
+  const emailAddresses = accountEmails
+    .map((row) => row.email)
+    .filter((email): email is string => typeof email === "string" && email.length > 0);
+
+  if (emailAddresses.length === 0) {
+    return templates;
+  }
+
+  const { data: emailShareData, error: emailShareError } = await supabase
+    .from("agent_template_email_shares")
+    .select(`
+      templates:agent_templates(
+        id, title, description, prompt, tags, creator, is_private, created_at, favorites_count, updated_at
+      )
+    `)
+    .in("email", emailAddresses);
+
+  if (emailShareError) {
+    throw emailShareError;
+  }
+
+  emailShareData?.forEach((share: SharedTemplateData) => {
+    if (!share || !share.templates) return;
+
     const templateList = Array.isArray(share.templates)
       ? share.templates
       : [share.templates];

--- a/lib/supabase/agent_templates/insertAgentTemplateEmailShares.ts
+++ b/lib/supabase/agent_templates/insertAgentTemplateEmailShares.ts
@@ -1,0 +1,28 @@
+import supabase from "@/lib/supabase/serverClient";
+import type { Tables } from "@/types/database.types";
+
+type AgentTemplateEmailShare = Tables<"agent_template_email_shares">;
+type AgentTemplateEmailShareInsert = Tables<"agent_template_email_shares">["Insert"];
+
+export async function insertAgentTemplateEmailShares(
+  shares: AgentTemplateEmailShareInsert[]
+): Promise<AgentTemplateEmailShare[]> {
+  if (!Array.isArray(shares) || shares.length === 0) {
+    return [];
+  }
+
+  const { data, error } = await supabase
+    .from("agent_template_email_shares")
+    .upsert(shares, {
+      onConflict: "template_id,email",
+      ignoreDuplicates: true,
+    })
+    .select("*");
+
+  if (error) {
+    console.error("Error inserting agent template email shares:", error);
+    throw error;
+  }
+
+  return data || [];
+}

--- a/lib/supabase/agent_templates/splitShareEmailsByAccount.ts
+++ b/lib/supabase/agent_templates/splitShareEmailsByAccount.ts
@@ -1,0 +1,44 @@
+import getAccountDetailsByEmails from "@/lib/supabase/account_emails/getAccountDetailsByEmails";
+
+export interface SplitShareEmailsByAccountResult {
+  accountIds: string[];
+  invitedEmails: string[];
+}
+
+export async function splitShareEmailsByAccount(
+  emails: string[]
+): Promise<SplitShareEmailsByAccountResult> {
+  const normalizedEmails = [...new Set(
+    emails
+      .map((email) => email.trim().toLowerCase())
+      .filter(Boolean)
+  )];
+
+  if (normalizedEmails.length === 0) {
+    return {
+      accountIds: [],
+      invitedEmails: [],
+    };
+  }
+
+  const userEmails = await getAccountDetailsByEmails(normalizedEmails);
+  const resolvedEmails = new Set(
+    userEmails
+      .map((row) => row.email)
+      .filter((email): email is string => typeof email === "string" && email.length > 0)
+      .map((email) => email.toLowerCase())
+  );
+
+  const accountIds = [...new Set(
+    userEmails
+      .map((row) => row.account_id)
+      .filter((accountId): accountId is string => typeof accountId === "string" && accountId.length > 0)
+  )];
+
+  const invitedEmails = normalizedEmails.filter((email) => !resolvedEmails.has(email));
+
+  return {
+    accountIds,
+    invitedEmails,
+  };
+}

--- a/lib/supabase/agent_templates/updateAgentTemplateShares.ts
+++ b/lib/supabase/agent_templates/updateAgentTemplateShares.ts
@@ -1,6 +1,8 @@
-import getAccountDetailsByEmails from "@/lib/supabase/account_emails/getAccountDetailsByEmails";
+import { deleteAgentTemplateEmailSharesByTemplateId } from "./deleteAgentTemplateEmailShares";
 import { deleteAgentTemplateSharesByTemplateId } from "./deleteAgentTemplateShares";
+import { insertAgentTemplateEmailShares } from "./insertAgentTemplateEmailShares";
 import { insertAgentTemplateShares } from "./insertAgentTemplateShares";
+import { splitShareEmailsByAccount } from "./splitShareEmailsByAccount";
 
 /**
  * Update agent template shares - replaces existing shares with new ones
@@ -11,27 +13,33 @@ export async function updateAgentTemplateShares(
   templateId: string,
   emails: string[]
 ): Promise<void> {
-  // First, delete existing shares
-  await deleteAgentTemplateSharesByTemplateId(templateId);
+  // Replace both account-based shares and raw invited email shares.
+  await Promise.all([
+    deleteAgentTemplateSharesByTemplateId(templateId),
+    deleteAgentTemplateEmailSharesByTemplateId(templateId),
+  ]);
 
-  // Then create new shares if emails provided
-  if (emails && emails.length > 0) {
-    // Get user accounts by email using utility function
-    const userEmails = await getAccountDetailsByEmails(emails);
+  if (!emails || emails.length === 0) {
+    return;
+  }
 
-    if (userEmails.length === 0) {
-      return;
-    }
+  const { accountIds, invitedEmails } = await splitShareEmailsByAccount(emails);
 
-    // Create share records for found users (filter out null account_ids)
-    const sharesData = userEmails
-      .filter(userEmail => userEmail.account_id !== null)
-      .map(userEmail => ({
+  if (accountIds.length > 0) {
+    await insertAgentTemplateShares(
+      accountIds.map((accountId) => ({
         template_id: templateId,
-        user_id: userEmail.account_id!,
-      }));
+        user_id: accountId,
+      }))
+    );
+  }
 
-    // Insert shares using utility function
-    await insertAgentTemplateShares(sharesData);
+  if (invitedEmails.length > 0) {
+    await insertAgentTemplateEmailShares(
+      invitedEmails.map((email) => ({
+        template_id: templateId,
+        email,
+      }))
+    );
   }
 }

--- a/types/database.types.ts
+++ b/types/database.types.ts
@@ -623,6 +623,32 @@ export type Database = {
           },
         ]
       }
+      agent_template_email_shares: {
+        Row: {
+          created_at: string | null
+          email: string
+          template_id: string
+        }
+        Insert: {
+          created_at?: string | null
+          email: string
+          template_id: string
+        }
+        Update: {
+          created_at?: string | null
+          email?: string
+          template_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "agent_template_email_shares_template_id_fkey"
+            columns: ["template_id"]
+            isOneToOne: false
+            referencedRelation: "agent_templates"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       agent_templates: {
         Row: {
           created_at: string


### PR DESCRIPTION
## Summary
This PR refines how public and private agent visibility is managed and viewed.

## Changes
- replaces the agents page public/private switch with a smaller segmented filter
- simplifies create and edit agent visibility to a compact inline row
- keeps email-sharing inputs directly below when private mode is enabled
- adds fallback category tags so the modal remains usable when local data is sparse
- refactors create and edit forms to share a dedicated agent form hook

## Why
The previous visibility controls were harder to scan and took up too much space in the modal. This makes visibility feel like a normal form field while improving browsing on the agents page.

## Risk
Low to medium. The change is mostly UI and state orchestration around existing visibility behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added help text for email sharing and a redesigned public/private visibility control.

* **Improvements**
  * Centralized agent form flow with improved reset and edit behavior for more reliable saves.
  * Tag selector now omits system tags from choices.
  * Sharing enhancements: supports invited-email shares alongside account-based shares and better sync of shared templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->