### PR TITLE
feat(chat): add /sessions/[sid]/chats/[cid] route + session-scoped loader

### DIFF
--- a/app/sessions/[sessionId]/chats/[chatId]/page.tsx
+++ b/app/sessions/[sessionId]/chats/[chatId]/page.tsx
@@ -1,0 +1,17 @@
+import { Chat } from "@/components/VercelChat/chat";
+
+interface SessionChatPageProps {
+  params: Promise<{ sessionId: string; chatId: string }>;
+}
+
+export default async function SessionChatPage({
+  params,
+}: SessionChatPageProps) {
+  const { sessionId, chatId } = await params;
+
+  return (
+    <div className="flex flex-col size-full items-center">
+      <Chat id={chatId} sessionId={sessionId} />
+    </div>
+  );
+}

--- a/hooks/useMessageLoader.ts
+++ b/hooks/useMessageLoader.ts
@@ -1,26 +1,27 @@
 import { useState, useEffect } from "react";
 import { UIMessage } from "ai";
 import { usePrivy } from "@privy-io/react-auth";
-import getChatMessages from "@/lib/messages/getChatMessages";
+import { getChatMessages } from "@/lib/messages/getChatMessages";
 
 /**
- * Hook for loading existing messages from a room
- * @param roomId - The room ID to load messages from (undefined to skip loading)
- * @param userId - The current user ID (messages won't load if user is not authenticated)
- * @param setMessages - Callback function to set the loaded messages
- * @returns Loading state and error information
+ * Loads the persisted UI message stream for a session-scoped chat from
+ * recoup-api. Skips entirely when either id is missing — the new-chat
+ * bootstrap path mounts `<Chat>` before a session has been minted, and
+ * the in-transition legacy `/chat/{roomId}` route lacks a sessionId
+ * until track I redirects it.
  */
 export function useMessageLoader(
-  roomId: string | undefined,
+  sessionId: string | undefined,
+  chatId: string | undefined,
   userId: string | undefined,
   setMessages: (messages: UIMessage[]) => void,
 ) {
   const { getAccessToken } = usePrivy();
-  const [isLoading, setIsLoading] = useState(!!roomId);
+  const [isLoading, setIsLoading] = useState(!!(sessionId && chatId));
   const [error, setError] = useState<Error | null>(null);
 
   useEffect(() => {
-    if (!roomId) {
+    if (!sessionId || !chatId) {
       setIsLoading(false);
       return;
     }
@@ -38,9 +39,13 @@ export function useMessageLoader(
         const accessToken = await getAccessToken();
         if (!accessToken) return;
 
-        const initialMessages = await getChatMessages(roomId, accessToken);
+        const initialMessages = await getChatMessages(
+          sessionId,
+          chatId,
+          accessToken,
+        );
         if (initialMessages.length > 0) {
-          setMessages(initialMessages as UIMessage[]);
+          setMessages(initialMessages);
         }
       } catch (err) {
         console.error("Error loading messages:", err);
@@ -53,7 +58,7 @@ export function useMessageLoader(
     };
 
     loadMessages();
-  }, [userId, roomId, getAccessToken, setMessages]);
+  }, [userId, sessionId, chatId, getAccessToken, setMessages]);
 
   return {
     isLoading,

--- a/hooks/useVercelChat.ts
+++ b/hooks/useVercelChat.ts
@@ -283,6 +283,7 @@ export function useVercelChat({
   messagesLengthRef.current = messages.length;
 
   const { isLoading: isMessagesLoading, hasError } = useMessageLoader(
+    sessionId,
     messages.length === 0 ? id : undefined,
     userId,
     setMessages,

--- a/lib/messages/getChatMessages.ts
+++ b/lib/messages/getChatMessages.ts
@@ -1,37 +1,26 @@
+import { UIMessage } from "ai";
 import { getClientApiBaseUrl } from "@/lib/api/getClientApiBaseUrl";
 
-const getChatMessages = async (
+/**
+ * Fetch the persisted UI message stream for a session-scoped chat from
+ * recoup-api `GET /api/sessions/{sessionId}/chats/{chatId}`. Each row's
+ * `parts` blob is the full UIMessage, so the response can be handed
+ * straight to the Vercel AI SDK as initial messages.
+ */
+export async function getChatMessages(
+  sessionId: string,
   chatId: string,
   accessToken: string,
-) => {
-  try {
-    const url = getClientApiBaseUrl();
-    const response = await fetch(
-      `${url}/api/chats/${encodeURIComponent(chatId)}/messages`,
-      {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-      },
-    );
-    const data = await response.json();
+): Promise<UIMessage[]> {
+  const response = await fetch(
+    `${getClientApiBaseUrl()}/api/sessions/${encodeURIComponent(sessionId)}/chats/${encodeURIComponent(chatId)}`,
+    {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    },
+  );
 
-    const memories = data?.data || [];
+  if (!response.ok) return [];
 
-    return memories.map(
-      (memory: {
-        id: string;
-        content: { role: string; content: string };
-        updated_at: string;
-      }) => ({
-        id: memory.id,
-        ...memory.content,
-      }),
-    );
-  } catch {
-    // Error handling - could be logged to proper error tracking service
-    return [];
-  }
-};
-
-export default getChatMessages;
+  const data = (await response.json()) as { messages?: UIMessage[] };
+  return data.messages ?? [];
+}


### PR DESCRIPTION
Adds the canonical workflow URL `/sessions/{sessionId}/chats/{chatId}` and points the message loader at the matching session-scoped api endpoint.

- New route `app/sessions/[sessionId]/chats/[chatId]/page.tsx` mounts `<Chat id={chatId} sessionId={sessionId} />`.
- `useMessageLoader` takes `(sessionId, chatId, ...)` and fetches from `GET /api/sessions/{sid}/chats/{cid}`; legacy `memories` fetcher deleted.
- Skips when either id is missing — the legacy `/chat/{roomId}` route still renders, just with an empty transcript (no fallback to memories).

The sidebar PR (chat#1756) emits canonical URLs that this route receives. Merge order: chat#1756 → chat#1752 (back-to-back; sidebar links 404 between them).

`silentlyUpdateUrl` rewrite + HomePage refactor live in a follow-up PR.

## Test plan

- [ ] On a Vercel preview, navigate directly to `/sessions/{sid}/chats/{cid}` for a workflow chat → messages load → reload preserves them.
- [ ] Visit a sidebar row (after chat#1756 lands) → arrives at the same route → messages render.
- [ ] Legacy `/chat/{roomId}` still resolves but shows an empty transcript.