### PR TITLE
feat(chat): migrate GET /api/instagram/comments

### DIFF
--- a/lib/apify/comments/runInstagramCommentsScraper.ts
+++ b/lib/apify/comments/runInstagramCommentsScraper.ts
@@ -1,5 +1,6 @@
 import { APIFY_WEBHOOKS_VALUE } from "@/lib/consts";
 import { ApifyScraperResult } from "@/lib/apify/types";
+import { getClientApiBaseUrl } from "@/lib/api/getClientApiBaseUrl";
 
 /**
  * Runs the Instagram comments scraper for the provided post URLs
@@ -21,7 +22,7 @@ export default async function runInstagramCommentsScraper(
     }
 
     // Construct URL with postUrls as query parameters
-    const url = new URL("https://api.recoupable.com/api/instagram/comments");
+    const url = new URL(`${getClientApiBaseUrl()}/api/instagram/comments`);
     postUrls.forEach((postUrl) => {
       url.searchParams.append("postUrls", postUrl);
     });
@@ -34,7 +35,10 @@ export default async function runInstagramCommentsScraper(
 
     const response = await fetch(url.toString(), {
       method: "GET",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": process.env.RECOUP_API_KEY ?? "",
+      },
     });
 
     if (!response.ok) {


### PR DESCRIPTION
Repoints `lib/apify/comments/runInstagramCommentsScraper.ts` at mono/api via `getClientApiBaseUrl()` with `x-api-key` server-to-server auth. Response shape `{ runId, datasetId }` preserved for wire parity.

## Test plan

- [ ] Chat preview build green
- [ ] Smoke: trigger Instagram comments scrape, confirm request hits new api host with 200 and `{ runId, datasetId }` body

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates GET `/api/instagram/comments` to use the internal API via `getClientApiBaseUrl()` with server-to-server `x-api-key` auth, keeping the `{ runId, datasetId }` response unchanged.

- **Refactors**
  - Repointed URL to `${getClientApiBaseUrl()}/api/instagram/comments`.
  - Added `x-api-key` header from `process.env.RECOUP_API_KEY`.

- **Migration**
  - Set `RECOUP_API_KEY` in the server environment.

<sup>Written for commit b0e8c28e1c7d06f33420ee7091b3cedcd8a50649. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

