### PR TITLE
test(chat): use real navigation for artist redirect

### DIFF
--- a/hooks/useCreateArtistTool.ts
+++ b/hooks/useCreateArtistTool.ts
@@ -4,6 +4,7 @@ import { useConversationsProvider } from "@/providers/ConversationsProvider";
 import { CreateArtistResult } from "@/types/createArtistResult";
 import copyMessages from "@/lib/messages/copyMessages";
 import { usePrivy } from "@privy-io/react-auth";
+import { useRouter } from "next/navigation";
 
 /**
  * Hook for managing the create artist tool result
@@ -13,6 +14,7 @@ export function useCreateArtistTool(result: CreateArtistResult) {
   const { status, id } = useVercelChatContext();
   const { refetchConversations } = useConversationsProvider();
   const { getAccessToken } = usePrivy();
+  const router = useRouter();
   const [isProcessing, setIsProcessing] = useState(false);
   const [isSuccess, setIsSuccess] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -54,7 +56,7 @@ export function useCreateArtistTool(result: CreateArtistResult) {
 
           if (success) {
             // Update the URL to point to the new conversation
-            window.history.replaceState({}, "", `/chat/${result.newRoomId}`);
+            router.replace(`/chat/${result.newRoomId}`);
             setIsSuccess(true);
           } else {
             console.error("Failed to copy messages");
@@ -79,6 +81,7 @@ export function useCreateArtistTool(result: CreateArtistResult) {
     isProcessing,
     refetchConversations,
     getAccessToken,
+    router,
   ]);
 
   return {


### PR DESCRIPTION
## Summary
- replace the artist creation redirect with Next router navigation
- keep the rest of the existing copy flow unchanged
- use this PR to test whether real navigation stops the immediate copy loop

## Notes
- this is intentionally a narrow spike
- it does not address historical replay when revisiting the source chat

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch artist creation redirect to Next.js router navigation to use real navigation and potentially stop the immediate copy loop. Replaces window.history.replaceState with `router.replace` from `next/navigation`; no other copy flow changes.

<sup>Written for commit fcb8197caf6f3f020a50b7a43e87bdea4ef1398b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

