### PR TITLE
Promote test to main

### DIFF
--- a/components/Posts/PostCard.tsx
+++ b/components/Posts/PostCard.tsx
@@ -1,4 +1,4 @@
-import { type Post } from "@/lib/recoup/fetchPosts";
+import { type Post } from "@/types/Post";
 import { memo } from "react";
 import { useInView } from "react-intersection-observer";
 import dynamic from "next/dynamic";

--- a/components/Posts/Posts.tsx
+++ b/components/Posts/Posts.tsx
@@ -1,4 +1,4 @@
-import { type Post } from "@/lib/recoup/fetchPosts";
+import { type Post } from "@/types/Post";
 import PostCard from "./PostCard";
 import { useEffect, useRef } from "react";
 import { useInView } from "react-intersection-observer";

--- a/components/Posts/PostsWrapper.tsx
+++ b/components/Posts/PostsWrapper.tsx
@@ -1,6 +1,6 @@
 import { useArtistProvider } from "@/providers/ArtistProvider";
 import { useArtistPosts } from "@/hooks/useArtistPosts";
-import { type Post } from "@/lib/recoup/fetchPosts";
+import { type Post } from "@/types/Post";
 import Posts from "./Posts";
 import PostsSkeleton from "./PostsSkeleton";
 

--- a/hooks/useArtistPosts.ts
+++ b/hooks/useArtistPosts.ts
@@ -3,6 +3,7 @@ import {
   type UseInfiniteQueryResult,
   type InfiniteData,
 } from "@tanstack/react-query";
+import { usePrivy } from "@privy-io/react-auth";
 import fetchPosts, {
   type PostsResponse,
   type PostsError,
@@ -20,20 +21,28 @@ export function useArtistPosts(
   artistAccountId?: string,
   limit: number = 20
 ): UseInfiniteQueryResult<InfiniteData<PostsResponse>, PostsError> {
+  const { getAccessToken, authenticated } = usePrivy();
+
   return useInfiniteQuery<PostsResponse, PostsError>({
     queryKey: ["posts", artistAccountId, limit],
-    queryFn: ({ pageParam }) =>
-      fetchPosts({
+    queryFn: async ({ pageParam }) => {
+      const accessToken = await getAccessToken();
+      if (!accessToken) {
+        throw { message: "No access token" } as PostsError;
+      }
+      return fetchPosts({
         artistAccountId: artistAccountId!,
+        accessToken,
         page: pageParam as number,
         limit,
-      }),
+      });
+    },
     getNextPageParam: (lastPage: PostsResponse) => {
       const { page, total_pages } = lastPage.pagination;
       return page < total_pages ? page + 1 : undefined;
     },
     initialPageParam: 1,
-    enabled: !!artistAccountId,
+    enabled: !!artistAccountId && authenticated,
     staleTime: 1000 * 60 * 5, // 5 minutes
     refetchOnWindowFocus: false,
     retry: (failureCount, error) => {

--- a/lib/recoup/fetchPosts.ts
+++ b/lib/recoup/fetchPosts.ts
@@ -1,13 +1,11 @@
+import { getClientApiBaseUrl } from "@/lib/api/getClientApiBaseUrl";
+import type { Post } from "@/types/Post";
+
 interface FetchPostsParams {
   artistAccountId: string;
+  accessToken: string;
   page?: number;
   limit?: number;
-}
-
-export interface Post {
-  id: string;
-  post_url: string;
-  updated_at: string;
 }
 
 export interface PostsResponse {
@@ -26,21 +24,22 @@ export interface PostsError {
   status?: number;
 }
 
-/**
- * Fetches posts for a specific artist from the API
- */
 async function fetchPosts({
   artistAccountId,
+  accessToken,
   page = 1,
   limit = 20,
 }: FetchPostsParams): Promise<PostsResponse> {
   try {
-    const url = new URL("https://api.recoupable.com/api/posts");
-    url.searchParams.append("artist_account_id", artistAccountId);
-    url.searchParams.append("page", page.toString());
-    url.searchParams.append("limit", limit.toString());
+    const url = new URL(
+      `${getClientApiBaseUrl()}/api/artists/${artistAccountId}/posts?page=${page}&limit=${limit}`,
+    );
 
-    const response = await fetch(url.toString());
+    const response = await fetch(url.toString(), {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
 
     if (!response.ok) {
       const error: PostsError = {

--- a/types/Post.ts
+++ b/types/Post.ts
@@ -1,0 +1,5 @@
+export interface Post {
+  id: string;
+  post_url: string;
+  updated_at: string;
+}


### PR DESCRIPTION
Promotes `test` to `main`.

## Included

- #1695 — feat: migrate GET /api/artists/{id}/posts (squash `0471ef0b`)

Chat-side complement of recoupable/api#469 and recoupable/docs#155 (both already on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated artist posts fetching to the new `/api/artists/{id}/posts` endpoint using Privy auth, and extracted the `Post` type for reuse. Aligns the client with the latest mono API.

- **Refactors**
  - Switched from hardcoded `api.recoupable.com/api/posts` to `${getClientApiBaseUrl()}/api/artists/{id}/posts`
  - Added bearer auth via `@privy-io/react-auth`; gate `useArtistPosts` until `authenticated`
  - Updated `fetchPosts` to require `accessToken`; throw on missing token
  - Moved `Post` to `types/Post.ts`; updated imports in `Posts*` components; removed unused `platform` field

<sup>Written for commit 0471ef0ba5fee1039b3b8e629912006ffc16136b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

