### PR TITLE
chore(chat): point prod base URL at api.recoupable.com

### DIFF
--- a/lib/consts.ts
+++ b/lib/consts.ts
@@ -2,7 +2,7 @@ import { Address } from "viem";
 
 export const IS_PROD = process.env.NEXT_PUBLIC_VERCEL_ENV === "production";
 export const NEW_API_BASE_URL = IS_PROD
-  ? "https://recoup-api.vercel.app"
+  ? "https://api.recoupable.com"
   : "https://test-recoup-api.vercel.app";
 export const API_OVERRIDE_STORAGE_KEY = "recoup_api_override";
 export const ACCOUNT_OVERRIDE_STORAGE_KEY = "recoup_account_override";

--- a/lib/generateAndProcessImage.ts
+++ b/lib/generateAndProcessImage.ts
@@ -1,6 +1,7 @@
 import { Experimental_GenerateImageResult } from "ai";
 import Transaction from "arweave/node/lib/transaction";
 import { Address, Hash } from "viem";
+import { getClientApiBaseUrl } from "@/lib/api/getClientApiBaseUrl";
 
 interface RecoupImageGenerateResponse extends Experimental_GenerateImageResult {
   imageUrl: string;
@@ -35,7 +36,7 @@ export async function generateAndProcessImage(
     throw new Error("Account ID is required");
   }
 
-  const apiUrl = new URL("https://api.recoupable.com/api/image/generate");
+  const apiUrl = new URL(`${getClientApiBaseUrl()}/api/image/generate`);
   apiUrl.searchParams.set("prompt", prompt);
   apiUrl.searchParams.set("account_id", accountId);
 

--- a/lib/generateAndProcessImage.ts
+++ b/lib/generateAndProcessImage.ts
@@ -35,7 +35,7 @@ export async function generateAndProcessImage(
     throw new Error("Account ID is required");
   }
 
-  const apiUrl = new URL("https://recoup-api.vercel.app/api/image/generate");
+  const apiUrl = new URL("https://api.recoupable.com/api/image/generate");
   apiUrl.searchParams.set("prompt", prompt);
   apiUrl.searchParams.set("account_id", accountId);
 


### PR DESCRIPTION
## Summary
mono/api is moving to api.recoupable.com. Switch chat's prod NEW_API_BASE_URL and the one hardcoded image-generate URL so all chat→api callers hit the new domain. Non-prod still uses test-recoup-api.vercel.app.

## Test plan
- [ ] On the deployed preview, confirm a logged-in chat session's API calls (network tab) hit api.recoupable.com/api/* once api.recoupable.com is fronting mono/api
- [ ] Image generation in chat hits api.recoupable.com/api/image/generate

🤖 Generated with [Claude Code](https://claude.com/claude-code)