### PR TITLE
Security: enforce auth and ownership checks on chat fallback DELETE /api/scheduled-actions/delete

### DIFF
--- a/app/api/scheduled-actions/delete/__tests__/route.test.ts
+++ b/app/api/scheduled-actions/delete/__tests__/route.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { DELETE } from "../route";
+import supabase from "@/lib/supabase/serverClient";
+import { validateHeaders } from "@/lib/chat/validateHeaders";
+import { checkAccountArtistAccess } from "@/lib/supabase/account_artist_ids/checkAccountArtistAccess";
+
+vi.mock("@/lib/supabase/serverClient", () => ({
+  default: {
+    from: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/chat/validateHeaders", () => ({
+  validateHeaders: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/account_artist_ids/checkAccountArtistAccess", () => ({
+  checkAccountArtistAccess: vi.fn(),
+}));
+
+function makeRequest(body: unknown): NextRequest {
+  return new Request("http://localhost/api/scheduled-actions/delete", {
+    method: "DELETE",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }) as NextRequest;
+}
+
+describe("DELETE /api/scheduled-actions/delete", () => {
+  const mockFrom = vi.mocked(supabase.from);
+  const mockValidateHeaders = vi.mocked(validateHeaders);
+  const mockCheckAccountArtistAccess = vi.mocked(checkAccountArtistAccess);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when caller is unauthenticated", async () => {
+    mockValidateHeaders.mockResolvedValueOnce({});
+
+    const response = await DELETE(makeRequest({ id: "1e632dc8-94aa-4f85-9f85-241213d0d2f9" }));
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data).toEqual({ error: "Unauthorized" });
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when id is missing or invalid", async () => {
+    mockValidateHeaders.mockResolvedValueOnce({ accountId: "account-123" });
+
+    const response = await DELETE(makeRequest({ id: "not-a-uuid" }));
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toContain("UUID");
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when task does not exist", async () => {
+    mockValidateHeaders.mockResolvedValueOnce({ accountId: "account-123" });
+
+    const maybeSingle = vi.fn().mockResolvedValueOnce({ data: null, error: null });
+    const eq = vi.fn().mockReturnValue({ maybeSingle });
+    const select = vi.fn().mockReturnValue({ eq });
+    mockFrom.mockReturnValueOnce({ select } as never);
+
+    const response = await DELETE(makeRequest({ id: "1e632dc8-94aa-4f85-9f85-241213d0d2f9" }));
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data).toEqual({ error: "Task not found" });
+  });
+
+  it("returns 403 when caller is not owner and lacks artist access", async () => {
+    mockValidateHeaders.mockResolvedValueOnce({ accountId: "account-123" });
+    mockCheckAccountArtistAccess.mockResolvedValueOnce(false);
+
+    const maybeSingle = vi.fn().mockResolvedValueOnce({
+      data: {
+        id: "1e632dc8-94aa-4f85-9f85-241213d0d2f9",
+        account_id: "other-account",
+        artist_account_id: "artist-456",
+      },
+      error: null,
+    });
+    const eqForSelect = vi.fn().mockReturnValue({ maybeSingle });
+    const select = vi.fn().mockReturnValue({ eq: eqForSelect });
+    mockFrom.mockReturnValueOnce({ select } as never);
+
+    const response = await DELETE(makeRequest({ id: "1e632dc8-94aa-4f85-9f85-241213d0d2f9" }));
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data).toEqual({ error: "Forbidden" });
+  });
+
+  it("returns 200 and deletes when caller owns the task", async () => {
+    mockValidateHeaders.mockResolvedValueOnce({ accountId: "account-123" });
+
+    const maybeSingle = vi.fn().mockResolvedValueOnce({
+      data: {
+        id: "1e632dc8-94aa-4f85-9f85-241213d0d2f9",
+        account_id: "account-123",
+        artist_account_id: "artist-456",
+      },
+      error: null,
+    });
+    const eqForSelect = vi.fn().mockReturnValue({ maybeSingle });
+    const select = vi.fn().mockReturnValue({ eq: eqForSelect });
+
+    const deleteEq = vi.fn().mockResolvedValueOnce({ error: null });
+    const deleteFn = vi.fn().mockReturnValue({ eq: deleteEq });
+
+    mockFrom
+      .mockReturnValueOnce({ select } as never)
+      .mockReturnValueOnce({ delete: deleteFn } as never);
+
+    const response = await DELETE(makeRequest({ id: "1e632dc8-94aa-4f85-9f85-241213d0d2f9" }));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({ success: true });
+    expect(mockCheckAccountArtistAccess).not.toHaveBeenCalled();
+    expect(deleteFn).toHaveBeenCalledOnce();
+    expect(deleteEq).toHaveBeenCalledWith("id", "1e632dc8-94aa-4f85-9f85-241213d0d2f9");
+  });
+});

--- a/app/api/scheduled-actions/delete/__tests__/route.test.ts
+++ b/app/api/scheduled-actions/delete/__tests__/route.test.ts
@@ -1,15 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 import { DELETE } from "../route";
-import supabase from "@/lib/supabase/serverClient";
 import { validateHeaders } from "@/lib/chat/validateHeaders";
 import { checkAccountArtistAccess } from "@/lib/supabase/account_artist_ids/checkAccountArtistAccess";
-
-vi.mock("@/lib/supabase/serverClient", () => ({
-  default: {
-    from: vi.fn(),
-  },
-}));
+import { deleteScheduledActionById } from "@/lib/supabase/scheduled_actions/deleteScheduledActionById";
+import { selectScheduledActionById } from "@/lib/supabase/scheduled_actions/selectScheduledActionById";
 
 vi.mock("@/lib/chat/validateHeaders", () => ({
   validateHeaders: vi.fn(),
@@ -17,6 +12,14 @@ vi.mock("@/lib/chat/validateHeaders", () => ({
 
 vi.mock("@/lib/supabase/account_artist_ids/checkAccountArtistAccess", () => ({
   checkAccountArtistAccess: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/scheduled_actions/selectScheduledActionById", () => ({
+  selectScheduledActionById: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/scheduled_actions/deleteScheduledActionById", () => ({
+  deleteScheduledActionById: vi.fn(),
 }));
 
 function makeRequest(body: unknown): NextRequest {
@@ -28,9 +31,10 @@ function makeRequest(body: unknown): NextRequest {
 }
 
 describe("DELETE /api/scheduled-actions/delete", () => {
-  const mockFrom = vi.mocked(supabase.from);
   const mockValidateHeaders = vi.mocked(validateHeaders);
   const mockCheckAccountArtistAccess = vi.mocked(checkAccountArtistAccess);
+  const mockSelectScheduledActionById = vi.mocked(selectScheduledActionById);
+  const mockDeleteScheduledActionById = vi.mocked(deleteScheduledActionById);
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -44,7 +48,7 @@ describe("DELETE /api/scheduled-actions/delete", () => {
 
     expect(response.status).toBe(401);
     expect(data).toEqual({ error: "Unauthorized" });
-    expect(mockFrom).not.toHaveBeenCalled();
+    expect(mockSelectScheduledActionById).not.toHaveBeenCalled();
   });
 
   it("returns 400 when id is missing or invalid", async () => {
@@ -55,16 +59,15 @@ describe("DELETE /api/scheduled-actions/delete", () => {
 
     expect(response.status).toBe(400);
     expect(data.error).toContain("UUID");
-    expect(mockFrom).not.toHaveBeenCalled();
+    expect(mockSelectScheduledActionById).not.toHaveBeenCalled();
   });
 
   it("returns 404 when task does not exist", async () => {
     mockValidateHeaders.mockResolvedValueOnce({ accountId: "account-123" });
-
-    const maybeSingle = vi.fn().mockResolvedValueOnce({ data: null, error: null });
-    const eq = vi.fn().mockReturnValue({ maybeSingle });
-    const select = vi.fn().mockReturnValue({ eq });
-    mockFrom.mockReturnValueOnce({ select } as never);
+    mockSelectScheduledActionById.mockResolvedValueOnce({
+      data: null,
+      error: null,
+    } as Awaited<ReturnType<typeof selectScheduledActionById>>);
 
     const response = await DELETE(makeRequest({ id: "1e632dc8-94aa-4f85-9f85-241213d0d2f9" }));
     const data = await response.json();
@@ -76,46 +79,36 @@ describe("DELETE /api/scheduled-actions/delete", () => {
   it("returns 403 when caller is not owner and lacks artist access", async () => {
     mockValidateHeaders.mockResolvedValueOnce({ accountId: "account-123" });
     mockCheckAccountArtistAccess.mockResolvedValueOnce(false);
-
-    const maybeSingle = vi.fn().mockResolvedValueOnce({
+    mockSelectScheduledActionById.mockResolvedValueOnce({
       data: {
         id: "1e632dc8-94aa-4f85-9f85-241213d0d2f9",
         account_id: "other-account",
         artist_account_id: "artist-456",
       },
       error: null,
-    });
-    const eqForSelect = vi.fn().mockReturnValue({ maybeSingle });
-    const select = vi.fn().mockReturnValue({ eq: eqForSelect });
-    mockFrom.mockReturnValueOnce({ select } as never);
+    } as Awaited<ReturnType<typeof selectScheduledActionById>>);
 
     const response = await DELETE(makeRequest({ id: "1e632dc8-94aa-4f85-9f85-241213d0d2f9" }));
     const data = await response.json();
 
     expect(response.status).toBe(403);
     expect(data).toEqual({ error: "Forbidden" });
+    expect(mockDeleteScheduledActionById).not.toHaveBeenCalled();
   });
 
   it("returns 200 and deletes when caller owns the task", async () => {
     mockValidateHeaders.mockResolvedValueOnce({ accountId: "account-123" });
-
-    const maybeSingle = vi.fn().mockResolvedValueOnce({
+    mockSelectScheduledActionById.mockResolvedValueOnce({
       data: {
         id: "1e632dc8-94aa-4f85-9f85-241213d0d2f9",
         account_id: "account-123",
         artist_account_id: "artist-456",
       },
       error: null,
-    });
-    const eqForSelect = vi.fn().mockReturnValue({ maybeSingle });
-    const select = vi.fn().mockReturnValue({ eq: eqForSelect });
-
-    const deleteEq = vi.fn().mockResolvedValueOnce({ error: null });
-    const deleteFn = vi.fn().mockReturnValue({ eq: deleteEq });
-
-    mockFrom
-      .mockReturnValueOnce({ select } as never)
-      .mockReturnValueOnce({ delete: deleteFn } as never);
+    } as Awaited<ReturnType<typeof selectScheduledActionById>>);
+    mockDeleteScheduledActionById.mockResolvedValueOnce({
+      error: null,
+    } as Awaited<ReturnType<typeof deleteScheduledActionById>>);
 
     const response = await DELETE(makeRequest({ id: "1e632dc8-94aa-4f85-9f85-241213d0d2f9" }));
     const data = await response.json();
@@ -123,7 +116,9 @@ describe("DELETE /api/scheduled-actions/delete", () => {
     expect(response.status).toBe(200);
     expect(data).toEqual({ success: true });
     expect(mockCheckAccountArtistAccess).not.toHaveBeenCalled();
-    expect(deleteFn).toHaveBeenCalledOnce();
-    expect(deleteEq).toHaveBeenCalledWith("id", "1e632dc8-94aa-4f85-9f85-241213d0d2f9");
+    expect(mockDeleteScheduledActionById).toHaveBeenCalledTimes(1);
+    expect(mockDeleteScheduledActionById).toHaveBeenCalledWith(
+      "1e632dc8-94aa-4f85-9f85-241213d0d2f9"
+    );
   });
 });

--- a/app/api/scheduled-actions/delete/route.ts
+++ b/app/api/scheduled-actions/delete/route.ts
@@ -1,14 +1,62 @@
 import { NextRequest, NextResponse } from "next/server";
 import supabase from "@/lib/supabase/serverClient";
+import { z } from "zod";
+import { validateHeaders } from "@/lib/chat/validateHeaders";
+import { checkAccountArtistAccess } from "@/lib/supabase/account_artist_ids/checkAccountArtistAccess";
+
+const deleteScheduledActionBodySchema = z.object({
+  id: z.string().uuid("id must be a valid UUID"),
+});
 
 export async function DELETE(req: NextRequest) {
-  const { id } = await req.json();
+  const auth = await validateHeaders(req);
+  if (auth instanceof Response) {
+    return auth;
+  }
 
-  if (!id) {
-    return NextResponse.json({ error: "Missing task id" }, { status: 400 });
+  const accountId = auth.accountId;
+  if (!accountId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = deleteScheduledActionBodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.issues[0]?.message ?? "Invalid id" }, { status: 400 });
   }
 
   try {
+    const { id } = parsed.data;
+
+    const { data: scheduledAction, error: selectError } = await supabase
+      .from("scheduled_actions")
+      .select("id, account_id, artist_account_id")
+      .eq("id", id)
+      .maybeSingle();
+
+    if (selectError) {
+      throw new Error(`Failed to load task: ${selectError.message}`);
+    }
+
+    if (!scheduledAction) {
+      return NextResponse.json({ error: "Task not found" }, { status: 404 });
+    }
+
+    const canDeleteAsOwner = scheduledAction.account_id === accountId;
+    const canDeleteAsArtistAccess = canDeleteAsOwner
+      ? true
+      : await checkAccountArtistAccess(accountId, scheduledAction.artist_account_id);
+
+    if (!canDeleteAsOwner && !canDeleteAsArtistAccess) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
     const { error } = await supabase
       .from("scheduled_actions")
       .delete()

--- a/app/api/scheduled-actions/delete/route.ts
+++ b/app/api/scheduled-actions/delete/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
-import supabase from "@/lib/supabase/serverClient";
 import { z } from "zod";
 import { validateHeaders } from "@/lib/chat/validateHeaders";
 import { checkAccountArtistAccess } from "@/lib/supabase/account_artist_ids/checkAccountArtistAccess";
+import { deleteScheduledActionById } from "@/lib/supabase/scheduled_actions/deleteScheduledActionById";
+import { selectScheduledActionById } from "@/lib/supabase/scheduled_actions/selectScheduledActionById";
 
 const deleteScheduledActionBodySchema = z.object({
   id: z.string().uuid("id must be a valid UUID"),
@@ -34,11 +35,7 @@ export async function DELETE(req: NextRequest) {
   try {
     const { id } = parsed.data;
 
-    const { data: scheduledAction, error: selectError } = await supabase
-      .from("scheduled_actions")
-      .select("id, account_id, artist_account_id")
-      .eq("id", id)
-      .maybeSingle();
+    const { data: scheduledAction, error: selectError } = await selectScheduledActionById(id);
 
     if (selectError) {
       throw new Error(`Failed to load task: ${selectError.message}`);
@@ -57,10 +54,7 @@ export async function DELETE(req: NextRequest) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
-    const { error } = await supabase
-      .from("scheduled_actions")
-      .delete()
-      .eq("id", id);
+    const { error } = await deleteScheduledActionById(id);
 
     if (error) {
       throw new Error(`Failed to delete task: ${error.message}`);
@@ -76,4 +70,3 @@ export async function DELETE(req: NextRequest) {
 }
 
 export const dynamic = "force-dynamic";
-

--- a/hooks/useDeleteScheduledAction.ts
+++ b/hooks/useDeleteScheduledAction.ts
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { toast } from "react-toastify";
 import { useQueryClient } from "@tanstack/react-query";
+import { usePrivy } from "@privy-io/react-auth";
 import { deleteTask } from "@/lib/tasks/deleteTask";
 
 interface DeleteScheduledActionParams {
@@ -12,6 +13,7 @@ interface DeleteScheduledActionParams {
 export const useDeleteScheduledAction = () => {
   const [isLoading, setIsLoading] = useState(false);
   const queryClient = useQueryClient();
+  const { getAccessToken } = usePrivy();
 
   const deleteAction = async ({
     actionId,
@@ -20,7 +22,12 @@ export const useDeleteScheduledAction = () => {
   }: DeleteScheduledActionParams) => {
     setIsLoading(true);
     try {
-      await deleteTask({ id: actionId });
+      const accessToken = await getAccessToken();
+      if (!accessToken) {
+        throw new Error("Please sign in to delete scheduled actions");
+      }
+
+      await deleteTask({ id: actionId, accessToken });
 
       onSuccess?.();
       toast.success(successMessage);

--- a/lib/supabase/scheduled_actions/deleteScheduledActionById.ts
+++ b/lib/supabase/scheduled_actions/deleteScheduledActionById.ts
@@ -1,0 +1,5 @@
+import supabase from "@/lib/supabase/serverClient";
+
+export async function deleteScheduledActionById(id: string) {
+  return supabase.from("scheduled_actions").delete().eq("id", id);
+}

--- a/lib/supabase/scheduled_actions/selectScheduledActionById.ts
+++ b/lib/supabase/scheduled_actions/selectScheduledActionById.ts
@@ -1,0 +1,15 @@
+import supabase from "@/lib/supabase/serverClient";
+import type { Tables } from "@/types/database.types";
+
+export type ScheduledActionAuthRow = Pick<
+  Tables<"scheduled_actions">,
+  "id" | "account_id" | "artist_account_id"
+>;
+
+export async function selectScheduledActionById(id: string) {
+  return supabase
+    .from("scheduled_actions")
+    .select("id, account_id, artist_account_id")
+    .eq("id", id)
+    .maybeSingle<ScheduledActionAuthRow>();
+}

--- a/lib/tasks/deleteTask.ts
+++ b/lib/tasks/deleteTask.ts
@@ -3,6 +3,7 @@ import { TASKS_API_URL } from "@/lib/consts";
 
 export interface DeleteTaskParams {
   id: string;
+  accessToken: string;
 }
 
 const SCHEDULE_NOT_FOUND_MSG = "Schedule not found";
@@ -18,10 +19,13 @@ function isScheduleNotFoundError(errorText: string): boolean {
 /**
  * Delete task record from database when scheduler deletion isn't possible
  */
-async function deleteTaskFromDatabase(taskId: string): Promise<void> {
+async function deleteTaskFromDatabase(taskId: string, accessToken: string): Promise<void> {
   await fetch("/api/scheduled-actions/delete", {
     method: "DELETE",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${accessToken}`,
+    },
     body: JSON.stringify({ id: taskId }),
   });
 }
@@ -32,10 +36,15 @@ async function deleteTaskFromDatabase(taskId: string): Promise<void> {
  */
 export async function deleteTask(params: DeleteTaskParams): Promise<void> {
   try {
+    if (!params.accessToken) {
+      throw new Error("Please sign in to delete scheduled actions");
+    }
+
     const response = await fetch(TASKS_API_URL, {
       method: "DELETE",
       headers: {
         "Content-Type": "application/json",
+        Authorization: `Bearer ${params.accessToken}`,
       },
       body: JSON.stringify({
         id: params.id,
@@ -46,7 +55,7 @@ export async function deleteTask(params: DeleteTaskParams): Promise<void> {
       const errorText = await response.text();
 
       if (isScheduleNotFoundError(errorText)) {
-        await deleteTaskFromDatabase(params.id);
+        await deleteTaskFromDatabase(params.id, params.accessToken);
         return;
       }
 


### PR DESCRIPTION
- hardening the chat fallback delete route for scheduled actions
- closing an auth gap where deletion could be triggered by task UUID alone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scheduled action deletion now requires authentication via access tokens.
  * Added access control validation—only action owners or authorized users can delete scheduled actions.

* **Bug Fixes**
  * Enhanced request validation with UUID format verification.
  * Improved error handling with clearer responses for invalid or unauthorized deletion attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->