### PR TITLE
feat(chat): enhance chat component with workflowChatId and isBootstrapPreparing props

### DIFF
--- a/components/VercelChat/ChatInput.tsx
+++ b/components/VercelChat/ChatInput.tsx
@@ -26,6 +26,7 @@ export function ChatInput() {
     setInput,
     input,
     textAttachments,
+    isBootstrapPreparing,
   } = useVercelChatContext();
   // Allow typing regardless of artist selection
   const isDisabled = false;
@@ -38,6 +39,8 @@ export function ChatInput() {
       stop();
       return;
     }
+
+    if (isBootstrapPreparing) return;
 
     // Only check input requirements for sending new messages
     // Allow sending if there are text attachments even without typed input
@@ -82,17 +85,32 @@ export function ChatInput() {
               {/* YouTube connect button removed from ChatInput UI intentionally; preserved for future reuse */}
               <ModelSelect />
             </PromptInputTools>
-            <PromptInputSubmit
-              disabled={isDisabled || hasPendingUploads || isLoadingSignedUrls}
-              status={status}
-              className={cn(
-                "rounded-full hover:scale-105 active:scale-95 transition-all",
-                {
-                  "cursor-not-allowed opacity-50":
-                    isDisabled || hasPendingUploads || isLoadingSignedUrls,
+            <div className="flex items-center gap-2">
+              {isBootstrapPreparing ? (
+                <span className="text-xs text-muted-foreground whitespace-nowrap">
+                  Preparing…
+                </span>
+              ) : null}
+              <PromptInputSubmit
+                disabled={
+                  isDisabled ||
+                  hasPendingUploads ||
+                  isLoadingSignedUrls ||
+                  isBootstrapPreparing
                 }
-              )}
-            />
+                status={status}
+                className={cn(
+                  "rounded-full hover:scale-105 active:scale-95 transition-all",
+                  {
+                    "cursor-not-allowed opacity-50":
+                      isDisabled ||
+                      hasPendingUploads ||
+                      isLoadingSignedUrls ||
+                      isBootstrapPreparing,
+                  }
+                )}
+              />
+            </div>
           </PromptInputToolbar>
         </PromptInput>
       </motion.div>

--- a/components/VercelChat/NewChatBootstrap.tsx
+++ b/components/VercelChat/NewChatBootstrap.tsx
@@ -2,7 +2,10 @@
 
 import type { UIMessage } from "ai";
 import { useRef } from "react";
-import { useNewChatBootstrap } from "@/hooks/useNewChatBootstrap";
+import {
+  isNewChatBootstrapPreparing,
+  useNewChatBootstrap,
+} from "@/hooks/useNewChatBootstrap";
 import { Chat } from "@/components/VercelChat/chat";
 import { generateUUID } from "@/lib/generateUUID";
 
@@ -26,7 +29,7 @@ export default function NewChatBootstrap({
   const state = useNewChatBootstrap();
   const placeholderChatId = useRef(generateUUID()).current;
 
-  const isBootstrapPreparing = state.status !== "ready";
+  const isBootstrapPreparing = isNewChatBootstrapPreparing(state);
 
   if (state.status === "error") {
     return (

--- a/components/VercelChat/NewChatBootstrap.tsx
+++ b/components/VercelChat/NewChatBootstrap.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import type { UIMessage } from "ai";
-import { Loader } from "lucide-react";
+import { useRef } from "react";
 import { useNewChatBootstrap } from "@/hooks/useNewChatBootstrap";
 import { Chat } from "@/components/VercelChat/chat";
+import { generateUUID } from "@/lib/generateUUID";
 
 interface NewChatBootstrapProps {
   initialMessages?: UIMessage[];
@@ -12,24 +13,20 @@ interface NewChatBootstrapProps {
 /**
  * Thin renderer over `useNewChatBootstrap`. Mounted by
  * `app/page.tsx` (via HomePage) and `app/chat/page.tsx`; provisions
- * a recoup-api session + sandbox before mounting `<Chat>` so the
- * workflow transport (`/api/chat/workflow`) has the `sessionId` +
- * `chatId` its validator requires (recoupable/chat#1747).
+ * a recoup-api session + sandbox in parallel while `<Chat>` is visible.
+ * Send stays disabled until bootstrap resolves so the workflow transport
+ * has the api-minted `sessionId` + `chatId` (recoupable/chat#1747).
+ *
+ * Auto-login is handled app-wide by `<UserAutoLogin />` in `UserProvider`
+ * (chat#1761) — do not call `useAutoLogin()` here.
  */
 export default function NewChatBootstrap({
   initialMessages,
 }: NewChatBootstrapProps) {
   const state = useNewChatBootstrap();
+  const placeholderChatId = useRef(generateUUID()).current;
 
-  if (state.status === "ready") {
-    return (
-      <Chat
-        id={state.chatId}
-        sessionId={state.sessionId}
-        initialMessages={initialMessages}
-      />
-    );
-  }
+  const isBootstrapPreparing = state.status !== "ready";
 
   if (state.status === "error") {
     return (
@@ -40,8 +37,12 @@ export default function NewChatBootstrap({
   }
 
   return (
-    <div className="flex size-full items-center justify-center">
-      <Loader className="size-5 animate-spin text-muted-foreground" />
-    </div>
+    <Chat
+      id={placeholderChatId}
+      sessionId={state.status === "ready" ? state.sessionId : undefined}
+      workflowChatId={state.status === "ready" ? state.chatId : undefined}
+      isBootstrapPreparing={isBootstrapPreparing}
+      initialMessages={initialMessages}
+    />
   );
 }

--- a/components/VercelChat/chat.tsx
+++ b/components/VercelChat/chat.tsx
@@ -29,10 +29,23 @@ interface ChatProps {
    * onto their rows, recoupable/chat#1747).
    */
   sessionId?: string;
+  /**
+   * Api-minted chat id from bootstrap. When the mount `id` is a client
+   * placeholder, this is the row id the workflow transport must send.
+   */
+  workflowChatId?: string;
+  /** True while session + sandbox provisioning is in flight on `/` or `/chat`. */
+  isBootstrapPreparing?: boolean;
   initialMessages?: UIMessage[];
 }
 
-export function Chat({ id, sessionId, initialMessages }: ChatProps) {
+export function Chat({
+  id,
+  sessionId,
+  workflowChatId,
+  isBootstrapPreparing,
+  initialMessages,
+}: ChatProps) {
   const { selectedOrgId } = useOrganization();
   const providerKey = `${id}-${selectedOrgId ?? "personal"}`;
 
@@ -41,6 +54,8 @@ export function Chat({ id, sessionId, initialMessages }: ChatProps) {
       key={providerKey}
       chatId={id}
       sessionId={sessionId}
+      workflowChatId={workflowChatId}
+      isBootstrapPreparing={isBootstrapPreparing}
       initialMessages={initialMessages}
     >
       <ChatContent id={id} />

--- a/hooks/useNewChatBootstrap.ts
+++ b/hooks/useNewChatBootstrap.ts
@@ -16,6 +16,13 @@ export type NewChatBootstrapState =
   | { status: "ready"; sessionId: string; chatId: string }
   | { status: "error"; message: string };
 
+/** True until api session + sandbox ids are available (incl. pre-auth idle). */
+export function isNewChatBootstrapPreparing(
+  state: NewChatBootstrapState,
+): boolean {
+  return state.status !== "ready";
+}
+
 /**
  * Runs the new-chat provisioning flow: read `selectedOrgId` from
  * `OrganizationProvider`, `POST /api/sessions` (api derives `cloneUrl`

--- a/hooks/useVercelChat.ts
+++ b/hooks/useVercelChat.ts
@@ -34,6 +34,11 @@ interface UseVercelChatProps {
    * (recoupable/chat#1747 Phase 2).
    */
   sessionId?: string;
+  /**
+   * Api-minted chat id from bootstrap when the mount `id` is a client
+   * placeholder. Used for workflow transport, message load, and URL.
+   */
+  workflowChatId?: string;
   initialMessages?: UIMessage[];
   attachments?: FileUIPart[];
   textAttachments?: TextAttachment[];
@@ -47,6 +52,7 @@ interface UseVercelChatProps {
 export function useVercelChat({
   id,
   sessionId,
+  workflowChatId,
   initialMessages,
   attachments = [],
   textAttachments = [],
@@ -64,8 +70,9 @@ export function useVercelChat({
   const [input, setInput] = useState("");
   const [model, setModel] = useLocalStorage("RECOUP_MODEL", DEFAULT_MODEL);
   const { refetchCredits } = usePaymentProvider();
+  const transportChatId = workflowChatId ?? id;
   const { transport, getHeaders } = useChatTransport({
-    chatId: id,
+    chatId: transportChatId,
     sessionId,
   });
   const { authenticated, getAccessToken } = usePrivy();
@@ -284,7 +291,7 @@ export function useVercelChat({
 
   const { isLoading: isMessagesLoading, hasError } = useMessageLoader(
     sessionId,
-    messages.length === 0 ? id : undefined,
+    messages.length === 0 ? transportChatId : undefined,
     userId,
     setMessages,
   );
@@ -302,9 +309,9 @@ export function useVercelChat({
     window.history.replaceState(
       {},
       "",
-      `/sessions/${sessionId}/chats/${id}`,
+      `/sessions/${sessionId}/chats/${transportChatId}`,
     );
-  }, [id, sessionId]);
+  }, [transportChatId, sessionId]);
 
   const handleSendMessage = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -325,7 +332,12 @@ export function useVercelChat({
     if (!roomId) {
       // Optimistically append a temporary conversation so it appears in Recent Chats
       // It will be replaced by the real conversation after the updates/refetch
-      addOptimisticConversation("New Chat", id, sessionId, messageContent);
+      addOptimisticConversation(
+        "New Chat",
+        transportChatId,
+        sessionId,
+        messageContent,
+      );
       silentlyUpdateUrl();
     }
   };
@@ -345,12 +357,14 @@ export function useVercelChat({
     const hasMessages = messages.length > 1;
     const hasInitialMessages = initialMessages && initialMessages.length > 0;
     // Wait for authentication before sending initial message to avoid 401 errors
+    // New-chat bootstrap mounts before sessionId exists; defer until workflow ids land.
     if (
       !hasInitialMessages ||
       !isReady ||
       hasMessages ||
       !isFullyLoggedIn ||
-      !authenticated
+      !authenticated ||
+      (!roomId && !sessionId)
     )
       return;
     handleSendQueryMessages(initialMessages[0]);
@@ -361,6 +375,8 @@ export function useVercelChat({
     handleSendQueryMessages,
     messages.length,
     authenticated,
+    roomId,
+    sessionId,
   ]);
 
   return {

--- a/hooks/useVercelChatProviderValue.ts
+++ b/hooks/useVercelChatProviderValue.ts
@@ -1,0 +1,121 @@
+"use client";
+
+import { useCallback, useEffect } from "react";
+import { UIMessage } from "ai";
+import { useVercelChat } from "@/hooks/useVercelChat";
+import useAttachments from "@/hooks/useAttachments";
+import { useTextAttachments } from "@/hooks/useTextAttachments";
+import { useArtistProvider } from "@/providers/ArtistProvider";
+import { VercelChatContextType } from "@/providers/VercelChatContext";
+
+interface UseVercelChatProviderValueOptions {
+  chatId: string;
+  sessionId?: string;
+  workflowChatId?: string;
+  isBootstrapPreparing?: boolean;
+  initialMessages?: UIMessage[];
+}
+
+export function useVercelChatProviderValue({
+  chatId,
+  sessionId,
+  workflowChatId,
+  isBootstrapPreparing = false,
+  initialMessages,
+}: UseVercelChatProviderValueOptions): VercelChatContextType {
+  const {
+    attachments,
+    pendingAttachments,
+    setAttachments,
+    removeAttachment,
+    clearAttachments: clearFileAttachments,
+    hasPendingUploads,
+  } = useAttachments();
+
+  const {
+    textAttachments,
+    setTextAttachments,
+    addTextAttachment,
+    removeTextAttachment,
+    clearTextAttachments,
+  } = useTextAttachments();
+
+  const { updateChatState } = useArtistProvider();
+
+  const clearAttachments = useCallback(() => {
+    clearFileAttachments();
+    clearTextAttachments();
+  }, [clearFileAttachments, clearTextAttachments]);
+
+  const {
+    messages,
+    status,
+    isLoading,
+    hasError,
+    isGeneratingResponse,
+    isLoadingSignedUrls,
+    handleSendMessage,
+    stop,
+    setInput,
+    input,
+    setMessages,
+    reload: originalReload,
+    append,
+    model,
+    setModel,
+    availableModels,
+  } = useVercelChat({
+    id: chatId,
+    sessionId,
+    workflowChatId,
+    initialMessages,
+    attachments,
+    textAttachments,
+  });
+
+  const reload = useCallback(() => {
+    return originalReload();
+  }, [originalReload]);
+
+  const handleSendMessageWithClear = async (
+    event: React.FormEvent<HTMLFormElement>,
+  ) => {
+    await handleSendMessage(event);
+    clearAttachments();
+  };
+
+  useEffect(() => {
+    updateChatState(status, messages);
+  }, [status, messages, updateChatState]);
+
+  return {
+    id: chatId,
+    messages,
+    model,
+    availableModels,
+    status,
+    isLoading,
+    hasError,
+    isGeneratingResponse,
+    isLoadingSignedUrls,
+    handleSendMessage: handleSendMessageWithClear,
+    stop,
+    setInput,
+    input,
+    setMessages,
+    setModel,
+    reload,
+    append,
+    attachments,
+    pendingAttachments,
+    setAttachments,
+    removeAttachment,
+    clearAttachments,
+    hasPendingUploads,
+    textAttachments,
+    setTextAttachments,
+    addTextAttachment,
+    removeTextAttachment,
+    isBootstrapPreparing,
+  };
+}

--- a/hooks/useVercelChatProviderValue.ts
+++ b/hooks/useVercelChatProviderValue.ts
@@ -59,7 +59,7 @@ export function useVercelChatProviderValue({
     setInput,
     input,
     setMessages,
-    reload: originalReload,
+    reload,
     append,
     model,
     setModel,
@@ -73,15 +73,14 @@ export function useVercelChatProviderValue({
     textAttachments,
   });
 
-  const reload = useCallback(() => {
-    return originalReload();
-  }, [originalReload]);
-
   const handleSendMessageWithClear = async (
     event: React.FormEvent<HTMLFormElement>,
   ) => {
-    await handleSendMessage(event);
-    clearAttachments();
+    try {
+      await handleSendMessage(event);
+    } finally {
+      clearAttachments();
+    }
   };
 
   useEffect(() => {

--- a/providers/VercelChatContext.tsx
+++ b/providers/VercelChatContext.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { createContext, useContext } from "react";
+import { UseChatHelpers } from "@ai-sdk/react";
+import { ChatStatus, FileUIPart, UIMessage } from "ai";
+import { GatewayLanguageModelEntry } from "@ai-sdk/gateway";
+import { TextAttachment } from "@/types/textAttachment";
+
+export interface VercelChatContextType {
+  id: string | undefined;
+  messages: UIMessage[];
+  availableModels: GatewayLanguageModelEntry[];
+  status: ChatStatus;
+  isLoading: boolean;
+  hasError: boolean;
+  isGeneratingResponse: boolean;
+  isLoadingSignedUrls: boolean;
+  handleSendMessage: (event: React.FormEvent<HTMLFormElement>) => Promise<void>;
+  stop: UseChatHelpers<UIMessage>["stop"];
+  setInput: (input: string) => void;
+  input: string;
+  setMessages: UseChatHelpers<UIMessage>["setMessages"];
+  reload: () => void;
+  append: (message: UIMessage) => void;
+  attachments: FileUIPart[];
+  pendingAttachments: FileUIPart[];
+  setAttachments: (
+    attachments: FileUIPart[] | ((prev: FileUIPart[]) => FileUIPart[])
+  ) => void;
+  removeAttachment: (index: number) => void;
+  clearAttachments: () => void;
+  hasPendingUploads: boolean;
+  textAttachments: TextAttachment[];
+  setTextAttachments: (
+    attachments: TextAttachment[] | ((prev: TextAttachment[]) => TextAttachment[])
+  ) => void;
+  addTextAttachment: (file: File, type: TextAttachment["type"]) => Promise<void>;
+  removeTextAttachment: (index: number) => void;
+  model: string;
+  setModel: (model: string) => void;
+  isBootstrapPreparing: boolean;
+}
+
+export const VercelChatContext = createContext<
+  VercelChatContextType | undefined
+>(undefined);
+
+export function useVercelChatContext() {
+  const context = useContext(VercelChatContext);
+
+  if (context === undefined) {
+    throw new Error(
+      "useVercelChatContext must be used within a VercelChatProvider",
+    );
+  }
+
+  return context;
+}

--- a/providers/VercelChatProvider.tsx
+++ b/providers/VercelChatProvider.tsx
@@ -1,61 +1,13 @@
-import React, {
-  createContext,
-  useContext,
-  ReactNode,
-  useEffect,
-  useCallback,
-} from "react";
-import { useVercelChat } from "@/hooks/useVercelChat";
-import { UseChatHelpers } from "@ai-sdk/react";
-import useAttachments from "@/hooks/useAttachments";
-import { useTextAttachments } from "@/hooks/useTextAttachments";
-import { ChatStatus, FileUIPart, UIMessage } from "ai";
-import { useArtistProvider } from "./ArtistProvider";
-import { GatewayLanguageModelEntry } from "@ai-sdk/gateway";
-import { TextAttachment } from "@/types/textAttachment";
+"use client";
 
-// Interface for the context data
-interface VercelChatContextType {
-  id: string | undefined;
-  messages: UIMessage[];
-  availableModels: GatewayLanguageModelEntry[];
-  status: ChatStatus;
-  isLoading: boolean;
-  hasError: boolean;
-  isGeneratingResponse: boolean;
-  isLoadingSignedUrls: boolean;
-  handleSendMessage: (event: React.FormEvent<HTMLFormElement>) => Promise<void>;
-  stop: UseChatHelpers<UIMessage>["stop"];
-  setInput: (input: string) => void;
-  input: string;
-  setMessages: UseChatHelpers<UIMessage>["setMessages"];
-  reload: () => void;
-  append: (message: UIMessage) => void;
-  attachments: FileUIPart[];
-  pendingAttachments: FileUIPart[];
-  setAttachments: (
-    attachments: FileUIPart[] | ((prev: FileUIPart[]) => FileUIPart[])
-  ) => void;
-  removeAttachment: (index: number) => void;
-  clearAttachments: () => void;
-  hasPendingUploads: boolean;
-  textAttachments: TextAttachment[];
-  setTextAttachments: (
-    attachments: TextAttachment[] | ((prev: TextAttachment[]) => TextAttachment[])
-  ) => void;
-  addTextAttachment: (file: File, type: TextAttachment["type"]) => Promise<void>;
-  removeTextAttachment: (index: number) => void;
-  model: string;
-  setModel: (model: string) => void;
-  isBootstrapPreparing: boolean;
-}
+import { ReactNode } from "react";
+import { UIMessage } from "ai";
+import { useVercelChatProviderValue } from "@/hooks/useVercelChatProviderValue";
+import { VercelChatContext } from "@/providers/VercelChatContext";
 
-// Create the context
-const VercelChatContext = createContext<VercelChatContextType | undefined>(
-  undefined
-);
+export { useVercelChatContext } from "@/providers/VercelChatContext";
+export type { VercelChatContextType } from "@/providers/VercelChatContext";
 
-// Props for the provider component
 interface VercelChatProviderProps {
   children: ReactNode;
   chatId: string;
@@ -70,139 +22,25 @@ interface VercelChatProviderProps {
   initialMessages?: UIMessage[];
 }
 
-/**
- * Provider component that wraps its children with the VercelChat context
- */
 export function VercelChatProvider({
   children,
   chatId,
   sessionId,
   workflowChatId,
-  isBootstrapPreparing = false,
+  isBootstrapPreparing,
   initialMessages,
 }: VercelChatProviderProps) {
-  const {
-    attachments,
-    pendingAttachments,
-    setAttachments,
-    removeAttachment,
-    clearAttachments: clearFileAttachments,
-    hasPendingUploads,
-  } = useAttachments();
-
-  const {
-    textAttachments,
-    setTextAttachments,
-    addTextAttachment,
-    removeTextAttachment,
-    clearTextAttachments,
-  } = useTextAttachments();
-
-  const { updateChatState } = useArtistProvider();
-
-  // Compose clear function for both attachment types
-  const clearAttachments = useCallback(() => {
-    clearFileAttachments();
-    clearTextAttachments();
-  }, [clearFileAttachments, clearTextAttachments]);
-
-  // Use the useVercelChat hook to get the chat state and functions
-  const {
-    messages,
-    status,
-    isLoading,
-    hasError,
-    isGeneratingResponse,
-    isLoadingSignedUrls,
-    handleSendMessage,
-    stop,
-    setInput,
-    input,
-    setMessages,
-    reload: originalReload,
-    append,
-    model,
-    setModel,
-    availableModels,
-  } = useVercelChat({
-    id: chatId,
+  const contextValue = useVercelChatProviderValue({
+    chatId,
     sessionId,
     workflowChatId,
+    isBootstrapPreparing,
     initialMessages,
-    attachments,
-    textAttachments,
   });
 
-  const reload = useCallback(() => {
-    return originalReload();
-  }, [originalReload]);
-
-  // When a message is sent successfully, clear the attachments
-  const handleSendMessageWithClear = async (
-    event: React.FormEvent<HTMLFormElement>
-  ) => {
-    await handleSendMessage(event);
-
-    // Clear attachments after sending
-    clearAttachments();
-  };
-
-  // Create the context value object
-  const contextValue: VercelChatContextType = {
-    id: chatId,
-    messages,
-    model,
-    availableModels,
-    status,
-    isLoading,
-    hasError,
-    isGeneratingResponse,
-    isLoadingSignedUrls,
-    handleSendMessage: handleSendMessageWithClear,
-    stop,
-    setInput,
-    input,
-    setMessages,
-    setModel,
-    reload,
-    append,
-    attachments,
-    pendingAttachments,
-    setAttachments,
-    removeAttachment,
-    clearAttachments,
-    hasPendingUploads,
-    textAttachments,
-    setTextAttachments,
-    addTextAttachment,
-    removeTextAttachment,
-    isBootstrapPreparing,
-  };
-
-  // Send chat status and messages to ArtistProvider
-  useEffect(() => {
-    updateChatState(status, messages);
-  }, [status, messages, updateChatState]);
-
-  // Provide the context value to children
   return (
     <VercelChatContext.Provider value={contextValue}>
       {children}
     </VercelChatContext.Provider>
   );
-}
-
-/**
- * Custom hook to use the VercelChat context
- */
-export function useVercelChatContext() {
-  const context = useContext(VercelChatContext);
-
-  if (context === undefined) {
-    throw new Error(
-      "useVercelChatContext must be used within a VercelChatProvider"
-    );
-  }
-
-  return context;
 }

--- a/providers/VercelChatProvider.tsx
+++ b/providers/VercelChatProvider.tsx
@@ -47,6 +47,7 @@ interface VercelChatContextType {
   removeTextAttachment: (index: number) => void;
   model: string;
   setModel: (model: string) => void;
+  isBootstrapPreparing: boolean;
 }
 
 // Create the context
@@ -64,6 +65,8 @@ interface VercelChatProviderProps {
    * transport to recoup-api's `/api/chat/workflow`.
    */
   sessionId?: string;
+  workflowChatId?: string;
+  isBootstrapPreparing?: boolean;
   initialMessages?: UIMessage[];
 }
 
@@ -74,6 +77,8 @@ export function VercelChatProvider({
   children,
   chatId,
   sessionId,
+  workflowChatId,
+  isBootstrapPreparing = false,
   initialMessages,
 }: VercelChatProviderProps) {
   const {
@@ -122,6 +127,7 @@ export function VercelChatProvider({
   } = useVercelChat({
     id: chatId,
     sessionId,
+    workflowChatId,
     initialMessages,
     attachments,
     textAttachments,
@@ -170,6 +176,7 @@ export function VercelChatProvider({
     setTextAttachments,
     addTextAttachment,
     removeTextAttachment,
+    isBootstrapPreparing,
   };
 
   // Send chat status and messages to ArtistProvider


### PR DESCRIPTION
This update introduces two new props, `workflowChatId` and `isBootstrapPreparing`, to the Chat component, improving the handling of chat sessions. The `workflowChatId` is used for workflow transport when the chat ID is a client placeholder, while `isBootstrapPreparing` indicates when session provisioning is in progress. Additionally, the ChatInput component now disables message sending during bootstrap preparation, enhancing user experience. The NewChatBootstrap component has been updated to manage these new props effectively.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable parallel new‑chat bootstrap with `workflowChatId` and `isBootstrapPreparing`; the chat UI renders immediately with a placeholder ID and blocks send until the session is ready. Also simplifies the provider with a new `useVercelChatProviderValue` hook and keeps session‑based chat APIs.

- New Features
  - `NewChatBootstrap` mounts `<Chat>` with a client placeholder ID and passes `workflowChatId`/`isBootstrapPreparing` via `isNewChatBootstrapPreparing`.
  - `useVercelChat` uses `transportChatId = workflowChatId ?? id` for transport, initial message load, and URL; defers the first send until auth and `sessionId` exist.
  - `ChatInput` disables send and shows “Preparing…” during bootstrap.

- Refactors
  - Centralized auto‑login in `UserProvider`; removed `useAutoLogin` across pages/components.
  - Extracted `VercelChatContext` and `useVercelChatProviderValue`; `VercelChatProvider` now passes `isBootstrapPreparing`.
  - Always clear attachments after send (finally), removed a redundant reload wrapper, and kept session‑based delete/rename APIs.

<sup>Written for commit b8bad91c3b224e453236440e48cbf968da672e33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat shows a persistent "Preparing…" status during bootstrap so users know initialization is in progress.
  * Submit button is disabled while preparing to prevent sending messages prematurely.
  * Chat interface now appears immediately during bootstrap (with temporary session handling) to reduce perceived loading time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->