### PR TITLE
refactor: integrate Privy access token handling in delete and update

### DIFF
--- a/hooks/useDeleteScheduledAction.ts
+++ b/hooks/useDeleteScheduledAction.ts
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { toast } from "react-toastify";
 import { useQueryClient } from "@tanstack/react-query";
+import { usePrivy } from "@privy-io/react-auth";
 import { deleteTask } from "@/lib/tasks/deleteTask";
 
 interface DeleteScheduledActionParams {
@@ -12,6 +13,7 @@ interface DeleteScheduledActionParams {
 export const useDeleteScheduledAction = () => {
   const [isLoading, setIsLoading] = useState(false);
   const queryClient = useQueryClient();
+  const { getAccessToken } = usePrivy();
 
   const deleteAction = async ({
     actionId,
@@ -20,7 +22,13 @@ export const useDeleteScheduledAction = () => {
   }: DeleteScheduledActionParams) => {
     setIsLoading(true);
     try {
-      await deleteTask({ id: actionId });
+      const accessToken = await getAccessToken();
+      if (!accessToken) {
+        toast.error("Please sign in to delete tasks");
+        throw new Error("Please sign in to delete tasks");
+      }
+
+      await deleteTask(accessToken, { id: actionId });
 
       onSuccess?.();
       toast.success(successMessage);
@@ -31,9 +39,9 @@ export const useDeleteScheduledAction = () => {
       throw error;
     } finally {
       setIsLoading(false);
-      queryClient.invalidateQueries({ 
+      queryClient.invalidateQueries({
         queryKey: ["scheduled-actions"],
-        exact: false 
+        exact: false,
       });
     }
   };

--- a/hooks/useUpdateScheduledAction.ts
+++ b/hooks/useUpdateScheduledAction.ts
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { toast } from "react-toastify";
 import { Tables } from "@/types/database.types";
 import { useQueryClient } from "@tanstack/react-query";
+import { usePrivy } from "@privy-io/react-auth";
 import { updateTask, UpdateTaskParams } from "@/lib/tasks/updateTask";
 
 type ScheduledAction = Tables<"scheduled_actions">;
@@ -15,6 +16,7 @@ interface UpdateScheduledActionParams {
 export const useUpdateScheduledAction = () => {
   const [isLoading, setIsLoading] = useState(false);
   const queryClient = useQueryClient();
+  const { getAccessToken } = usePrivy();
 
   const updateAction = async ({
     updates,
@@ -23,7 +25,13 @@ export const useUpdateScheduledAction = () => {
   }: UpdateScheduledActionParams) => {
     setIsLoading(true);
     try {
-      const updatedTask = await updateTask(updates);
+      const accessToken = await getAccessToken();
+      if (!accessToken) {
+        toast.error("Please sign in to update tasks");
+        throw new Error("Please sign in to update tasks");
+      }
+
+      const updatedTask = await updateTask(accessToken, updates);
 
       onSuccess?.(updatedTask);
       toast.success(successMessage);
@@ -35,9 +43,9 @@ export const useUpdateScheduledAction = () => {
       throw error;
     } finally {
       setIsLoading(false);
-      queryClient.invalidateQueries({ 
+      queryClient.invalidateQueries({
         queryKey: ["scheduled-actions"],
-        exact: false 
+        exact: false,
       });
     }
   };

--- a/lib/tasks/deleteTask.ts
+++ b/lib/tasks/deleteTask.ts
@@ -1,4 +1,3 @@
-import { ScheduledAction } from "@/components/VercelChat/types";
 import { TASKS_API_URL } from "@/lib/consts";
 
 export interface DeleteTaskParams {
@@ -26,39 +25,49 @@ async function deleteTaskFromDatabase(taskId: string): Promise<void> {
   });
 }
 
+interface DeleteTaskApiResponse {
+  status: "success" | "error";
+  error?: string;
+}
+
 /**
- * Deletes a task via the Recoup API and database
+ * Deletes a task via the Recoup API and database.
+ *
+ * @param accessToken - Privy access token (same auth model as getTasks).
+ * @param params - Task id to delete.
  * @see https://docs.recoupable.com/tasks/delete
  */
-export async function deleteTask(params: DeleteTaskParams): Promise<void> {
+export async function deleteTask(accessToken: string, params: DeleteTaskParams): Promise<void> {
+  const response = await fetch(TASKS_API_URL, {
+    method: "DELETE",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({
+      id: params.id,
+    }),
+  });
+
+  const responseText = await response.text();
+
+  if (!response.ok) {
+    if (isScheduleNotFoundError(responseText)) {
+      await deleteTaskFromDatabase(params.id);
+      return;
+    }
+
+    throw new Error(`HTTP ${response.status}: ${responseText}`);
+  }
+
+  let data: DeleteTaskApiResponse;
   try {
-    const response = await fetch(TASKS_API_URL, {
-      method: "DELETE",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        id: params.id,
-      }),
-    });
+    data = JSON.parse(responseText) as DeleteTaskApiResponse;
+  } catch {
+    throw new Error("Failed to delete task: invalid response");
+  }
 
-    if (!response.ok) {
-      const errorText = await response.text();
-
-      if (isScheduleNotFoundError(errorText)) {
-        await deleteTaskFromDatabase(params.id);
-        return;
-      }
-
-      throw new Error(`HTTP ${response.status}: ${errorText}`);
-    }
-
-    const data: ScheduledAction = await response.json();
-
-    if (!data) {
-      throw new Error("Failed to delete task");
-    }
-  } catch (error) {
-    throw error;
+  if (data.status === "error") {
+    throw new Error(data.error || "Failed to delete task");
   }
 }

--- a/lib/tasks/updateTask.ts
+++ b/lib/tasks/updateTask.ts
@@ -9,33 +9,35 @@ export interface UpdateTaskParams {
   title?: string;
   prompt?: string;
   schedule?: string;
-  account_id?: string;
   artist_account_id?: string;
   enabled?: boolean | null;
   model?: string | null;
 }
 
 /**
- * Updates an existing task via the Recoup API
+ * Updates an existing task via the Recoup API.
+ * Identity is taken from the Bearer token; do not send account_id (API ignores it on PATCH).
+ *
+ * @param accessToken - Privy access token (same auth model as getTasks).
+ * @param params - Task id and fields to update.
  * @see https://docs.recoupable.com/tasks/update
  */
 export async function updateTask(
-  params: UpdateTaskParams
+  accessToken: string,
+  params: UpdateTaskParams,
 ): Promise<ScheduledAction> {
   try {
     const response = await fetch(TASKS_API_URL, {
       method: "PATCH",
       headers: {
         "Content-Type": "application/json",
+        Authorization: `Bearer ${accessToken}`,
       },
       body: JSON.stringify({
         id: params.id,
         ...(params.title !== undefined && { title: params.title }),
         ...(params.prompt !== undefined && { prompt: params.prompt }),
         ...(params.schedule !== undefined && { schedule: params.schedule }),
-        ...(params.account_id !== undefined && {
-          account_id: params.account_id,
-        }),
         ...(params.artist_account_id !== undefined && {
           artist_account_id: params.artist_account_id,
         }),


### PR DESCRIPTION
* Updated useDeleteScheduledAction and useUpdateScheduledAction hooks to directly use getAccessToken from usePrivy for authentication.
* Enhanced error handling to prompt users to sign in if the access token is not available.
* Modified deleteTask and updateTask functions to accept the access token as a parameter for API calls, ensuring secure and authenticated requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Task deletion and updates now require user authentication. Users will see a sign-in prompt if attempting to delete or update tasks while not signed in, with improved error messaging to guide the authentication flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->