### PR TITLE
Promote test to main

### DIFF
--- a/hooks/useCatalogs.ts
+++ b/hooks/useCatalogs.ts
@@ -1,15 +1,21 @@
 import { useQuery, UseQueryResult } from "@tanstack/react-query";
+import { usePrivy } from "@privy-io/react-auth";
 import { getCatalogs, CatalogsResponse } from "@/lib/catalog/getCatalogs";
 import { useUserProvider } from "@/providers/UserProvder";
 
 const useCatalogs = (): UseQueryResult<CatalogsResponse> => {
+  const { getAccessToken, authenticated } = usePrivy();
   const { userData } = useUserProvider();
   const accountId = userData?.account_id || "";
 
   return useQuery({
     queryKey: ["catalogs", accountId],
-    queryFn: () => getCatalogs(accountId),
-    enabled: !!accountId,
+    queryFn: async () => {
+      const accessToken = await getAccessToken();
+      if (!accessToken) throw new Error("No access token");
+      return getCatalogs(accountId, accessToken);
+    },
+    enabled: !!accountId && authenticated,
     staleTime: 5 * 60 * 1000, // 5 minutes
     refetchOnWindowFocus: false,
   });

--- a/lib/catalog/getCatalogs.ts
+++ b/lib/catalog/getCatalogs.ts
@@ -1,6 +1,5 @@
-import { Tables } from "@/types/database.types";
-
-type Catalog = Tables<"catalogs">;
+import { getClientApiBaseUrl } from "@/lib/api/getClientApiBaseUrl";
+import type { Catalog } from "@/types/Catalog";
 
 export interface CatalogsResponse {
   status: string;
@@ -8,18 +7,28 @@ export interface CatalogsResponse {
   error?: string;
 }
 
+/**
+ * Fetches catalogs linked to an account from the Recoup API.
+ *
+ * Authentication is via Bearer token (Privy access token).
+ *
+ * @param accountId - The account id whose catalogs to fetch (path segment).
+ * @param accessToken - Privy access token for Bearer auth.
+ */
 export async function getCatalogs(
-  accountId: string
+  accountId: string,
+  accessToken: string,
 ): Promise<CatalogsResponse> {
   try {
     const response = await fetch(
-      `https://api.recoupable.com/api/catalogs?account_id=${accountId}`,
+      `${getClientApiBaseUrl()}/api/accounts/${accountId}/catalogs`,
       {
         method: "GET",
         headers: {
           "Content-Type": "application/json",
+          Authorization: `Bearer ${accessToken}`,
         },
-      }
+      },
     );
 
     if (!response.ok) {

--- a/types/Catalog.ts
+++ b/types/Catalog.ts
@@ -1,0 +1,6 @@
+export interface Catalog {
+  id: string;
+  name: string;
+  created_at: string;
+  updated_at: string;
+}


### PR DESCRIPTION
Promotes `test` to `main`.

## Included

- #1691 — feat: migrate GET /api/accounts/{id}/catalogs (squash `99a7feb6`)
- Plus any other commits merged into `test` since the last promotion.

This is the chat-side complement of recoupable/api#464 and recoupable/docs#153 (both already on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes `test` to `main`, migrating catalog fetching to the new `/api/accounts/{id}/catalogs` route with Privy Bearer auth. Replaces the legacy query-param endpoint and aligns chat with the current API.

- **New Features**
  - Switch to `${getClientApiBaseUrl()}/api/accounts/{accountId}/catalogs` and send `Authorization: Bearer <Privy token>`.
  - Add `types/Catalog.ts` and update `getCatalogs`/`useCatalogs` to use the new `Catalog` type.

- **Bug Fixes**
  - Gate the query on `authenticated` from `@privy-io/react-auth` and a valid account id to avoid firing requests without a token (`@tanstack/react-query`).

<sup>Written for commit 99a7feb64b4f0b0fd8a35d2b83d424a263580cd7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

