### PR TITLE
Promote test to main

### DIFF
--- a/components/TasksPage/CreateTaskButton.tsx
+++ b/components/TasksPage/CreateTaskButton.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { useCreateTask } from "@/hooks/useCreateTask";
+
+export function CreateTaskButton() {
+  const { handleCreateTask, isCreating } = useCreateTask();
+
+  return (
+    <Button
+      onClick={() => handleCreateTask()}
+      disabled={isCreating}
+      className="w-full sm:w-auto"
+    >
+      {isCreating ? "Creating..." : "Create Task"}
+    </Button>
+  );
+}

--- a/components/TasksPage/TasksList.tsx
+++ b/components/TasksPage/TasksList.tsx
@@ -46,6 +46,7 @@ const TasksList: React.FC<TasksListProps> = ({ tasks, isLoading, isError }) => {
       {tasks.map((task: Task, index) => (
         <TaskDetailsDialog key={task.id} task={task}>
           <div
+            data-task-dialog-trigger={task.id}
             className={
               index !== tasks.length - 1 ? "border-b border-border " : ""
             }

--- a/components/TasksPage/TasksPage.tsx
+++ b/components/TasksPage/TasksPage.tsx
@@ -2,19 +2,14 @@
 
 import useAutoLogin from "@/hooks/useAutoLogin";
 import TasksTabs from "./TasksTabs";
+import { TasksPageHeader } from "./TasksPageHeader";
 
 const TasksPage = () => {
   useAutoLogin();
 
   return (
     <div className="max-w-full md:max-w-[calc(100vw-200px)] grow py-8 px-6 md:px-12">
-      <h1 className="text-left font-heading text-3xl font-bold dark:text-white mb-4">
-        Tasks
-      </h1>
-      <p className="text-lg text-muted-foreground text-left mb-6 font-light font-sans max-w-2xl">
-        View and manage all the tasks for your selected artist.
-      </p>
-
+      <TasksPageHeader />
       <TasksTabs />
     </div>
   );

--- a/components/TasksPage/TasksPageHeader.tsx
+++ b/components/TasksPage/TasksPageHeader.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { CreateTaskButton } from "./CreateTaskButton";
+
+export function TasksPageHeader() {
+  return (
+    <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+      <div>
+        <h1 className="text-left font-heading text-3xl font-bold dark:text-white mb-4">
+          Tasks
+        </h1>
+        <p className="text-lg text-muted-foreground text-left font-light font-sans max-w-2xl">
+          View and manage all the tasks for your selected artist.
+        </p>
+      </div>
+      <CreateTaskButton />
+    </div>
+  );
+}

--- a/hooks/useCreateTask.ts
+++ b/hooks/useCreateTask.ts
@@ -1,0 +1,76 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { usePrivy } from "@privy-io/react-auth";
+import { toast } from "sonner";
+import { createTask } from "@/lib/tasks/createTask";
+import { useArtistProvider } from "@/providers/ArtistProvider";
+import { DEFAULT_MODEL } from "@/lib/consts";
+
+const DEFAULT_SCHEDULE = "0 9 * * *";
+
+function clickTaskDialogTrigger(taskId: string) {
+  requestAnimationFrame(() => {
+    document
+      .querySelector<HTMLElement>(`[data-task-dialog-trigger="${taskId}"]`)
+      ?.click();
+  });
+}
+
+export function useCreateTask() {
+  const { getAccessToken } = usePrivy();
+  const { selectedArtist } = useArtistProvider();
+  const queryClient = useQueryClient();
+
+  const { mutate: handleCreateTask, isPending: isCreating } = useMutation({
+    mutationFn: async () => {
+      const artistAccountId = selectedArtist?.account_id;
+      if (!artistAccountId) {
+        throw new Error("ARTIST_REQUIRED");
+      }
+      const accessToken = await getAccessToken();
+      if (!accessToken) {
+        throw new Error("AUTH_REQUIRED");
+      }
+      return createTask(accessToken, {
+        title: "Untitled Task",
+        prompt: "New task — replace with your instructions.",
+        schedule: DEFAULT_SCHEDULE,
+        artist_account_id: artistAccountId,
+        model: DEFAULT_MODEL,
+      });
+    },
+    onSuccess: async (task) => {
+      await queryClient.invalidateQueries({
+        queryKey: ["scheduled-actions"],
+        exact: false,
+      });
+      await queryClient.refetchQueries({
+        queryKey: ["scheduled-actions"],
+        exact: false,
+      });
+      toast.success("Task created", {
+        action: {
+          label: "View",
+          onClick: () => clickTaskDialogTrigger(task.id),
+        },
+      });
+    },
+    onError: (error) => {
+      console.error("Failed to create task:", error);
+      if (error instanceof Error) {
+        if (error.message === "ARTIST_REQUIRED") {
+          toast.error("Please select an artist first.");
+          return;
+        }
+        if (error.message === "AUTH_REQUIRED") {
+          toast.error("Please sign in to create a task.");
+          return;
+        }
+      }
+      toast.error("Failed to create task. Please try again.");
+    },
+  });
+
+  return { handleCreateTask, isCreating };
+}

--- a/lib/tasks/__tests__/createTask.errors.test.ts
+++ b/lib/tasks/__tests__/createTask.errors.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTask } from "@/lib/tasks/createTask";
+import { getClientApiBaseUrl } from "@/lib/api/getClientApiBaseUrl";
+
+vi.mock("@/lib/api/getClientApiBaseUrl", () => ({
+  getClientApiBaseUrl: vi.fn(),
+}));
+
+describe("createTask error handling", () => {
+  const accessToken = "test-token";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getClientApiBaseUrl).mockReturnValue(
+      "https://api.recoupable.com",
+    );
+  });
+
+  it("throws on non-ok HTTP response", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+      text: vi
+        .fn()
+        .mockResolvedValue('{"status":"error","error":"Access denied"}'),
+    }) as unknown as typeof fetch;
+
+    await expect(
+      createTask(accessToken, {
+        title: "Denied",
+        prompt: "Denied",
+        schedule: "0 9 * * *",
+        artist_account_id: "artist-3",
+      }),
+    ).rejects.toThrow('HTTP 403: {"status":"error","error":"Access denied"}');
+  });
+
+  it("throws when API returns status:error", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        status: "error",
+        error: "Validation failed",
+      }),
+    }) as unknown as typeof fetch;
+
+    await expect(
+      createTask(accessToken, {
+        title: "Invalid",
+        prompt: "Invalid",
+        schedule: "0 9 * * *",
+        artist_account_id: "artist-4",
+      }),
+    ).rejects.toThrow("Validation failed");
+  });
+
+  it("throws when success response has no created task", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        status: "success",
+        tasks: [],
+      }),
+    }) as unknown as typeof fetch;
+
+    await expect(
+      createTask(accessToken, {
+        title: "No task",
+        prompt: "No task",
+        schedule: "0 9 * * *",
+        artist_account_id: "artist-5",
+      }),
+    ).rejects.toThrow("API returned success but no task was created");
+  });
+});

--- a/lib/tasks/__tests__/createTask.test.ts
+++ b/lib/tasks/__tests__/createTask.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTask } from "@/lib/tasks/createTask";
+import { getClientApiBaseUrl } from "@/lib/api/getClientApiBaseUrl";
+
+vi.mock("@/lib/api/getClientApiBaseUrl", () => ({
+  getClientApiBaseUrl: vi.fn(),
+}));
+
+describe("createTask", () => {
+  const accessToken = "test-token";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getClientApiBaseUrl).mockReturnValue(
+      "https://api.recoupable.com",
+    );
+  });
+
+  it("calls POST /api/tasks with bearer auth and required payload", async () => {
+    const createdTask = { id: "task-1" };
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        status: "success",
+        tasks: [createdTask],
+      }),
+    }) as unknown as typeof fetch;
+
+    const result = await createTask(accessToken, {
+      title: "Daily summary",
+      prompt: "Summarize fan growth",
+      schedule: "0 9 * * *",
+      artist_account_id: "artist-1",
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.recoupable.com/api/tasks",
+      expect.objectContaining({
+        method: "POST",
+        headers: {
+          Authorization: "Bearer test-token",
+          "Content-Type": "application/json",
+        },
+      }),
+    );
+    const init = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
+    expect(JSON.parse(String(init.body))).toEqual({
+      title: "Daily summary",
+      prompt: "Summarize fan growth",
+      schedule: "0 9 * * *",
+      artist_account_id: "artist-1",
+    });
+    expect(result).toEqual(createdTask);
+  });
+
+  it("includes optional account_id and model when provided", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        status: "success",
+        tasks: [{ id: "task-2" }],
+      }),
+    }) as unknown as typeof fetch;
+
+    await createTask(accessToken, {
+      title: "Weekly sync",
+      prompt: "Generate weekly report",
+      schedule: "0 9 * * 1",
+      artist_account_id: "artist-2",
+      account_id: "account-2",
+      model: "anthropic/claude-sonnet-4.5",
+    });
+
+    const call = vi.mocked(fetch).mock.calls[0];
+    const init = call[1] as RequestInit;
+    expect(JSON.parse(String(init.body))).toEqual({
+      title: "Weekly sync",
+      prompt: "Generate weekly report",
+      schedule: "0 9 * * 1",
+      artist_account_id: "artist-2",
+      account_id: "account-2",
+      model: "anthropic/claude-sonnet-4.5",
+    });
+  });
+});

--- a/lib/tasks/__tests__/getCronHumanPreview.test.ts
+++ b/lib/tasks/__tests__/getCronHumanPreview.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { getCronHumanPreview } from "@/lib/tasks/getCronHumanPreview";
+
+describe("getCronHumanPreview", () => {
+  it("returns human text for valid cron", () => {
+    const preview = getCronHumanPreview("0 9 * * *");
+    expect(preview).toBeTruthy();
+    expect(preview!.length).toBeGreaterThan(10);
+  });
+
+  it("returns null for invalid cron", () => {
+    expect(getCronHumanPreview("not-a-cron")).toBeNull();
+  });
+});

--- a/lib/tasks/createTask.ts
+++ b/lib/tasks/createTask.ts
@@ -1,0 +1,67 @@
+import { getClientApiBaseUrl } from "@/lib/api/getClientApiBaseUrl";
+import type { Task } from "./getTasks";
+import type { CreateTaskApiResponse } from "./createTaskApiResponse";
+
+export interface CreateTaskParams {
+  title: string;
+  prompt: string;
+  schedule: string;
+  artist_account_id: string;
+  /** When omitted, the API uses the authenticated account. When set, must be allowed for the caller (e.g. org membership). */
+  account_id?: string;
+  model?: string | null;
+}
+
+/**
+ * Creates a new scheduled task via the Recoup API.
+ * Requires a valid bearer token. Optional `account_id` matches OpenAPI `CreateTaskRequest`.
+ */
+export async function createTask(
+  accessToken: string,
+  params: CreateTaskParams,
+): Promise<Task> {
+  const body: Record<string, string> = {
+    title: params.title,
+    prompt: params.prompt,
+    schedule: params.schedule,
+    artist_account_id: params.artist_account_id,
+  };
+
+  if (params.account_id !== undefined && params.account_id !== "") {
+    body.account_id = params.account_id;
+  }
+
+  if (
+    params.model !== undefined &&
+    params.model !== null &&
+    params.model !== ""
+  ) {
+    body.model = params.model;
+  }
+
+  const response = await fetch(`${getClientApiBaseUrl()}/api/tasks`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`HTTP ${response.status}: ${errorText}`);
+  }
+
+  const data = (await response.json()) as CreateTaskApiResponse;
+  if (data.status === "error") {
+    throw new Error(data.error || "Unknown error occurred");
+  }
+
+  const tasks = data.tasks;
+  if (!tasks?.length) {
+    throw new Error("API returned success but no task was created");
+  }
+
+  return tasks[0];
+}

--- a/lib/tasks/createTaskApiResponse.ts
+++ b/lib/tasks/createTaskApiResponse.ts
@@ -1,0 +1,19 @@
+import type { Task } from "./getTasks";
+
+/**
+ * POST /api/tasks JSON body — separate from {@link GetTasksResponse} (GET list)
+ * even when the wire shape overlaps (success returns `tasks` for parity with GET).
+ */
+export type CreateTaskApiSuccessBody = {
+  status: "success";
+  tasks: Task[];
+};
+
+export type CreateTaskApiErrorBody = {
+  status: "error";
+  error?: string;
+};
+
+export type CreateTaskApiResponse =
+  | CreateTaskApiSuccessBody
+  | CreateTaskApiErrorBody;

--- a/lib/tasks/getCronHumanPreview.ts
+++ b/lib/tasks/getCronHumanPreview.ts
@@ -1,0 +1,12 @@
+import cronstrue from "cronstrue";
+
+/**
+ * Human-readable description of a cron expression, or `null` if invalid.
+ */
+export function getCronHumanPreview(value: string): string | null {
+  try {
+    return cronstrue.toString(value.trim());
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Promotes `test` to `main`.

## Included

- #1655 — feat: implement createTask function and associated tests (squash `13755072`)

Adds the aligned task-creation client flow: \`createTask\` helper, \`CreateTaskButton\`, \`TasksPageHeader\`, \`CreateTaskPage\`, cron preview helper, and supporting types. Resolves the modify/delete conflict against test by accepting the dead-code sweep from #1697 and drops an orphaned \`validateCronExpression\` import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added task creation functionality with a dedicated "Create Task" button on the Tasks page.
  * Introduced a Tasks page header section displaying the page title and supporting description.
  * New tasks can be created with title, prompt, scheduling options, and artist assignment.
  * Task creation includes loading state feedback and success notifications with quick access to created tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes `test` to `main` and ships the new task-creation flow on the Tasks page with a "Create Task" button, API helper, and cron preview. Adds tests and better error handling with success toasts that open the created task.

- **New Features**
  - `useCreateTask` hook and `createTask` API helper to create a default “Untitled Task”, invalidate/refetch `scheduled-actions`, and show a “View” toast that opens the new task’s dialog.
  - Adds `CreateTaskButton` and `TasksPageHeader`; updates `TasksPage` to use them.
  - `getCronHumanPreview` utility for human-readable cron text with tests; adds createTask tests for success and error cases.

- **Bug Fixes**
  - Removed an orphaned `validateCronExpression` import that broke cron preview tests.
  - Added `data-task-dialog-trigger` to task rows so the newly created task opens reliably.

<sup>Written for commit 1375507224946974ada9544413bd729b26d1fab7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

