### PR TITLE
feat(chat): integrate session ID retrieval for chat component

### DIFF
--- a/app/chat/[roomId]/page.tsx
+++ b/app/chat/[roomId]/page.tsx
@@ -1,4 +1,5 @@
 import { Chat } from "@/components/VercelChat/chat";
+import { getSessionIdByChatId } from "@/lib/supabase/chats/getSessionIdByChatId";
 
 interface PageProps {
   params: Promise<{
@@ -8,10 +9,11 @@ interface PageProps {
 
 export default async function InstantChatRoom({ params }: PageProps) {
   const { roomId } = await params;
+  const sessionId = await getSessionIdByChatId(roomId);
 
   return (
     <div className="flex flex-col size-full items-center">
-      <Chat id={roomId} />
+      <Chat id={roomId} sessionId={sessionId ?? undefined} />
     </div>
   );
 }

--- a/app/chat/[roomId]/page.tsx
+++ b/app/chat/[roomId]/page.tsx
@@ -1,6 +1,8 @@
 import { Chat } from "@/components/VercelChat/chat";
 import { getSessionIdByChatId } from "@/lib/supabase/chats/getSessionIdByChatId";
 
+export const dynamic = "force-dynamic";
+
 interface PageProps {
   params: Promise<{
     roomId: string;

--- a/lib/supabase/chats/getSessionIdByChatId.ts
+++ b/lib/supabase/chats/getSessionIdByChatId.ts
@@ -12,8 +12,8 @@ export async function getSessionIdByChatId(
     .from("chats")
     .select("session_id")
     .eq("id", chatId)
-    .single();
+    .maybeSingle();
 
-  if (error) return null;
+  if (error) throw error;
   return (data as { session_id: string } | null)?.session_id ?? null;
 }

--- a/lib/supabase/chats/getSessionIdByChatId.ts
+++ b/lib/supabase/chats/getSessionIdByChatId.ts
@@ -1,0 +1,19 @@
+import supabase from "../serverClient";
+
+/**
+ * Returns the session_id for a given chat id, or null if not found.
+ * Used to route legacy /chat/[roomId] URLs through the new workflow
+ * after the Phase 2 backfill (rooms → sessions/chats/chat_messages).
+ */
+export async function getSessionIdByChatId(
+  chatId: string,
+): Promise<string | null> {
+  const { data, error } = await supabase
+    .from("chats")
+    .select("session_id")
+    .eq("id", chatId)
+    .single();
+
+  if (error) return null;
+  return (data as { session_id: string } | null)?.session_id ?? null;
+}


### PR DESCRIPTION
Added functionality to fetch the session ID using the room ID and pass it to the Chat component. This ensures that the chat component receives the correct session context for improved functionality.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fetches the session ID from Supabase using the room ID and passes it to the `Chat` component so legacy /chat/[roomId] routes map to the correct session during the Phase 2 cutover. Also forces dynamic rendering on the page to avoid stale data.

- New Features
  - Added `getSessionIdByChatId(chatId)` to read `session_id` from the `chats` table (throws on query error, returns null if missing).
  - Updated `app/chat/[roomId]/page.tsx` to pass `sessionId` to `<Chat />` and set `export const dynamic = "force-dynamic"`.

<sup>Written for commit 76877fcdcfd4ae3ec29d27f6ceb34cee1de6082f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1754?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced chat session handling to support legacy URL routing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/recoupable/chat/pull/1754?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->