### PR TITLE
feat: integrate Privy authentication for task updates

### DIFF
--- a/hooks/useUpdateScheduledAction.ts
+++ b/hooks/useUpdateScheduledAction.ts
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { toast } from "react-toastify";
 import { Tables } from "@/types/database.types";
 import { useQueryClient } from "@tanstack/react-query";
+import { usePrivy } from "@privy-io/react-auth";
 import { updateTask, UpdateTaskParams } from "@/lib/tasks/updateTask";
 
 type ScheduledAction = Tables<"scheduled_actions">;
@@ -15,6 +16,7 @@ interface UpdateScheduledActionParams {
 export const useUpdateScheduledAction = () => {
   const [isLoading, setIsLoading] = useState(false);
   const queryClient = useQueryClient();
+  const { getAccessToken } = usePrivy();
 
   const updateAction = async ({
     updates,
@@ -23,7 +25,12 @@ export const useUpdateScheduledAction = () => {
   }: UpdateScheduledActionParams) => {
     setIsLoading(true);
     try {
-      const updatedTask = await updateTask(updates);
+      const accessToken = await getAccessToken();
+      if (!accessToken) {
+        throw new Error("Please sign in to update tasks");
+      }
+
+      const updatedTask = await updateTask(accessToken, updates);
 
       onSuccess?.(updatedTask);
       toast.success(successMessage);

--- a/lib/tasks/__tests__/updateTask.errors.test.ts
+++ b/lib/tasks/__tests__/updateTask.errors.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { updateTask } from "@/lib/tasks/updateTask";
+import { getClientApiBaseUrl } from "@/lib/api/getClientApiBaseUrl";
+
+vi.mock("@/lib/api/getClientApiBaseUrl", () => ({
+  getClientApiBaseUrl: vi.fn(),
+}));
+
+describe("updateTask error handling", () => {
+  const accessToken = "test-token";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getClientApiBaseUrl).mockReturnValue("https://api.recoupable.com");
+  });
+
+  it("throws on non-ok HTTP response", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: vi.fn().mockResolvedValue('{"status":"error","error":"Invalid request"}'),
+    }) as unknown as typeof fetch;
+
+    await expect(updateTask(accessToken, { id: "bad-id" })).rejects.toThrow(
+      'HTTP 400: {"status":"error","error":"Invalid request"}',
+    );
+  });
+
+  it("throws when API returns status:error", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        status: "error",
+        error: "Validation failed",
+      }),
+    }) as unknown as typeof fetch;
+
+    await expect(updateTask(accessToken, { id: "task-1" })).rejects.toThrow(
+      "Validation failed",
+    );
+  });
+});

--- a/lib/tasks/__tests__/updateTask.test.ts
+++ b/lib/tasks/__tests__/updateTask.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { updateTask } from "@/lib/tasks/updateTask";
+import { getClientApiBaseUrl } from "@/lib/api/getClientApiBaseUrl";
+
+vi.mock("@/lib/api/getClientApiBaseUrl", () => ({
+  getClientApiBaseUrl: vi.fn(),
+}));
+
+describe("updateTask", () => {
+  const accessToken = "test-token";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getClientApiBaseUrl).mockReturnValue("https://api.recoupable.com");
+  });
+
+  it("calls PATCH /api/tasks with bearer auth", async () => {
+    const updatedTask = { id: "task-1", title: "Updated" };
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        status: "success",
+        tasks: [updatedTask],
+      }),
+    }) as unknown as typeof fetch;
+
+    const result = await updateTask(accessToken, {
+      id: "task-1",
+      title: "Updated",
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.recoupable.com/api/tasks",
+      expect.objectContaining({
+        method: "PATCH",
+        headers: {
+          Authorization: "Bearer test-token",
+          "Content-Type": "application/json",
+        },
+      }),
+    );
+    expect(result).toEqual(updatedTask);
+  });
+});

--- a/lib/tasks/updateTask.ts
+++ b/lib/tasks/updateTask.ts
@@ -1,5 +1,5 @@
 import { Tables } from "@/types/database.types";
-import { TASKS_API_URL } from "@/lib/consts";
+import { getClientApiBaseUrl } from "@/lib/api/getClientApiBaseUrl";
 import { GetTasksResponse } from "./getTasks";
 
 type ScheduledAction = Tables<"scheduled_actions">;
@@ -20,12 +20,14 @@ export interface UpdateTaskParams {
  * @see https://docs.recoupable.com/tasks/update
  */
 export async function updateTask(
+  accessToken: string,
   params: UpdateTaskParams
 ): Promise<ScheduledAction> {
   try {
-    const response = await fetch(TASKS_API_URL, {
+    const response = await fetch(`${getClientApiBaseUrl()}/api/tasks`, {
       method: "PATCH",
       headers: {
+        Authorization: `Bearer ${accessToken}`,
         "Content-Type": "application/json",
       },
       body: JSON.stringify({


### PR DESCRIPTION
- Added Privy authentication to the `useUpdateScheduledAction` hook, requiring an access token for task updates.
- Updated the `updateTask` function to include the access token in the request headers, enhancing security and ensuring only authenticated users can modify tasks.