### PR TITLE
fix: wire account override to /files page

### DIFF
--- a/hooks/useSandboxFileContent.ts
+++ b/hooks/useSandboxFileContent.ts
@@ -2,6 +2,7 @@ import { useCallback, useState } from "react";
 import { useMutation } from "@tanstack/react-query";
 import { usePrivy } from "@privy-io/react-auth";
 import { getFileContents } from "@/lib/sandboxes/getFileContents";
+import { useAccountOverride } from "@/providers/AccountOverrideProvider";
 
 interface UseSandboxFileContentReturn {
   selectedPath: string | undefined;
@@ -14,6 +15,7 @@ interface UseSandboxFileContentReturn {
 
 export default function useSandboxFileContent(): UseSandboxFileContentReturn {
   const { getAccessToken } = usePrivy();
+  const { accountIdOverride } = useAccountOverride();
   const [selectedPath, setSelectedPath] = useState<string>();
 
   const mutation = useMutation({
@@ -23,7 +25,7 @@ export default function useSandboxFileContent(): UseSandboxFileContentReturn {
         throw new Error("Please sign in to view file contents");
       }
 
-      return getFileContents(accessToken, path);
+      return getFileContents(accessToken, path, accountIdOverride);
     },
   });
 

--- a/hooks/useSandboxes.ts
+++ b/hooks/useSandboxes.ts
@@ -4,6 +4,7 @@ import { usePrivy } from "@privy-io/react-auth";
 import { getSandboxes } from "@/lib/sandboxes/getSandboxes";
 import { convertFileTreeEntries } from "@/lib/sandboxes/convertFileTreeEntries";
 import getSubtreeAtPath from "@/lib/sandboxes/getSubtreeAtPath";
+import { useAccountOverride } from "@/providers/AccountOverrideProvider";
 import type { Sandbox } from "@/lib/sandboxes/createSandbox";
 import type { FileNode } from "@/lib/sandboxes/parseFileTree";
 
@@ -17,15 +18,16 @@ interface UseSandboxesReturn {
 
 export default function useSandboxes(): UseSandboxesReturn {
   const { getAccessToken, authenticated } = usePrivy();
+  const { accountIdOverride } = useAccountOverride();
 
   const query = useQuery({
-    queryKey: ["sandboxes"],
+    queryKey: ["sandboxes", accountIdOverride],
     queryFn: async () => {
       const accessToken = await getAccessToken();
       if (!accessToken) {
         throw new Error("Please sign in to view sandboxes");
       }
-      return getSandboxes(accessToken);
+      return getSandboxes(accessToken, accountIdOverride);
     },
     enabled: authenticated,
   });

--- a/lib/sandboxes/getFileContents.ts
+++ b/lib/sandboxes/getFileContents.ts
@@ -21,16 +21,20 @@ interface FileContentsResult {
 export async function getFileContents(
   accessToken: string,
   path: string,
+  accountId?: string | null,
 ): Promise<FileContentsResult> {
-  const response = await fetch(
-    `${getClientApiBaseUrl()}/api/sandboxes/file?path=${encodeURIComponent(path)}`,
-    {
-      method: "GET",
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
+  const url = new URL(`${getClientApiBaseUrl()}/api/sandboxes/file`);
+  url.searchParams.set("path", path);
+  if (accountId) {
+    url.searchParams.set("account_id", accountId);
+  }
+
+  const response = await fetch(url.toString(), {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
     },
-  );
+  });
 
   const data: GetFileContentsResponse = await response.json();
 

--- a/lib/sandboxes/getSandboxes.ts
+++ b/lib/sandboxes/getSandboxes.ts
@@ -15,9 +15,15 @@ export interface GetSandboxesResult {
 }
 
 export async function getSandboxes(
-  accessToken: string
+  accessToken: string,
+  accountId?: string | null,
 ): Promise<GetSandboxesResult> {
-  const response = await fetch(`${getClientApiBaseUrl()}/api/sandboxes`, {
+  const url = new URL(`${getClientApiBaseUrl()}/api/sandboxes`);
+  if (accountId) {
+    url.searchParams.set("account_id", accountId);
+  }
+
+  const response = await fetch(url.toString(), {
     method: "GET",
     headers: {
       Authorization: `Bearer ${accessToken}`,


### PR DESCRIPTION
## Summary
- Wires `useAccountOverride()` into `useSandboxes` and `useSandboxFileContent` hooks
- Passes the resolved `accountIdOverride` as `account_id` query param to both `GET /api/sandboxes` and `GET /api/sandboxes/file`
- Includes `accountIdOverride` in react-query cache key for proper re-fetching when override changes

## Context
Part of REC-53: the `/files` page showed the logged-in user's files even when the `email` override was active. The `AccountOverrideProvider` already resolved the email to accountId, but the sandbox hooks were not consuming the override. Now they do.

**Depends on:** recoupable/api#410

## Test plan
- [ ] Navigate to `/files?email=someone@example.com` — should show override account's files
- [ ] Navigate to `/files` without override — should show own files
- [ ] CI build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the /files page to respect the email-based account override by passing the resolved account_id to sandbox API calls. Addresses REC-53 so files and file contents reflect the overridden account, not the logged-in user.

- **Bug Fixes**
  - Wired `useAccountOverride()` into `useSandboxes` and `useSandboxFileContent`.
  - Added `account_id` query param to `GET /api/sandboxes` and `GET /api/sandboxes/file`.
  - Included `accountIdOverride` in react-query keys to trigger refetch on change.

- **Dependencies**
  - Requires recoupable/api#410.

<sup>Written for commit 00173bdb7e78f5a8d2c35620c90b3e5a18a645bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

