### PR TITLE
chore(chat): drop youtube_tokens from generated types

### DIFF
--- a/types/database.types.ts
+++ b/types/database.types.ts
@@ -3441,44 +3441,6 @@ export type Database = {
         }
         Relationships: []
       }
-      youtube_tokens: {
-        Row: {
-          access_token: string
-          artist_account_id: string
-          created_at: string
-          expires_at: string
-          id: string
-          refresh_token: string | null
-          updated_at: string
-        }
-        Insert: {
-          access_token: string
-          artist_account_id: string
-          created_at?: string
-          expires_at: string
-          id?: string
-          refresh_token?: string | null
-          updated_at?: string
-        }
-        Update: {
-          access_token?: string
-          artist_account_id?: string
-          created_at?: string
-          expires_at?: string
-          id?: string
-          refresh_token?: string | null
-          updated_at?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "youtube_tokens_artist_account_id_fkey"
-            columns: ["artist_account_id"]
-            isOneToOne: true
-            referencedRelation: "accounts"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
     }
     Views: {
       [_ in never]: never


### PR DESCRIPTION
## Summary
Companion to recoupable/database#22 — once the table is dropped the next `pnpm update-types` yields this same diff.

## Test plan
- [ ] Merge **after** recoupable/database#22 has applied to the linked Supabase project
- [ ] Run `pnpm update-types` locally and confirm zero diff against this branch
- [ ] Verify YouTube connect/disconnect + channel info still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the `youtube_tokens` table from `types/database.types.ts` to align with the dropped table in Supabase. Keeps generated types in sync and avoids stale references.

- **Migration**
  - Merge after recoupable/database#22 is applied to the Supabase project.
  - Run `pnpm update-types` and confirm no diff.
  - Verify YouTube connect/disconnect and channel info still work.

<sup>Written for commit cc5305abb66449a5f8f4b54fd4b8ff7acc623f73. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

