### PR TITLE
feat(chat): route all chats through workflow; drop legacy /api/chat branch

### DIFF
--- a/app/chat/[roomId]/page.tsx
+++ b/app/chat/[roomId]/page.tsx
@@ -1,4 +1,4 @@
-import { Chat } from "@/components/VercelChat/chat";
+import ExistingChatBootstrap from "@/components/VercelChat/ExistingChatBootstrap";
 
 interface PageProps {
   params: Promise<{
@@ -11,7 +11,7 @@ export default async function InstantChatRoom({ params }: PageProps) {
 
   return (
     <div className="flex flex-col size-full items-center">
-      <Chat id={roomId} />
+      <ExistingChatBootstrap key={roomId} roomId={roomId} />
     </div>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,4 @@
 import HomePage from "@/components/Home/HomePage";
-import generateUUID from "@/lib/generateUUID";
 import { getMessages } from "@/lib/messages/getMessages";
 
 export const dynamic = "force-dynamic";
@@ -9,9 +8,8 @@ interface ChatPageProps {
 }
 
 export default async function Home({ searchParams }: ChatPageProps) {
-  const id = generateUUID();
   const initialMessage = (await searchParams)?.q as string;
   const initialMessages = getMessages(initialMessage);
 
-  return <HomePage id={id} initialMessages={initialMessages} />;
+  return <HomePage initialMessages={initialMessages} />;
 }

--- a/components/Home/HomePage.tsx
+++ b/components/Home/HomePage.tsx
@@ -1,17 +1,11 @@
 "use client";
 
 import { useMiniKit } from "@coinbase/onchainkit/minikit";
-import { Chat } from "../VercelChat/chat";
+import NewChatBootstrap from "../VercelChat/NewChatBootstrap";
 import { useEffect } from "react";
 import { UIMessage } from "ai";
 
-const HomePage = ({
-  id,
-  initialMessages,
-}: {
-  id: string;
-  initialMessages?: UIMessage[];
-}) => {
+const HomePage = ({ initialMessages }: { initialMessages?: UIMessage[] }) => {
   const { setFrameReady, isFrameReady } = useMiniKit();
 
   useEffect(() => {
@@ -22,7 +16,7 @@ const HomePage = ({
 
   return (
     <div className="flex flex-col size-full items-center">
-      <Chat id={id} initialMessages={initialMessages} />
+      <NewChatBootstrap initialMessages={initialMessages} />
     </div>
   );
 };

--- a/components/VercelChat/ExistingChatBootstrap.tsx
+++ b/components/VercelChat/ExistingChatBootstrap.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useExistingChatBootstrap } from "@/hooks/useExistingChatBootstrap";
+import { Chat } from "@/components/VercelChat/chat";
+import ChatSkeleton from "../Chat/ChatSkeleton";
+
+interface ExistingChatBootstrapProps {
+  roomId: string;
+}
+
+/**
+ * Resolves an existing chat's `sessionId` (via `useExistingChatBootstrap`)
+ * before mounting `<Chat>` on the workflow path. Mirrors
+ * `NewChatBootstrap`, but for `/chat/[roomId]` pages opened from history
+ * rather than a freshly provisioned session (recoupable/chat#1747).
+ */
+export default function ExistingChatBootstrap({ roomId }: ExistingChatBootstrapProps) {
+  const state = useExistingChatBootstrap(roomId);
+
+  if (state.status === "ready") {
+    return <Chat id={state.chatId} sessionId={state.sessionId} />;
+  }
+
+  if (state.status === "not_found") {
+    return (
+      <div className="flex items-center justify-center h-dvh">
+        <div className="text-grey-dark-1">This chat isn’t available.</div>
+      </div>
+    );
+  }
+
+  if (state.status === "error") {
+    return (
+      <div className="flex items-center justify-center h-dvh">
+        <div className="text-red-500 dark:text-red-400">{state.message}</div>
+      </div>
+    );
+  }
+
+  return <ChatSkeleton />;
+}

--- a/components/VercelChat/NewChatBootstrap.tsx
+++ b/components/VercelChat/NewChatBootstrap.tsx
@@ -3,6 +3,7 @@
 import type { UIMessage } from "ai";
 import { Loader } from "lucide-react";
 import { useNewChatBootstrap } from "@/hooks/useNewChatBootstrap";
+import { useAutoLogin } from "@/hooks/useAutoLogin";
 import { Chat } from "@/components/VercelChat/chat";
 
 interface NewChatBootstrapProps {
@@ -10,15 +11,20 @@ interface NewChatBootstrapProps {
 }
 
 /**
- * Thin renderer over `useNewChatBootstrap`. Mounted by
- * `app/chat/page.tsx`; provisions a recoup-api session + sandbox
- * before mounting `<Chat>` so the workflow transport
+ * Thin renderer over `useNewChatBootstrap`. Mounted by the home route
+ * (`/`) and `app/chat/page.tsx`; provisions a recoup-api session +
+ * sandbox before mounting `<Chat>` so the workflow transport
  * (`/api/chat/workflow`) has the `sessionId` + `chatId` its validator
  * requires (recoupable/chat#1747).
+ *
+ * `useAutoLogin` prompts sign-in for anonymous visitors — the bootstrap
+ * waits on `authenticated`, so without it a logged-out landing would
+ * hang on the spinner.
  */
 export default function NewChatBootstrap({
   initialMessages,
 }: NewChatBootstrapProps) {
+  useAutoLogin();
   const state = useNewChatBootstrap();
 
   if (state.status === "ready") {

--- a/components/VercelChat/chat.tsx
+++ b/components/VercelChat/chat.tsx
@@ -23,13 +23,12 @@ import { useOrganization } from "@/providers/OrganizationProvider";
 interface ChatProps {
   id: string;
   /**
-   * Session id from the new-chat bootstrap. When present the chat
-   * routes through recoup-api's `/api/chat/workflow`; when absent it
-   * falls back to the legacy `/api/chat` (existing chats opened from
-   * history — they'll cut over once Phase 2 backfills `session_id`
-   * onto their rows, recoupable/chat#1747).
+   * Session id for the chat. Both new chats (`NewChatBootstrap`) and
+   * existing chats (`ExistingChatBootstrap`) resolve it before mounting
+   * `<Chat>`, which always routes through recoup-api's
+   * `/api/chat/workflow` (recoupable/chat#1747).
    */
-  sessionId?: string;
+  sessionId: string;
   initialMessages?: UIMessage[];
 }
 

--- a/hooks/useChatTransport.ts
+++ b/hooks/useChatTransport.ts
@@ -7,42 +7,24 @@ interface UseChatTransportOptions {
   /** Chat row id (also the AI SDK `useChat({ id })` instance id). */
   chatId: string;
   /**
-   * Session id from `createSession`. When provided, the transport
-   * targets recoup-api's `POST /api/chat/workflow` (the workflow path
-   * cutover tracked in recoupable/chat#1747) and injects
-   * `sessionId` + `chatId` + `recoupAccessToken` at the transport
-   * boundary.
-   *
-   * When absent, the transport targets the legacy `POST /api/chat`
-   * route — used by `/chat/[roomId]` pages opened from history that
-   * don't have a `session_id` on their chat row yet. Those rows will
-   * be backfilled in Phase 2 (recoupable/chat#1747), at which point
-   * this branch can be deleted.
+   * Session id for the chat. Required: the transport targets recoup-api's
+   * `POST /api/chat/workflow` and injects `sessionId` + `chatId` +
+   * `recoupAccessToken` at the transport boundary. New chats get the
+   * `sessionId` from the bootstrap; existing chats resolve it from the
+   * chat row (recoupable/chat#1747).
    */
-  sessionId?: string;
+  sessionId: string;
 }
 
 /**
- * Chat transport for chat.recoupable.com. Branches on `sessionId`:
- *   - **workflow path** (sessionId present) → recoup-api
- *     `/api/chat/workflow`, with `sessionId` + `chatId` +
- *     `recoupAccessToken` injected so per-`sendMessage` callers don't
- *     need to know the workflow body shape.
- *   - **legacy path** (no sessionId) → `/api/chat` on the same base,
- *     same behavior chat.recoupable.com had before the workflow
- *     cutover. Per-call body from `useVercelChat`'s
- *     `sendMessage(payload, { body })` (`roomId`, `artistId`, `model`,
- *     …) flows through unchanged.
- *
- * Both branches return the Privy JWT in the `Authorization: Bearer`
- * header via `getHeaders`; the workflow branch also adds it
- * transport-side so recoup-api's `validateAuthContext` accepts the
- * cross-origin POST.
+ * Chat transport for chat.recoupable.com. Targets recoup-api's
+ * `/api/chat/workflow` with `sessionId` + `chatId` + `recoupAccessToken`
+ * injected so per-`sendMessage` callers don't need to know the workflow
+ * body shape. The Privy JWT is returned both via `getHeaders` (for
+ * per-call use) and transport-side so recoup-api's `validateAuthContext`
+ * accepts the cross-origin POST.
  */
-export function useChatTransport({
-  chatId,
-  sessionId,
-}: UseChatTransportOptions) {
+export function useChatTransport({ chatId, sessionId }: UseChatTransportOptions) {
   const { getAccessToken } = usePrivy();
   const baseUrl = getClientApiBaseUrl();
 
@@ -52,12 +34,6 @@ export function useChatTransport({
   }, [getAccessToken]);
 
   const transport = useMemo(() => {
-    if (!sessionId) {
-      return new DefaultChatTransport({
-        api: `${baseUrl}/api/chat`,
-      });
-    }
-
     return new DefaultChatTransport({
       api: `${baseUrl}/api/chat/workflow`,
       headers: async (): Promise<Record<string, string>> => {

--- a/hooks/useExistingChatBootstrap.ts
+++ b/hooks/useExistingChatBootstrap.ts
@@ -1,0 +1,59 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { usePrivy } from "@privy-io/react-auth";
+import { getChat } from "@/lib/chats/getChat";
+
+/**
+ * Discriminated state for resolving an existing chat. The `ready`
+ * variant carries the `sessionId` the workflow transport + history read
+ * require; `not_found` covers chats that don't exist or aren't
+ * accessible (deleted-account / unmigrated rooms).
+ */
+export type ExistingChatBootstrapState =
+  | { status: "loading" }
+  | { status: "ready"; sessionId: string; chatId: string }
+  | { status: "not_found" }
+  | { status: "error"; message: string };
+
+/**
+ * Resolves an existing `/chat/[roomId]` chat to its `sessionId` via
+ * recoup-api `GET /api/chats/{chatId}`, so the page can mount `<Chat>`
+ * on the workflow path (recoupable/chat#1747). Backfilled rooms carry a
+ * `session_id` (`chats.id == rooms.id`); a chat with no session, or one
+ * the caller can't access, resolves to `not_found`.
+ *
+ * Mount with `key={roomId}` so a route change to a different chat
+ * remounts and re-resolves; the ref then only guards StrictMode's
+ * double-invoke. The GET is side-effect-free, so a duplicate fetch is
+ * harmless either way.
+ */
+export function useExistingChatBootstrap(chatId: string): ExistingChatBootstrapState {
+  const { authenticated, getAccessToken } = usePrivy();
+  const [state, setState] = useState<ExistingChatBootstrapState>({ status: "loading" });
+  const startedRef = useRef(false);
+
+  useEffect(() => {
+    if (!authenticated) return;
+    if (startedRef.current) return;
+    startedRef.current = true;
+
+    void (async () => {
+      try {
+        const accessToken = await getAccessToken();
+        const chat = await getChat(chatId, accessToken);
+        if (!chat || !chat.sessionId) {
+          setState({ status: "not_found" });
+          return;
+        }
+        setState({ status: "ready", sessionId: chat.sessionId, chatId: chat.id });
+      } catch (error) {
+        startedRef.current = false;
+        const message = error instanceof Error ? error.message : "Failed to load chat.";
+        setState({ status: "error", message });
+      }
+    })();
+  }, [authenticated, chatId, getAccessToken]);
+
+  return state;
+}

--- a/hooks/useMessageLoader.ts
+++ b/hooks/useMessageLoader.ts
@@ -4,23 +4,26 @@ import { usePrivy } from "@privy-io/react-auth";
 import getChatMessages from "@/lib/messages/getChatMessages";
 
 /**
- * Hook for loading existing messages from a room
- * @param roomId - The room ID to load messages from (undefined to skip loading)
+ * Hook for loading a chat's persisted history from `chat_messages`
+ * (via recoup-api's session-chat endpoint).
+ * @param sessionId - Parent session id (undefined to skip loading)
+ * @param roomId - The chat/room ID to load messages from (undefined to skip loading)
  * @param userId - The current user ID (messages won't load if user is not authenticated)
  * @param setMessages - Callback function to set the loaded messages
  * @returns Loading state and error information
  */
 export function useMessageLoader(
+  sessionId: string | undefined,
   roomId: string | undefined,
   userId: string | undefined,
   setMessages: (messages: UIMessage[]) => void,
 ) {
   const { getAccessToken } = usePrivy();
-  const [isLoading, setIsLoading] = useState(!!roomId);
+  const [isLoading, setIsLoading] = useState(!!roomId && !!sessionId);
   const [error, setError] = useState<Error | null>(null);
 
   useEffect(() => {
-    if (!roomId) {
+    if (!roomId || !sessionId) {
       setIsLoading(false);
       return;
     }
@@ -38,7 +41,7 @@ export function useMessageLoader(
         const accessToken = await getAccessToken();
         if (!accessToken) return;
 
-        const initialMessages = await getChatMessages(roomId, accessToken);
+        const initialMessages = await getChatMessages(sessionId, roomId, accessToken);
         if (initialMessages.length > 0) {
           setMessages(initialMessages as UIMessage[]);
         }
@@ -53,7 +56,7 @@ export function useMessageLoader(
     };
 
     loadMessages();
-  }, [userId, roomId, getAccessToken, setMessages]);
+  }, [userId, sessionId, roomId, getAccessToken, setMessages]);
 
   return {
     isLoading,

--- a/hooks/useVercelChat.ts
+++ b/hooks/useVercelChat.ts
@@ -27,13 +27,13 @@ import getMimeFromPath from "@/lib/files/getMimeFromPath";
 interface UseVercelChatProps {
   id: string;
   /**
-   * Session id from the chat-bootstrap (`createSession`). When present
-   * the transport targets `/api/chat/workflow`; when absent it falls
-   * back to the legacy `/api/chat` for chats opened from history that
-   * haven't been backfilled to the workflow architecture yet
-   * (recoupable/chat#1747 Phase 2).
+   * Session id for the chat. Every chat now routes through recoup-api's
+   * `/api/chat/workflow`: new chats get it from the bootstrap
+   * (`createSession`), existing chats resolve it from the chat row
+   * (recoupable/chat#1747). The legacy `/api/chat` path has been removed,
+   * so this is required.
    */
-  sessionId?: string;
+  sessionId: string;
   initialMessages?: UIMessage[];
   attachments?: FileUIPart[];
   textAttachments?: TextAttachment[];
@@ -283,6 +283,7 @@ export function useVercelChat({
   messagesLengthRef.current = messages.length;
 
   const { isLoading: isMessagesLoading, hasError } = useMessageLoader(
+    sessionId,
     messages.length === 0 ? id : undefined,
     userId,
     setMessages,

--- a/lib/chats/__tests__/getChat.test.ts
+++ b/lib/chats/__tests__/getChat.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { getChat } from "../getChat";
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+const chat = {
+  id: "room-1",
+  sessionId: "sess-1",
+  title: "Hello",
+  modelId: null,
+  activeStreamId: null,
+  lastAssistantMessageAt: null,
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+};
+
+describe("getChat", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the chat (incl. sessionId) on success", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ chat }) });
+
+    const result = await getChat("room-1", "tok");
+
+    expect(result).toEqual(chat);
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/chats/room-1"),
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer tok" }),
+      }),
+    );
+  });
+
+  it("returns null on 404 (not found)", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 404 });
+    expect(await getChat("room-1", "tok")).toBeNull();
+  });
+
+  it("returns null on 403 (no access)", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 403 });
+    expect(await getChat("room-1", "tok")).toBeNull();
+  });
+
+  it("throws on other non-2xx (e.g. 500)", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+    await expect(getChat("room-1", "tok")).rejects.toThrow("Failed to load chat (500)");
+  });
+});

--- a/lib/chats/getChat.ts
+++ b/lib/chats/getChat.ts
@@ -1,0 +1,61 @@
+import { getClientApiBaseUrl } from "@/lib/api/getClientApiBaseUrl";
+
+/**
+ * Chat row as returned by recoup-api `GET /api/chats/{chatId}`
+ * (camelCase wire format from `toChatResponse`).
+ */
+export interface ApiChat {
+  id: string;
+  sessionId: string | null;
+  title: string | null;
+  modelId: string | null;
+  activeStreamId: string | null;
+  lastAssistantMessageAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface GetChatResponse {
+  chat: ApiChat;
+}
+
+/**
+ * Fetch a chat row (incl. `sessionId`) from recoup-api
+ * `GET /api/chats/{chatId}`. Lets an existing `/chat/[roomId]` page
+ * recover the `sessionId` the workflow transport and `chat_messages`
+ * history read require (recoupable/chat#1747).
+ *
+ * Returns `null` when the chat doesn't exist or the caller can't access
+ * it (404/403) — e.g. a legacy room whose account was deleted, or one
+ * the Phase 2 backfill skipped — so the caller can render a "not found"
+ * state instead of an error. Throws on other failures (e.g. 5xx) so
+ * transient problems aren't silently swallowed.
+ *
+ * @param chatId - The chat (room) id from the URL.
+ * @param recoupAccessToken - Short-lived Privy JWT for `Authorization`.
+ */
+export async function getChat(
+  chatId: string,
+  recoupAccessToken: string | null,
+): Promise<ApiChat | null> {
+  const headers: Record<string, string> = {};
+  if (recoupAccessToken) {
+    headers.Authorization = `Bearer ${recoupAccessToken}`;
+  }
+
+  const response = await fetch(
+    `${getClientApiBaseUrl()}/api/chats/${encodeURIComponent(chatId)}`,
+    { headers },
+  );
+
+  if (response.status === 404 || response.status === 403) {
+    return null;
+  }
+
+  if (!response.ok) {
+    throw new Error(`Failed to load chat (${response.status})`);
+  }
+
+  const { chat } = (await response.json()) as GetChatResponse;
+  return chat;
+}

--- a/lib/messages/__tests__/getChatMessages.test.ts
+++ b/lib/messages/__tests__/getChatMessages.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import getChatMessages from "../getChatMessages";
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+const messages = [
+  { id: "m1", role: "user", parts: [{ type: "text", text: "hi" }] },
+  { id: "m2", role: "assistant", parts: [{ type: "text", text: "hello" }] },
+];
+
+describe("getChatMessages", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reads chat_messages via the session-chat endpoint and returns messages", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ chat: {}, isStreaming: false, messages }),
+    });
+
+    const result = await getChatMessages("sess-1", "room-1", "tok");
+
+    expect(result).toEqual(messages);
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/sessions/sess-1/chats/room-1"),
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer tok" }),
+      }),
+    );
+  });
+
+  it("returns [] when the response has no messages", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ chat: {} }) });
+    expect(await getChatMessages("sess-1", "room-1", "tok")).toEqual([]);
+  });
+
+  it("returns [] when the response is not ok", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 404 });
+    expect(await getChatMessages("sess-1", "room-1", "tok")).toEqual([]);
+  });
+
+  it("returns [] when fetch throws", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("network"));
+    expect(await getChatMessages("sess-1", "room-1", "tok")).toEqual([]);
+  });
+});

--- a/lib/messages/getChatMessages.ts
+++ b/lib/messages/getChatMessages.ts
@@ -1,35 +1,41 @@
 import { getClientApiBaseUrl } from "@/lib/api/getClientApiBaseUrl";
+import { UIMessage } from "ai";
 
+/**
+ * Load a chat's persisted history from recoup-api
+ * `GET /api/sessions/{sessionId}/chats/{chatId}`, which reads the
+ * `chat_messages` table (the workflow architecture). Each row's `parts`
+ * column stores the full `UIMessage`, so the response `messages` are
+ * ready to hand to `useChat` as-is.
+ *
+ * Returns `[]` on any failure so a history-load error never blocks the
+ * chat surface from rendering.
+ *
+ * @param sessionId - Parent session id (resolved from the chat row).
+ * @param chatId - The chat id (equals the legacy room id).
+ * @param accessToken - Short-lived Privy JWT for `Authorization`.
+ */
 const getChatMessages = async (
+  sessionId: string,
   chatId: string,
   accessToken: string,
-) => {
+): Promise<UIMessage[]> => {
   try {
     const url = getClientApiBaseUrl();
     const response = await fetch(
-      `${url}/api/chats/${encodeURIComponent(chatId)}/messages`,
+      `${url}/api/sessions/${encodeURIComponent(sessionId)}/chats/${encodeURIComponent(chatId)}`,
       {
         headers: {
           Authorization: `Bearer ${accessToken}`,
         },
       },
     );
+
+    if (!response.ok) return [];
+
     const data = await response.json();
-
-    const memories = data?.data || [];
-
-    return memories.map(
-      (memory: {
-        id: string;
-        content: { role: string; content: string };
-        updated_at: string;
-      }) => ({
-        id: memory.id,
-        ...memory.content,
-      }),
-    );
+    return (data?.messages ?? []) as UIMessage[];
   } catch {
-    // Error handling - could be logged to proper error tracking service
     return [];
   }
 };

--- a/providers/VercelChatProvider.tsx
+++ b/providers/VercelChatProvider.tsx
@@ -59,11 +59,11 @@ interface VercelChatProviderProps {
   children: ReactNode;
   chatId: string;
   /**
-   * Session id from the new-chat bootstrap. Forwarded into
-   * `useVercelChat` -> `useChatTransport`; presence flips the
-   * transport to recoup-api's `/api/chat/workflow`.
+   * Session id for the chat. Forwarded into `useVercelChat` ->
+   * `useChatTransport`, which always targets recoup-api's
+   * `/api/chat/workflow` (recoupable/chat#1747).
    */
-  sessionId?: string;
+  sessionId: string;
   initialMessages?: UIMessage[];
 }
 


### PR DESCRIPTION
## Summary

Completes the chat.recoupable.com cutover (recoupable/chat#1747) by removing the legacy-vs-new conditional now that the Phase 2 backfill is in place. Every chat — new, existing-from-history, and the home landing — routes through recoup-api's `/api/chat/workflow` and reads history from `chat_messages`.

Three coordinated changes:

- **(a) Resolve `sessionId` for existing chats.** `/chat/[roomId]` now renders `ExistingChatBootstrap` (`useExistingChatBootstrap`), which fetches `GET /api/chats/[id]` to recover the chat's `sessionId` before mounting `<Chat>`. Backfilled rooms carry a `session_id` (`chats.id == rooms.id`); a chat with no session / no access renders a graceful "isn't available" state.
- **(b) Read history from `chat_messages`.** `getChatMessages` now calls `GET /api/sessions/{sessionId}/chats/{chatId}` (returns `messages` from `selectChatMessages`) instead of the memories-backed `GET /api/chats/[id]/messages`. `useMessageLoader` threads `sessionId` through.
- **(c) Delete the legacy `/api/chat` branch.** Removed the `if (!sessionId)` fork in `useChatTransport`; `sessionId` is now **required** through `useVercelChat` → `VercelChatProvider` → `Chat` (compiler-enforced — no sessionless mount). Migrated the home route `/` to bootstrap a session like `/chat` (`NewChatBootstrap`), and moved `useAutoLogin` into `NewChatBootstrap` so anonymous landings still prompt sign-in.

## Dependencies (api, against `test`)

- recoupable/api#625 — `GET /api/chats/[id]` (chatId → chat row incl. `sessionId`). **Required at runtime.**
- recoupable/api#627 — backfill `parts` shape fix; the ~46k migrated rows were already reconciled on prod so migrated history deserializes as `UIMessage`.

## Merge gating

Do **not** merge to `main` ahead of the cutover bundle. Production still writes `rooms`/`memories` (cutover is on `test`), so rooms created after the backfill have no session/chat rows yet. This lands on `main` only with the rest of the bundle, after the final idempotent backfill re-run.

## Behavior notes / risks

- Eager provisioning: `/` now creates a session + sandbox on load (post-login landing, logo, SideMenu "New Chat" all hit `/`) — matches `/chat` today; accepted tradeoff.
- Reopening any historical chat now routes through the workflow path, inheriting the documented accepted regressions (no MCP/Composio tools, artist context, title gen, `send_email`, Telegram) and inherited gaps (Stop, multi-tool traces, sandbox persistence).

## Test plan

- [x] Unit: `getChat` (200/404/403/500) and `getChatMessages` (success / empty / not-ok / throw). 8 tests green.
- [x] `tsc --noEmit` clean on changed files; `eslint` clean.
- [ ] Preview (needs api#625 reachable): open a backfilled `/chat/[roomId]` → history renders from `chat_messages`, follow-up message streams via workflow.
- [ ] Preview: new chat from `/` and `/chat` → session provisioned, streams, URL → `/chat/<id>`.
- [ ] Preview: anonymous visit to `/` → sign-in prompt (not a hung spinner).
- [ ] Preview: unknown / deleted-account room id → graceful "isn't available".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes all chats (new and historical) through the workflow path and removes the legacy `/api/chat` branch. History now loads from `chat_messages`, completing the cutover.

- **New Features**
  - `/chat/[roomId]` resolves `sessionId` via `GET /api/chats/{id}` using `ExistingChatBootstrap`; missing/no-access chats show “isn’t available”.
  - History reads from `chat_messages` via `GET /api/sessions/{sessionId}/chats/{chatId}`; `useMessageLoader` threads `sessionId`.
  - Legacy path removed; `sessionId` is required through `Chat` → `VercelChatProvider` → `useVercelChat` → transport. Home `/` now bootstraps a session via `NewChatBootstrap`; `useAutoLogin` moved there to prompt sign-in for anonymous users.

- **Migration**
  - Ship only with the cutover bundle after the final backfill; prod still writes `rooms`/`memories`. Requires `recoupable/api#625` (runtime) and `recoupable/api#627`.

<sup>Written for commit 694fc723247bdafa77a6ca9f0e014eb6ea30e1fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading and resuming existing chat sessions with improved authentication handling.

* **Refactor**
  * Improved chat initialization flow with better session-based handling for both new and existing conversations.
  * Enhanced authentication bootstrap process to provide more reliable chat loading and resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/recoupable/chat/pull/1755?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->