### PR TITLE
feat: include file owner email in file list

### DIFF
--- a/components/Files/FileInfoDialog.tsx
+++ b/components/Files/FileInfoDialog.tsx
@@ -11,11 +11,7 @@ import { extractAccountIds } from "@/utils/extractAccountIds";
 import FileInfoDialogHeader from "./FileInfoDialogHeader";
 import FileInfoDialogContent from "./FileInfoDialogContent";
 import FileInfoDialogMetadata from "./FileInfoDialogMetadata";
-import { useQuery } from "@tanstack/react-query";
-import { Tables } from "@/types/database.types";
 import { useUserProvider } from "@/providers/UserProvder";
-
-type AccountEmail = Tables<"account_emails">;
 
 type FileInfoDialogProps = {
   file: FileRow | null;
@@ -23,37 +19,23 @@ type FileInfoDialogProps = {
   onOpenChange: (open: boolean) => void;
 };
 
-export default function FileInfoDialog({ file, open, onOpenChange }: FileInfoDialogProps) {
+export default function FileInfoDialog({
+  file,
+  open,
+  onOpenChange,
+}: FileInfoDialogProps) {
   const { userData } = useUserProvider();
   const { content } = useFileContent(
-    file?.file_name || "", 
-    file?.storage_key || "", 
-    userData?.account_id || ""
+    file?.file_name || "",
+    file?.storage_key || "",
+    userData?.account_id || "",
   );
-  
+
   // Extract account IDs and check if file is editable
-  const { ownerAccountId, artistAccountId } = file 
-    ? extractAccountIds(file.storage_key) 
+  const { ownerAccountId, artistAccountId } = file
+    ? extractAccountIds(file.storage_key)
     : { ownerAccountId: "", artistAccountId: "" };
   const canEdit = file ? isTextFile(file.file_name) : false;
-
-  // Fetch owner email
-  const { data: emails } = useQuery<AccountEmail[]>({
-    queryKey: ["file-owner-email", ownerAccountId, artistAccountId],
-    queryFn: async () => {
-      if (!ownerAccountId || !artistAccountId || !userData) return [];
-      const params = new URLSearchParams();
-      params.append("accountIds", ownerAccountId);
-      params.append("currentAccountId", userData.id);
-      params.append("artistAccountId", artistAccountId);
-      const response = await fetch(`/api/account-emails?${params}`);
-      if (!response.ok) return [];
-      return response.json();
-    },
-    enabled: !!ownerAccountId && !!artistAccountId && !!userData && open,
-  });
-
-  const ownerEmail = emails?.[0]?.email || undefined;
 
   // File editing state and operations
   const {
@@ -92,7 +74,7 @@ export default function FileInfoDialog({ file, open, onOpenChange }: FileInfoDia
     }
     baseHandleEditToggle(editing);
   };
-  
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="w-[96vw] sm:w-[92vw] max-w-5xl h-[90vh] p-0 gap-0 pt-6 flex flex-col">
@@ -107,7 +89,7 @@ export default function FileInfoDialog({ file, open, onOpenChange }: FileInfoDia
         />
 
         <div className="flex flex-col sm:flex-row flex-1 overflow-hidden">
-          <FileInfoDialogContent 
+          <FileInfoDialogContent
             isEditing={isEditing}
             fileName={file.file_name}
             storageKey={file.storage_key}
@@ -115,10 +97,12 @@ export default function FileInfoDialog({ file, open, onOpenChange }: FileInfoDia
             editedContent={editedContent}
             onContentChange={setEditedContent}
           />
-          <FileInfoDialogMetadata file={file} ownerEmail={ownerEmail} />
+          <FileInfoDialogMetadata
+            file={file}
+            ownerEmail={file.owner_email || undefined}
+          />
         </div>
       </DialogContent>
     </Dialog>
   );
 }
-

--- a/components/Files/types.ts
+++ b/components/Files/types.ts
@@ -5,8 +5,8 @@ export interface FileRow {
   mime_type?: string | null;
   is_directory?: boolean;
   size_bytes?: number | null;
+  owner_email?: string | null;
 }
-
 
 // Shared types for File Access UI
 export type ArtistAccess = {
@@ -20,7 +20,10 @@ export type ArtistAccess = {
 
 export type AccessArtistsResponse = {
   success: boolean;
-  data?: { artists: ArtistAccess[]; count: number; fileId: string; accountId: string };
+  data?: {
+    artists: ArtistAccess[];
+    count: number;
+    fileId: string;
+    accountId: string;
+  };
 };
-
-

--- a/hooks/useFilesManager.ts
+++ b/hooks/useFilesManager.ts
@@ -11,14 +11,21 @@ export interface ListedFileRow {
   storage_key: string;
   mime_type: string | null;
   is_directory?: boolean;
+  owner_email?: string | null;
 }
 
-export default function useFilesManager(activePath?: string, recursive: boolean = false) {
+export default function useFilesManager(
+  activePath?: string,
+  recursive: boolean = false,
+) {
   const { userData } = useUserProvider();
   const { selectedArtist } = useArtistProvider();
 
   const ownerAccountId = useMemo(() => userData?.account_id || "", [userData]);
-  const artistAccountId = useMemo(() => selectedArtist?.account_id || "", [selectedArtist]);
+  const artistAccountId = useMemo(
+    () => selectedArtist?.account_id || "",
+    [selectedArtist],
+  );
 
   const [file, setFile] = useState<File | null>(null);
   const [status, setStatus] = useState<string>("");
@@ -38,7 +45,7 @@ export default function useFilesManager(activePath?: string, recursive: boolean 
           if (relativePath) relativePath += "/";
         }
       }
-      
+
       const p = relativePath ? `&path=${encodeURIComponent(relativePath)}` : "";
       const r = recursive ? "&recursive=true" : "";
       const url = `/api/files/list?ownerAccountId=${ownerAccountId}&artistAccountId=${artistAccountId}${p}${r}`;
@@ -54,21 +61,25 @@ export default function useFilesManager(activePath?: string, recursive: boolean 
     const items = data?.files || [];
     if (items.length === 0) return;
     const basePath = activePath
-      ? activePath.endsWith("/") ? activePath : activePath + "/"
+      ? activePath.endsWith("/")
+        ? activePath
+        : activePath + "/"
       : `files/${ownerAccountId}/${artistAccountId}/`;
-    items.filter((f) => f.is_directory).forEach((dir) => {
-      const childPath = `${basePath}${dir.file_name}/`;
-      qc.prefetchQuery({
-        queryKey: ["files", ownerAccountId, artistAccountId, childPath],
-        queryFn: async () => {
-          const url = `/api/files/list?ownerAccountId=${ownerAccountId}&artistAccountId=${artistAccountId}&path=${encodeURIComponent(childPath)}`;
-          const res = await fetch(url, { cache: "no-store" });
-          if (!res.ok) throw new Error("Failed to load files");
-          return res.json();
-        },
-        staleTime: 30000,
+    items
+      .filter((f) => f.is_directory)
+      .forEach((dir) => {
+        const childPath = `${basePath}${dir.file_name}/`;
+        qc.prefetchQuery({
+          queryKey: ["files", ownerAccountId, artistAccountId, childPath],
+          queryFn: async () => {
+            const url = `/api/files/list?ownerAccountId=${ownerAccountId}&artistAccountId=${artistAccountId}&path=${encodeURIComponent(childPath)}`;
+            const res = await fetch(url, { cache: "no-store" });
+            if (!res.ok) throw new Error("Failed to load files");
+            return res.json();
+          },
+          staleTime: 30000,
+        });
       });
-    });
   }, [data?.files, activePath, ownerAccountId, artistAccountId, qc]);
 
   const createFolderMutation = useMutation({
@@ -76,14 +87,22 @@ export default function useFilesManager(activePath?: string, recursive: boolean 
       const res = await fetch("/api/files/folder", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ ownerAccountId, artistAccountId, name, parentPath: activePath || `files/${ownerAccountId}/${artistAccountId}/` }),
+        body: JSON.stringify({
+          ownerAccountId,
+          artistAccountId,
+          name,
+          parentPath:
+            activePath || `files/${ownerAccountId}/${artistAccountId}/`,
+        }),
       });
       const json = await res.json();
       if (!res.ok) throw new Error(json.error || "Failed to create folder");
       return json.folder as ListedFileRow;
     },
     onSuccess: async () => {
-      await qc.invalidateQueries({ queryKey: ["files", ownerAccountId, artistAccountId] });
+      await qc.invalidateQueries({
+        queryKey: ["files", ownerAccountId, artistAccountId],
+      });
     },
   });
 
@@ -98,7 +117,9 @@ export default function useFilesManager(activePath?: string, recursive: boolean 
 
     const safeName = targetFile.name.replace(/[^a-zA-Z0-9._-]/g, "_");
     const basePath = activePath
-      ? (activePath.endsWith("/") ? activePath : activePath + "/")
+      ? activePath.endsWith("/")
+        ? activePath
+        : activePath + "/"
       : `files/${ownerAccountId}/${artistAccountId}/`;
     const key = `${basePath}${safeName}`;
 
@@ -149,7 +170,9 @@ export default function useFilesManager(activePath?: string, recursive: boolean 
 
     setStatus("Uploaded successfully");
     if (!selectedFile) setFile(null);
-    await qc.invalidateQueries({ queryKey: ["files", ownerAccountId, artistAccountId] });
+    await qc.invalidateQueries({
+      queryKey: ["files", ownerAccountId, artistAccountId],
+    });
 
     // Clear success status after 3 seconds to be ready for new uploads
     setTimeout(() => {
@@ -169,9 +192,9 @@ export default function useFilesManager(activePath?: string, recursive: boolean 
     handleUpload,
     createFolder: (name: string) => createFolderMutation.mutateAsync(name),
     refreshFiles: async () => {
-      await qc.invalidateQueries({ queryKey: ["files", ownerAccountId, artistAccountId] });
+      await qc.invalidateQueries({
+        queryKey: ["files", ownerAccountId, artistAccountId],
+      });
     },
   };
 }
-
-

--- a/lib/supabase/files/listFilesByArtist.ts
+++ b/lib/supabase/files/listFilesByArtist.ts
@@ -1,19 +1,23 @@
 import { Tables } from "@/types/database.types";
 import { getFilesByArtistId } from "./getFilesByArtistId";
 import { filterFilesByPath } from "@/lib/files/filterFilesByPath";
+import getAccountEmails from "@/lib/supabase/account_emails/getAccountEmails";
 
 type FileRecord = Tables<"files">;
+export type FileRecordWithOwnerEmail = FileRecord & {
+  owner_email: string | null;
+};
 
 /**
  * List files for an artist, optionally filtered by path
- * 
+ *
  * This is a convenience function that combines:
  * 1. Database query (getFilesByArtistId)
  * 2. Path filtering logic (filterFilesByPath)
- * 
+ *
  * Note: With file sharing enabled, this returns files from ALL team members
  * who have access to the artist, not just the specified owner.
- * 
+ *
  * @param ownerAccountId - Currently unused, kept for backward compatibility
  * @param artistAccountId - The artist account to get files for
  * @param path - Optional path filter for immediate children only
@@ -23,25 +27,41 @@ export async function listFilesByArtist(
   ownerAccountId: string,
   artistAccountId: string,
   path?: string,
-  recursive: boolean = false
-): Promise<FileRecord[]> {
-  // Get all files for the artist from database
+  recursive: boolean = false,
+): Promise<FileRecordWithOwnerEmail[]> {
   const allFiles = await getFilesByArtistId(artistAccountId);
+  const filteredFiles = recursive
+    ? path
+      ? allFiles.filter((file) => {
+          const match = file.storage_key.match(/^files\/[^\/]+\/[^\/]+\/(.+)$/);
+          if (!match) {
+            return false;
+          }
 
-  if (recursive) {
-    if (path) {
-        // Basic prefix filtering for recursive mode
-        const pathPrefix = path.endsWith('/') ? path : path + '/';
-        return allFiles.filter(f => {
-            const match = f.storage_key.match(/^files\/[^\/]+\/[^\/]+\/(.+)$/);
-            if (!match) return false;
-            const relativePath = match[1];
-            return relativePath.startsWith(pathPrefix);
-        });
-    }
-    return allFiles;
- }
+          const pathPrefix = path.endsWith("/") ? path : `${path}/`;
+          return match[1].startsWith(pathPrefix);
+        })
+      : allFiles
+    : filterFilesByPath(allFiles, path);
+  const ownerAccountIds = [
+    ...new Set(
+      filteredFiles.map((file) => file.owner_account_id).filter(Boolean),
+    ),
+  ];
 
-  // Apply path filtering logic
-  return filterFilesByPath(allFiles, path);
+  const accountEmails = await getAccountEmails(ownerAccountIds);
+  const ownerEmailByAccountId = new Map(
+    accountEmails.flatMap((accountEmail) =>
+      accountEmail.account_id
+        ? [[accountEmail.account_id, accountEmail.email]]
+        : [],
+    ),
+  );
+
+  return filteredFiles.map((file) => ({
+    ...file,
+    owner_email: file.owner_account_id
+      ? (ownerEmailByAccountId.get(file.owner_account_id) ?? null)
+      : null,
+  }));
 }


### PR DESCRIPTION
## Summary
- include `owner_email` in `/api/files/list` responses
- remove the file dialog's separate owner email fetch
- keep file owner metadata on the file row used by the UI

## Testing
- `git diff --check`
- formatted touched files with Prettier

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add owner email to the file list API so the UI can display it without a separate fetch. This reduces network calls and speeds up loading in the File Info dialog.

- **New Features**
  - `/api/files/list` now returns `owner_email` for each file (derived from account emails).
  - Updated `FileRow` and listed file types to include optional `owner_email`.
  - `FileInfoDialog` reads `file.owner_email` and removes the extra owner email query.
  - Keeps owner metadata on each file row; existing clients continue to work (new field is optional).

<sup>Written for commit d3c75bc10d115a8df521e21f91123af466a83621. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

