### PR TITLE
feat: add OpenRouter + direct OpenAI as alternative LLM providers

### DIFF
--- a/lib/ai/createModel.ts
+++ b/lib/ai/createModel.ts
@@ -11,7 +11,7 @@ import { openai } from "@ai-sdk/openai";
  */
 export function createModel(modelId: string): LanguageModel {
   // Vercel AI Gateway — existing production behavior
-  if (process.env.VERCEL_AI_GATEWAY_API_KEY) {
+  if (process.env.VERCEL_AI_GATEWAY_API_KEY || process.env.VERCEL_OIDC_TOKEN) {
     return gateway(modelId);
   }
 

--- a/lib/ai/createModel.ts
+++ b/lib/ai/createModel.ts
@@ -21,8 +21,14 @@ export function createModel(modelId: string): LanguageModel {
     return openrouter(modelId);
   }
 
-  // Direct OpenAI — strip provider prefix
+  // Direct OpenAI — only supports openai/* models
   if (process.env.OPENAI_API_KEY) {
+    if (!modelId.startsWith("openai/") && modelId.includes("/")) {
+      throw new Error(
+        `Model "${modelId}" is not an OpenAI model. Direct OpenAI mode only supports openai/* models. ` +
+          `Use OPENROUTER_API_KEY or VERCEL_AI_GATEWAY_API_KEY for multi-provider support.`,
+      );
+    }
     const bareModel = modelId.startsWith("openai/") ? modelId.slice(7) : modelId;
     return openai(bareModel);
   }

--- a/lib/ai/createModel.ts
+++ b/lib/ai/createModel.ts
@@ -1,0 +1,33 @@
+import type { LanguageModel } from "ai";
+import { gateway } from "@ai-sdk/gateway";
+import { createOpenRouter } from "@openrouter/ai-sdk-provider";
+import { openai } from "@ai-sdk/openai";
+
+/**
+ * Resolves a model string (e.g. "openai/gpt-5-mini") to a LanguageModel,
+ * routing through whichever provider is configured.
+ *
+ * Priority: Vercel AI Gateway > OpenRouter > direct OpenAI.
+ */
+export function createModel(modelId: string): LanguageModel {
+  // Vercel AI Gateway — existing production behavior
+  if (process.env.VERCEL_AI_GATEWAY_API_KEY) {
+    return gateway(modelId);
+  }
+
+  // OpenRouter — supports "provider/model" format natively
+  if (process.env.OPENROUTER_API_KEY) {
+    const openrouter = createOpenRouter({ apiKey: process.env.OPENROUTER_API_KEY });
+    return openrouter(modelId);
+  }
+
+  // Direct OpenAI — strip provider prefix
+  if (process.env.OPENAI_API_KEY) {
+    const bareModel = modelId.startsWith("openai/") ? modelId.slice(7) : modelId;
+    return openai(bareModel);
+  }
+
+  throw new Error(
+    "No LLM provider configured. Set VERCEL_AI_GATEWAY_API_KEY, OPENROUTER_API_KEY, or OPENAI_API_KEY.",
+  );
+}

--- a/lib/ai/generateText.ts
+++ b/lib/ai/generateText.ts
@@ -1,5 +1,6 @@
 import { generateText as generate } from "ai";
 import { DEFAULT_MODEL } from "@/lib/consts";
+import { createModel } from "./createModel";
 
 const generateText = async ({
   system,
@@ -12,7 +13,7 @@ const generateText = async ({
 }) => {
   const result = await generate({
     system,
-    model: model || DEFAULT_MODEL,
+    model: createModel(model || DEFAULT_MODEL),
     prompt,
   });
 

--- a/lib/ai/getAvailableModels.ts
+++ b/lib/ai/getAvailableModels.ts
@@ -1,29 +1,57 @@
 import { GatewayLanguageModelEntry } from "@ai-sdk/gateway";
 import isEmbedModel from "./isEmbedModel";
+import { DEFAULT_MODEL, LIGHTWEIGHT_MODEL } from "@/lib/consts";
 
 const GATEWAY_CONFIG_URL = "https://ai-gateway.vercel.sh/v1/ai/config";
+
+/**
+ * Default model list for non-gateway providers (OpenRouter, direct OpenAI).
+ * Returned when the Vercel AI Gateway is not configured.
+ */
+const DEFAULT_MODELS: GatewayLanguageModelEntry[] = [
+  {
+    id: DEFAULT_MODEL,
+    name: "GPT-5 Mini",
+    description: "Default model for chat and generation",
+    specification: { specificationVersion: "v2", provider: "openai", modelId: DEFAULT_MODEL },
+  },
+  {
+    id: LIGHTWEIGHT_MODEL,
+    name: "GPT-4o Mini",
+    description: "Lightweight model for simple tasks",
+    specification: { specificationVersion: "v2", provider: "openai", modelId: LIGHTWEIGHT_MODEL },
+  },
+];
 
 /**
  * Fetches the gateway model catalog directly instead of through
  * @ai-sdk/gateway's getAvailableModels(), which currently rejects valid
  * success responses with a Zod "expected error.object" validation error.
+ *
+ * Falls back to a default model list when the gateway is not configured.
  */
 export const getAvailableModels = async (): Promise<
   GatewayLanguageModelEntry[]
 > => {
-  try {
-    const headers: Record<string, string> = {
-      "ai-gateway-protocol-version": "0.0.1",
-    };
-    const token = process.env.VERCEL_OIDC_TOKEN;
-    if (token) headers.Authorization = `Bearer ${token}`;
+  // Use Vercel AI Gateway when configured
+  if (process.env.VERCEL_AI_GATEWAY_API_KEY || process.env.VERCEL_OIDC_TOKEN) {
+    try {
+      const headers: Record<string, string> = {
+        "ai-gateway-protocol-version": "0.0.1",
+      };
+      const token = process.env.VERCEL_OIDC_TOKEN;
+      if (token) headers.Authorization = `Bearer ${token}`;
 
-    const res = await fetch(GATEWAY_CONFIG_URL, { headers });
-    if (!res.ok) return [];
-    const data = (await res.json()) as { models: GatewayLanguageModelEntry[] };
-    return data.models.filter((m) => !isEmbedModel(m));
-  } catch (error) {
-    console.error("[getAvailableModels] Gateway fetch failed:", error);
-    return [];
+      const res = await fetch(GATEWAY_CONFIG_URL, { headers });
+      if (!res.ok) return DEFAULT_MODELS;
+      const data = (await res.json()) as { models: GatewayLanguageModelEntry[] };
+      return data.models.filter((m) => !isEmbedModel(m));
+    } catch (error) {
+      console.error("[getAvailableModels] Gateway fetch failed:", error);
+      return DEFAULT_MODELS;
+    }
   }
+
+  // Fallback for OpenRouter or direct OpenAI
+  return DEFAULT_MODELS;
 };

--- a/lib/ai/getAvailableModels.ts
+++ b/lib/ai/getAvailableModels.ts
@@ -6,19 +6,21 @@ const GATEWAY_CONFIG_URL = "https://ai-gateway.vercel.sh/v1/ai/config";
 
 /**
  * Default model list for non-gateway providers (OpenRouter, direct OpenAI).
- * Returned when the Vercel AI Gateway is not configured.
+ * Returned only when the Vercel AI Gateway is not configured.
  */
 const DEFAULT_MODELS: GatewayLanguageModelEntry[] = [
   {
     id: DEFAULT_MODEL,
     name: "GPT-5 Mini",
     description: "Default model for chat and generation",
+    pricing: { input: "0.0001", output: "0.0004" },
     specification: { specificationVersion: "v2", provider: "openai", modelId: DEFAULT_MODEL },
   },
   {
     id: LIGHTWEIGHT_MODEL,
     name: "GPT-4o Mini",
     description: "Lightweight model for simple tasks",
+    pricing: { input: "0.00015", output: "0.0006" },
     specification: { specificationVersion: "v2", provider: "openai", modelId: LIGHTWEIGHT_MODEL },
   },
 ];
@@ -43,12 +45,12 @@ export const getAvailableModels = async (): Promise<
       if (token) headers.Authorization = `Bearer ${token}`;
 
       const res = await fetch(GATEWAY_CONFIG_URL, { headers });
-      if (!res.ok) return DEFAULT_MODELS;
+      if (!res.ok) return [];
       const data = (await res.json()) as { models: GatewayLanguageModelEntry[] };
       return data.models.filter((m) => !isEmbedModel(m));
     } catch (error) {
       console.error("[getAvailableModels] Gateway fetch failed:", error);
-      return DEFAULT_MODELS;
+      return [];
     }
   }
 

--- a/lib/catalog/analyzeCatalogBatch.ts
+++ b/lib/catalog/analyzeCatalogBatch.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { generateObject } from "ai";
 import type { CatalogSong } from "./getCatalogSongs";
 import { DEFAULT_MODEL } from "@/lib/consts";
+import { createModel } from "@/lib/ai/createModel";
 
 /**
  * Analyzes a single batch of catalog songs using AI to filter by criteria
@@ -13,7 +14,7 @@ export async function analyzeCatalogBatch(
 ): Promise<CatalogSong[]> {
   // Use AI to select relevant songs from this batch
   const { object } = await generateObject({
-    model: DEFAULT_MODEL,
+    model: createModel(DEFAULT_MODEL),
     schema: z.object({
       selected_song_isrcs: z
         .array(z.string())

--- a/lib/tools/generateMermaidDiagram.ts
+++ b/lib/tools/generateMermaidDiagram.ts
@@ -1,6 +1,7 @@
 import { generateText, tool } from "ai";
 import { z } from "zod";
 import { ANTHROPIC_MODEL, MERMAID_INSTRUCTIONS_PROMPT } from "../consts";
+import { createModel } from "@/lib/ai/createModel";
 
 export interface GenerateMermaidDiagramResult {
   content: { type: "text"; text: string }[];
@@ -22,7 +23,7 @@ export const generateMermaidDiagram = tool({
   }),
   execute: async ({ context }) => {
     const result = await generateText({
-      model: ANTHROPIC_MODEL,
+      model: createModel(`anthropic/${ANTHROPIC_MODEL}`),
       system: MERMAID_INSTRUCTIONS_PROMPT,
       prompt: `Generate a Mermaid diagram for the following context: ${context}
             `,

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@hookform/resolvers": "^3.9.1",
     "@icons-pack/react-simple-icons": "^13.8.0",
     "@modelcontextprotocol/sdk": "^1.24.3",
+    "@openrouter/ai-sdk-provider": "^2.6.0",
     "@privy-io/react-auth": "^1.88.4",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.24.3
         version: 1.24.3(zod@3.25.76)
+      '@openrouter/ai-sdk-provider':
+        specifier: ^2.6.0
+        version: 2.6.0(ai@6.0.0-beta.99(zod@3.25.76))(zod@3.25.76)
       '@privy-io/react-auth':
         specifier: ^1.88.4
         version: 1.99.1(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/react@18.3.27)(@vercel/blob@2.3.2)(bs58@6.0.0)(bufferutil@4.0.9)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.1))(utf-8-validate@5.0.10)(zod@3.25.76)
@@ -2175,6 +2178,13 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@openrouter/ai-sdk-provider@2.6.0':
+    resolution: {integrity: sha512-6rQw/ORDjV9Q+S+uxJwpDyZtWANUr7cDDxtuS4cQ/8UhS/hNNjKcTJVfx56hwypvd0DlRM+KgWHwxFYb90km3w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      ai: ^6.0.0
+      zod: ^3.25.0 || ^4.0.0
 
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
@@ -12218,6 +12228,11 @@ snapshots:
       fastq: 1.19.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@openrouter/ai-sdk-provider@2.6.0(ai@6.0.0-beta.99(zod@3.25.76))(zod@3.25.76)':
+    dependencies:
+      ai: 6.0.0-beta.99(zod@3.25.76)
+      zod: 3.25.76
 
   '@opentelemetry/api@1.9.0': {}
 


### PR DESCRIPTION
## Summary
- Adds `createModel()` helper (`lib/ai/createModel.ts`) that resolves model strings through whichever provider is configured
- Priority cascade: Vercel AI Gateway → OpenRouter → direct OpenAI
- All AI SDK call sites updated to use `createModel()` (7 files)
- Adds `@openrouter/ai-sdk-provider` dependency
- Adds fallback model list in `getAvailableModels()` for non-gateway environments
- Fixes bare `ANTHROPIC_MODEL` in `generateMermaidDiagram` → uses provider-prefixed `"anthropic/claude-3-7-sonnet-20250219"`

## Motivation
Contributors without Vercel AI Gateway access can't run the chat features locally. This lets devs run with just an `OPENROUTER_API_KEY` (one key, many models) or a direct `OPENAI_API_KEY`.

No breaking changes — existing production deployments using the gateway are unaffected.

## Companion PR
- recoupable/api#442 (same feature for the API submodule)

## What's NOT changed
- `generateImage.ts` — uses `openai.image()` directly (OpenAI-specific API)
- `generateArray.ts` — uses `anthropic()` directly (Anthropic-specific call)
- Type-only imports from `"ai"` package

## Test plan
- [ ] Set `VERCEL_AI_GATEWAY_API_KEY` → verify existing behavior unchanged
- [ ] Set only `OPENROUTER_API_KEY` → verify chat works through OpenRouter
- [ ] Set only `OPENAI_API_KEY` → verify chat works through OpenAI directly
- [ ] `pnpm build` passes
- [ ] `pnpm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OpenRouter and direct OpenAI as fallback LLM providers via a new `createModel()` helper. Local devs can run chat with `OPENROUTER_API_KEY` or `OPENAI_API_KEY`; gateway behavior (including `VERCEL_OIDC_TOKEN`) remains unchanged.

- **New Features**
  - Added `createModel()` to resolve model strings by provider priority: `@ai-sdk/gateway` (incl. `VERCEL_OIDC_TOKEN`) → `@openrouter/ai-sdk-provider` → `@ai-sdk/openai`.
  - Updated AI SDK call sites to use `createModel()`.
  - `getAvailableModels()` returns a small default list when the gateway isn’t configured, now with pricing metadata.
  - Added `@openrouter/ai-sdk-provider` dependency.

- **Bug Fixes**
  - `generateMermaidDiagram` now uses `anthropic/${ANTHROPIC_MODEL}` via `createModel()` to ensure the provider prefix.
  - Added a clear error when a non-OpenAI model is used in direct OpenAI mode.
  - Gateway fetch failures now return `[]` instead of fallback models to avoid masking configuration errors.

<sup>Written for commit f2645d043255fb1887460a72c2d832bf1616fedd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

