### PR TITLE
fix: the middle of the “scroll to bottom” button is not clickable

### DIFF
--- a/components/VercelChat/PromptSuggestions.tsx
+++ b/components/VercelChat/PromptSuggestions.tsx
@@ -10,13 +10,13 @@ const PromptSuggestions = () => {
   if (isHidden) return null;
 
   return (
-    <div className="prompt-suggestions w-full bg-transparent rounded-lg absolute top-[-2.7rem] left-0 right-0 mx-auto no-scrollbar pb-2">
+    <div className="prompt-suggestions pointer-events-none w-full bg-transparent rounded-lg absolute top-[-2.7rem] left-0 right-0 mx-auto no-scrollbar pb-2">
       <div className="flex gap-2 overflow-x-auto scrollbar-hide pb-[0.8rem] bg-transparent">
         {isLoading ? (
           Array.from({ length: 4 }).map((_, index) => (
             <SkeletonShimmer
               key={`skeleton-${index}`}
-              className="h-8 px-3 flex-shrink-0 rounded-full bg-muted/50 border border-border/50 w-[120px] md:w-[200px] animate-pulse overflow-hidden"
+              className="pointer-events-auto h-8 px-3 flex-shrink-0 rounded-full bg-muted/50 border border-border/50 w-[120px] md:w-[200px] animate-pulse overflow-hidden"
             />
           ))
         ) : (
@@ -26,7 +26,7 @@ const PromptSuggestions = () => {
               variant="outline"
               size="sm"
               onClick={() => handleSuggestionClick(suggestion.text)}
-              className="text-xs h-8 px-3 flex-shrink-0 rounded-full bg-card/50 backdrop-blur-sm hover:bg-card transition-all duration-300 border border-border"
+              className="pointer-events-auto text-xs h-8 px-3 flex-shrink-0 rounded-full bg-card/50 backdrop-blur-sm hover:bg-card transition-all duration-300 border border-border"
             >
               <PromptIcon type={suggestion.type} />
               {suggestion.text}

--- a/hooks/usePromptSuggestions.tsx
+++ b/hooks/usePromptSuggestions.tsx
@@ -56,11 +56,16 @@ const usePromptSuggestions = () => {
     }
   }, [content, isMessageLoading, isAssistantMessage]);
 
+  const effectiveSuggestions = messages.length <= 0 ? [] : suggestions;
+  const shouldShowStrip =
+    isAssistantMessage &&
+    (isLoading || effectiveSuggestions.length > 0);
+
   return {
-    suggestions: messages.length <= 0 ? [] : suggestions,
+    suggestions: effectiveSuggestions,
     handleSuggestionClick,
     isLoading,
-    isHidden: !isAssistantMessage,
+    isHidden: !shouldShowStrip,
   };
 };
 


### PR DESCRIPTION
The button is overlapped by PromptSuggestions component, and it needs to enhance pointer events handling in PromptSuggestions component
- Updated the PromptSuggestions component to allow pointer events on suggestion buttons and skeleton loaders.
- Adjusted the logic for showing suggestions based on the assistant message state.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a hit-area bug where the middle of the “Scroll to bottom” button was not clickable due to overlap from the suggestions strip. The suggestions container now ignores pointer events and only shows when relevant.

- **Bug Fixes**
  - Set the `PromptSuggestions` wrapper to `pointer-events: none`, and enabled `pointer-events` on suggestion pills and skeletons to pass through clicks to the button.
  - Updated `usePromptSuggestions` to show the strip only during assistant messages when loading or suggestions exist, reducing accidental overlap.

<sup>Written for commit 42849448aeaa50578b2f2890b7466c1cd4876d0c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pointer interactions on prompt suggestions—clicks and hovers now register only on the buttons themselves rather than the entire container.
  * Enhanced visibility logic for prompt suggestions to display only when appropriate based on conversation state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->