### PR TITLE
refactor: use owner email from tasks response

### DIFF
--- a/components/TasksPage/TasksList.tsx
+++ b/components/TasksPage/TasksList.tsx
@@ -1,14 +1,8 @@
-import { Tables } from "@/types/database.types";
 import { Task } from "@/lib/tasks/getTasks";
 import TaskCard from "@/components/VercelChat/tools/tasks/TaskCard";
 import TaskSkeleton from "./TaskSkeleton";
 import TaskDetailsDialog from "@/components/VercelChat/dialogs/tasks/TaskDetailsDialog";
-import { useArtistProvider } from "@/providers/ArtistProvider";
 import { useUserProvider } from "@/providers/UserProvder";
-import { useMemo } from "react";
-import { useQuery } from "@tanstack/react-query";
-
-type AccountEmail = Tables<"account_emails">;
 
 interface TasksListProps {
   tasks: Task[];
@@ -18,45 +12,13 @@ interface TasksListProps {
 
 const TasksList: React.FC<TasksListProps> = ({ tasks, isLoading, isError }) => {
   const { userData } = useUserProvider();
-  const { selectedArtist } = useArtistProvider();
-
-  // Extract unique account IDs from tasks
-  const accountIds = useMemo(
-    () => [...new Set(tasks.map(task => task.account_id))],
-    [tasks]
-  );
-
-  // Batch fetch emails for all task owners
-  const { data: accountEmails = [] } = useQuery<AccountEmail[]>({
-    queryKey: ["task-owner-emails", accountIds],
-    queryFn: async () => {
-      if (accountIds.length === 0 || !userData) return [];
-      const params = new URLSearchParams();
-      accountIds.forEach(id => params.append("accountIds", id));
-      params.append("currentAccountId", userData.id);
-      if (selectedArtist) {
-        params.append("artistAccountId", selectedArtist.account_id);
-      }
-      const response = await fetch(`/api/account-emails?${params}`);
-      if (!response.ok) throw new Error("Failed to fetch emails");
-      return response.json();
-    },
-    enabled: accountIds.length > 0 && !!userData,
-  });
-
-  // Create lookup map for O(1) email access
-  const emailByAccountId = useMemo(() => {
-    const map = new Map<string, string>();
-    accountEmails.forEach(ae => {
-      if (ae.account_id && ae.email) {
-        map.set(ae.account_id, ae.email);
-      }
-    });
-    return map;
-  }, [accountEmails]);
 
   if (isError) {
-    return <div className="text-sm text-red-600 dark:text-red-400">Failed to load tasks</div>;
+    return (
+      <div className="text-sm text-red-600 dark:text-red-400">
+        Failed to load tasks
+      </div>
+    );
   }
 
   if (isLoading || !userData) {
@@ -88,10 +50,7 @@ const TasksList: React.FC<TasksListProps> = ({ tasks, isLoading, isError }) => {
               index !== tasks.length - 1 ? "border-b border-border " : ""
             }
           >
-            <TaskCard 
-              task={task} 
-              ownerEmail={emailByAccountId.get(task.account_id)}
-            />
+            <TaskCard task={task} ownerEmail={task.owner_email ?? undefined} />
           </div>
         </TaskDetailsDialog>
       ))}

--- a/lib/tasks/getTasks.ts
+++ b/lib/tasks/getTasks.ts
@@ -7,6 +7,7 @@ type ScheduledAction = Tables<"scheduled_actions">;
 export type Task = ScheduledAction & {
   recent_runs?: TaskRunItem[];
   upcoming?: string[];
+  owner_email?: string | null;
 };
 
 export interface GetTasksParams {
@@ -27,7 +28,7 @@ export interface GetTasksResponse {
  */
 export async function getTasks(
   accessToken: string,
-  params?: GetTasksParams
+  params?: GetTasksParams,
 ): Promise<Task[]> {
   try {
     const url = new URL(`${getClientApiBaseUrl()}/api/tasks`);


### PR DESCRIPTION
## Summary
- consume `owner_email` from the tasks API response on the Tasks page
- remove the extra task-owner email fetch from `TasksList`

## Testing
- not run locally in this fresh worktree

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the `owner_email` returned by the tasks API to display task owner emails on the Tasks page. This removes the extra email lookup and simplifies `TasksList`.

- **Refactors**
  - Read `owner_email` from the tasks response and pass it to `TaskCard`.
  - Removed the `/api/account-emails` fetch, `@tanstack/react-query`, and `ArtistProvider` from `TasksList`.
  - Extended the `Task` type in `getTasks` to include `owner_email`.

<sup>Written for commit eebf34d28bff125d1f1f2b6a727bb6036f26fb56. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal logic for displaying task owner emails. Email information is now retrieved directly from task data, reducing unnecessary external requests while maintaining the same user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->