### PR TITLE
feat(chat): silentlyUpdateUrl emits canonical session URL

### DIFF
--- a/hooks/useVercelChat.ts
+++ b/hooks/useVercelChat.ts
@@ -297,8 +297,13 @@ export function useVercelChat({
   const isGeneratingResponse = ["streaming", "submitted"].includes(status);
 
   const silentlyUpdateUrl = useCallback(() => {
-    window.history.replaceState({}, "", `/chat/${id}`);
-  }, [id]);
+    if (!sessionId) return;
+    window.history.replaceState(
+      {},
+      "",
+      `/sessions/${sessionId}/chats/${id}`,
+    );
+  }, [id, sessionId]);
 
   const handleSendMessage = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();


### PR DESCRIPTION
After the first user message, the URL bar is rewritten to `/sessions/{sessionId}/chats/{id}` instead of `/chat/{id}`. Surfaces without `sessionId` (today's `/` homepage) skip the rewrite — they get the canonical URL once the homepage is moved onto `NewChatBootstrap` in a follow-up.

## Test plan

- [ ] On a Vercel preview, send a first message from `/chat` → URL silently updates to `/sessions/{sid}/chats/{cid}` → reload preserves messages.
- [ ] Send a first message from `/` → URL stays at `/` (homepage hasn't been moved onto NewChatBootstrap yet).
- [ ] Existing chats opened via the sidebar (after chat#1756 lands) keep their canonical URL.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Silently updates the chat URL to the canonical session path after the first message: /sessions/{sessionId}/chats/{id}. If no sessionId is available (e.g., on the / homepage), the URL stays unchanged.

<sup>Written for commit f6900d048d3da78887e7ab9123ced6b2fa6f5247. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

