### PR TITLE
refactor(chat): drop redundant useAutoLogin calls

### DIFF
--- a/components/Catalog/CatalogSongsPage.tsx
+++ b/components/Catalog/CatalogSongsPage.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useAutoLogin } from "@/hooks/useAutoLogin";
 import CatalogSongsPageContent from "./CatalogSongsPageContent";
 import { useRouter } from "next/navigation";
 import { ArrowLeft } from "lucide-react";
@@ -10,7 +9,6 @@ interface CatalogSongsPageProps {
 }
 
 const CatalogSongsPage = ({ catalogId }: CatalogSongsPageProps) => {
-  useAutoLogin();
   const router = useRouter();
 
   const handleBack = () => {

--- a/components/Catalog/CatalogsPage.tsx
+++ b/components/Catalog/CatalogsPage.tsx
@@ -1,11 +1,8 @@
 "use client";
 
-import { useAutoLogin } from "@/hooks/useAutoLogin";
 import CatalogsPageContent from "./CatalogsPageContent";
 
 const CatalogsPage = () => {
-  useAutoLogin();
-
   return (
     <div className="min-h-screen p-4">
       <h1 className="text-lg md:text-xl font-medium pb-4">Catalogs</h1>

--- a/components/TasksPage/TasksPage.tsx
+++ b/components/TasksPage/TasksPage.tsx
@@ -1,12 +1,9 @@
 "use client";
 
-import useAutoLogin from "@/hooks/useAutoLogin";
 import TasksTabs from "./TasksTabs";
 import { TasksPageHeader } from "./TasksPageHeader";
 
 const TasksPage = () => {
-  useAutoLogin();
-
   return (
     <div className="max-w-full md:max-w-[calc(100vw-200px)] grow py-8 px-6 md:px-12">
       <TasksPageHeader />


### PR DESCRIPTION
`useAutoLogin` now fires once at the provider layer in `UserProvder`, so the page-level calls in `CatalogsPage`, `CatalogSongsPage`, and `TasksPage` are stylistically dead and removed here.

## Test plan
- [ ] Visit `/catalogs`, `/catalogs/[id]`, and `/tasks` while signed out — Privy login modal still opens automatically

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed redundant `useAutoLogin` calls from `CatalogsPage`, `CatalogSongsPage`, and `TasksPage`. The hook now runs once via `UserProvider`, so behavior is unchanged and the Privy modal still auto-opens when signed out.

<sup>Written for commit f9564233fccdffa9f9fbdbff7c666b457fbbbbb8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1753?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

