### PR TITLE
Promote test to main

### DIFF
--- a/hooks/useSongsByIsrc.ts
+++ b/hooks/useSongsByIsrc.ts
@@ -1,4 +1,5 @@
 import { useQuery, UseQueryResult } from "@tanstack/react-query";
+import { usePrivy } from "@privy-io/react-auth";
 import {
   getSongsByIsrc,
   SongsByIsrcResponse,
@@ -13,10 +14,16 @@ const useSongsByIsrc = ({
   isrc,
   enabled = true,
 }: UseSongsByIsrcOptions): UseQueryResult<SongsByIsrcResponse> => {
+  const { getAccessToken, authenticated } = usePrivy();
+
   return useQuery({
     queryKey: ["songsByIsrc", isrc],
-    queryFn: () => getSongsByIsrc(isrc),
-    enabled: enabled && !!isrc && isrc.trim() !== "",
+    queryFn: async () => {
+      const accessToken = await getAccessToken();
+      if (!accessToken) throw new Error("No access token");
+      return getSongsByIsrc(isrc, accessToken);
+    },
+    enabled: enabled && !!isrc && isrc.trim() !== "" && authenticated,
     staleTime: 5 * 60 * 1000, // 5 minutes
     refetchOnWindowFocus: false,
   });

--- a/lib/catalog/getSongsByIsrc.ts
+++ b/lib/catalog/getSongsByIsrc.ts
@@ -1,7 +1,4 @@
-/**
- * Fetches songs by ISRC code using the Recoupable API
- */
-
+import { getClientApiBaseUrl } from "@/lib/api/getClientApiBaseUrl";
 import { Tables } from "@/types/database.types";
 
 type Song = Tables<"songs">;
@@ -17,8 +14,14 @@ export interface SongsByIsrcResponse {
   error?: string;
 }
 
+/**
+ * Fetches songs by ISRC code from the Recoup API.
+ *
+ * Authentication is via Bearer token (Privy access token).
+ */
 export async function getSongsByIsrc(
-  isrc: string
+  isrc: string,
+  accessToken: string,
 ): Promise<SongsByIsrcResponse> {
   try {
     if (!isrc || isrc.trim() === "") {
@@ -30,13 +33,14 @@ export async function getSongsByIsrc(
     });
 
     const response = await fetch(
-      `https://api.recoupable.com/api/songs?${params}`,
+      `${getClientApiBaseUrl()}/api/songs?${params.toString()}`,
       {
         method: "GET",
         headers: {
           "Content-Type": "application/json",
+          Authorization: `Bearer ${accessToken}`,
         },
-      }
+      },
     );
 
     if (!response.ok) {


### PR DESCRIPTION
Promotes `test` to `main`.

## Included

- #1693 — feat: migrate GET /api/songs (squash `22b30956`)

Chat-side complement of recoupable/api#466 (already on main) and recoupable/docs#154 (already on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches `getSongsByIsrc` and `useSongsByIsrc` to the mono API `GET /api/songs` and secures calls with Privy auth. Prevents unauthenticated requests and uses an environment-based API URL.

- **Refactors**
  - Routes to `${getClientApiBaseUrl()}/api/songs` instead of `api.recoupable.com`.
  - Requires a Privy access token (`Authorization: Bearer` via `@privy-io/react-auth`); the hook gates on `authenticated` and errors if the token is missing.

<sup>Written for commit 22b309562b3e7185f6ab68a2a17160c316e0ff2b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Song lookup functionality now requires user authentication.
  * Only authenticated users can search and retrieve song information using ISRC identifiers.
  * Enhanced security through authenticated API requests for all song catalog queries.
  * Improved data protection by restricting song data access to logged-in users only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->