### PR TITLE
refactor(chat): remove UUID generation and update HomePage to use NewChatBootstrap

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,4 @@
 import HomePage from "@/components/Home/HomePage";
-import generateUUID from "@/lib/generateUUID";
 import { getMessages } from "@/lib/messages/getMessages";
 
 export const dynamic = "force-dynamic";
@@ -9,9 +8,8 @@ interface ChatPageProps {
 }
 
 export default async function Home({ searchParams }: ChatPageProps) {
-  const id = generateUUID();
   const initialMessage = (await searchParams)?.q as string;
   const initialMessages = getMessages(initialMessage);
 
-  return <HomePage id={id} initialMessages={initialMessages} />;
+  return <HomePage initialMessages={initialMessages} />;
 }

--- a/components/Home/HomePage.tsx
+++ b/components/Home/HomePage.tsx
@@ -1,17 +1,11 @@
 "use client";
 
 import { useMiniKit } from "@coinbase/onchainkit/minikit";
-import { Chat } from "../VercelChat/chat";
+import NewChatBootstrap from "../VercelChat/NewChatBootstrap";
 import { useEffect } from "react";
 import { UIMessage } from "ai";
 
-const HomePage = ({
-  id,
-  initialMessages,
-}: {
-  id: string;
-  initialMessages?: UIMessage[];
-}) => {
+const HomePage = ({ initialMessages }: { initialMessages?: UIMessage[] }) => {
   const { setFrameReady, isFrameReady } = useMiniKit();
 
   useEffect(() => {
@@ -22,7 +16,7 @@ const HomePage = ({
 
   return (
     <div className="flex flex-col size-full items-center">
-      <Chat id={id} initialMessages={initialMessages} />
+      <NewChatBootstrap initialMessages={initialMessages} />
     </div>
   );
 };

--- a/components/VercelChat/NewChatBootstrap.tsx
+++ b/components/VercelChat/NewChatBootstrap.tsx
@@ -2,6 +2,7 @@
 
 import type { UIMessage } from "ai";
 import { Loader } from "lucide-react";
+import { useAutoLogin } from "@/hooks/useAutoLogin";
 import { useNewChatBootstrap } from "@/hooks/useNewChatBootstrap";
 import { Chat } from "@/components/VercelChat/chat";
 
@@ -11,14 +12,15 @@ interface NewChatBootstrapProps {
 
 /**
  * Thin renderer over `useNewChatBootstrap`. Mounted by
- * `app/chat/page.tsx`; provisions a recoup-api session + sandbox
- * before mounting `<Chat>` so the workflow transport
- * (`/api/chat/workflow`) has the `sessionId` + `chatId` its validator
- * requires (recoupable/chat#1747).
+ * `app/page.tsx` (via HomePage) and `app/chat/page.tsx`; provisions
+ * a recoup-api session + sandbox before mounting `<Chat>` so the
+ * workflow transport (`/api/chat/workflow`) has the `sessionId` +
+ * `chatId` its validator requires (recoupable/chat#1747).
  */
 export default function NewChatBootstrap({
   initialMessages,
 }: NewChatBootstrapProps) {
+  useAutoLogin();
   const state = useNewChatBootstrap();
 
   if (state.status === "ready") {

--- a/components/VercelChat/chat.tsx
+++ b/components/VercelChat/chat.tsx
@@ -44,9 +44,16 @@ export function Chat({ id, sessionId, initialMessages }: ChatProps) {
       sessionId={sessionId}
       initialMessages={initialMessages}
     >
+      {!sessionId ? <LegacyAutoLogin /> : null}
       <ChatContent id={id} />
     </VercelChatProvider>
   );
+}
+
+/** Prompts sign-in for legacy `/chat/[roomId]` mounts (no bootstrap wrapper). */
+function LegacyAutoLogin() {
+  useAutoLogin();
+  return null;
 }
 
 // Inner component that uses the context
@@ -57,7 +64,6 @@ function ChatContentMemoized({
 }) {
   const { messages, status, isLoading, hasError } = useVercelChatContext();
   const { roomId } = useParams();
-  useAutoLogin();
   useArtistFromRoom(id);
   const { getRootProps, isDragActive } = useDropzone();
 


### PR DESCRIPTION
This commit eliminates the server-side UUID generation in Home and updates the HomePage component to use NewChatBootstrap instead of Chat. The changes streamline the chat initialization process by relying on the NewChatBootstrap for session management and message provisioning.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced direct `Chat` mount with `NewChatBootstrap`, removed server-side UUIDs, and added legacy auto-login for non-bootstrap chat routes. This centralizes chat bootstrap and ensures auth so `sessionId` and `chatId` are ready before rendering.

- **Refactors**
  - Removed `generateUUID` and `id` prop from `app/page.tsx` and `HomePage`.
  - Updated `HomePage` to render `NewChatBootstrap` with `initialMessages`.
  - Added `useAutoLogin()` in `NewChatBootstrap` to ensure auth before chat init.

- **New Features**
  - Introduced `LegacyAutoLogin` in `Chat` to prompt sign-in when `sessionId` is missing on legacy mounts.

<sup>Written for commit 26ede3b3043b11abb4dedbf5c107fc99ba3904cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1760?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated automatic login functionality into the new chat initialization flow, improving the session start experience.

* **Refactor**
  * Streamlined chat component initialization process by restructuring internal component dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/recoupable/chat/pull/1760?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->