### PR TITLE
fix(chat): mint one session per artist switch (#1767)

### DIFF
--- a/hooks/sessions/__tests__/provisionInputsMatch.test.ts
+++ b/hooks/sessions/__tests__/provisionInputsMatch.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { provisionInputsMatch } from "../provisionInputsMatch";
+
+describe("provisionInputsMatch", () => {
+  it("matches when artistId and orgId equal lastVariables", () => {
+    expect(
+      provisionInputsMatch(
+        { artistId: "artist-a", orgId: "org-1" },
+        "artist-a",
+        "org-1",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not match when artistId differs", () => {
+    expect(
+      provisionInputsMatch(
+        { artistId: "artist-a", orgId: undefined },
+        "artist-b",
+        undefined,
+      ),
+    ).toBe(false);
+  });
+});

--- a/hooks/sessions/__tests__/shouldProvisionChatSession.test.ts
+++ b/hooks/sessions/__tests__/shouldProvisionChatSession.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { shouldProvisionChatSession } from "../shouldProvisionChatSession";
+import {
+  provisionInputsMatch,
+  shouldProvisionChatSession,
+} from "../shouldProvisionChatSession";
 
 describe("shouldProvisionChatSession", () => {
   const base = {
@@ -65,5 +68,27 @@ describe("shouldProvisionChatSession", () => {
         isSuccess: true,
       }),
     ).toBe(true);
+  });
+});
+
+describe("provisionInputsMatch", () => {
+  it("matches when artistId and orgId equal lastVariables", () => {
+    expect(
+      provisionInputsMatch(
+        { artistId: "artist-a", orgId: "org-1" },
+        "artist-a",
+        "org-1",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not match when artistId differs", () => {
+    expect(
+      provisionInputsMatch(
+        { artistId: "artist-a", orgId: undefined },
+        "artist-b",
+        undefined,
+      ),
+    ).toBe(false);
   });
 });

--- a/hooks/sessions/__tests__/shouldProvisionChatSession.test.ts
+++ b/hooks/sessions/__tests__/shouldProvisionChatSession.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  provisionInputsMatch,
-  shouldProvisionChatSession,
-} from "../shouldProvisionChatSession";
+import { shouldProvisionChatSession } from "../shouldProvisionChatSession";
 
 describe("shouldProvisionChatSession", () => {
   const base = {
@@ -68,27 +65,5 @@ describe("shouldProvisionChatSession", () => {
         isSuccess: true,
       }),
     ).toBe(true);
-  });
-});
-
-describe("provisionInputsMatch", () => {
-  it("matches when artistId and orgId equal lastVariables", () => {
-    expect(
-      provisionInputsMatch(
-        { artistId: "artist-a", orgId: "org-1" },
-        "artist-a",
-        "org-1",
-      ),
-    ).toBe(true);
-  });
-
-  it("does not match when artistId differs", () => {
-    expect(
-      provisionInputsMatch(
-        { artistId: "artist-a", orgId: undefined },
-        "artist-b",
-        undefined,
-      ),
-    ).toBe(false);
   });
 });

--- a/hooks/sessions/__tests__/shouldProvisionChatSession.test.ts
+++ b/hooks/sessions/__tests__/shouldProvisionChatSession.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { shouldProvisionChatSession } from "../shouldProvisionChatSession";
+
+describe("shouldProvisionChatSession", () => {
+  const base = {
+    enabled: true,
+    artistId: "artist-a",
+    orgId: undefined as string | undefined,
+    lastVariables: undefined,
+    isPending: false,
+    isSuccess: false,
+  };
+
+  it("returns false when disabled", () => {
+    expect(
+      shouldProvisionChatSession({
+        ...base,
+        enabled: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when the same inputs are already pending", () => {
+    expect(
+      shouldProvisionChatSession({
+        ...base,
+        lastVariables: { artistId: "artist-a", orgId: undefined },
+        isPending: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when the same inputs already succeeded", () => {
+    expect(
+      shouldProvisionChatSession({
+        ...base,
+        lastVariables: { artistId: "artist-a", orgId: undefined },
+        isSuccess: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false while a mismatched request is still pending", () => {
+    expect(
+      shouldProvisionChatSession({
+        ...base,
+        artistId: "artist-b",
+        lastVariables: { artistId: "artist-a", orgId: undefined },
+        isPending: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true for a new input pair when idle", () => {
+    expect(shouldProvisionChatSession(base)).toBe(true);
+  });
+
+  it("returns true after a mismatched pending request settles", () => {
+    expect(
+      shouldProvisionChatSession({
+        ...base,
+        artistId: "artist-b",
+        lastVariables: { artistId: "artist-a", orgId: undefined },
+        isPending: false,
+        isSuccess: true,
+      }),
+    ).toBe(true);
+  });
+});

--- a/hooks/sessions/provisionInputsMatch.ts
+++ b/hooks/sessions/provisionInputsMatch.ts
@@ -1,0 +1,14 @@
+import type { ProvisionChatSessionInput } from "@/lib/sessions/provisionChatSession";
+
+/** True when `lastVariables` matches the current `(artistId, orgId)` pair. */
+export function provisionInputsMatch(
+  lastVariables: ProvisionChatSessionInput | undefined,
+  artistId: string | undefined,
+  orgId: string | undefined,
+): boolean {
+  return (
+    lastVariables !== undefined &&
+    lastVariables.artistId === artistId &&
+    lastVariables.orgId === orgId
+  );
+}

--- a/hooks/sessions/shouldProvisionChatSession.ts
+++ b/hooks/sessions/shouldProvisionChatSession.ts
@@ -1,0 +1,48 @@
+import type { ProvisionChatSessionInput } from "@/lib/sessions/provisionChatSession";
+
+interface ShouldProvisionChatSessionParams {
+  enabled: boolean;
+  artistId: string | undefined;
+  orgId: string | undefined;
+  lastVariables: ProvisionChatSessionInput | undefined;
+  isPending: boolean;
+  isSuccess: boolean;
+}
+
+/**
+ * Returns whether `useProvisionChatSession` should call `mutate()` for the
+ * current `(artistId, orgId)` inputs. Prevents duplicate POSTs when react
+ * re-renders with the same inputs, and avoids starting a second provision
+ * while a mismatched request is still in flight (inputs changed mid-flight).
+ */
+export function shouldProvisionChatSession({
+  enabled,
+  artistId,
+  orgId,
+  lastVariables,
+  isPending,
+  isSuccess,
+}: ShouldProvisionChatSessionParams): boolean {
+  if (!enabled) {
+    return false;
+  }
+
+  const sameInputs =
+    lastVariables !== undefined &&
+    lastVariables.artistId === artistId &&
+    lastVariables.orgId === orgId;
+
+  if (sameInputs && (isPending || isSuccess)) {
+    return false;
+  }
+
+  if (
+    isPending &&
+    lastVariables !== undefined &&
+    (lastVariables.artistId !== artistId || lastVariables.orgId !== orgId)
+  ) {
+    return false;
+  }
+
+  return true;
+}

--- a/hooks/sessions/shouldProvisionChatSession.ts
+++ b/hooks/sessions/shouldProvisionChatSession.ts
@@ -1,4 +1,5 @@
 import type { ProvisionChatSessionInput } from "@/lib/sessions/provisionChatSession";
+import { provisionInputsMatch } from "@/hooks/sessions/provisionInputsMatch";
 
 interface ShouldProvisionChatSessionParams {
   enabled: boolean;
@@ -7,19 +8,6 @@ interface ShouldProvisionChatSessionParams {
   lastVariables: ProvisionChatSessionInput | undefined;
   isPending: boolean;
   isSuccess: boolean;
-}
-
-/** True when `lastVariables` matches the current `(artistId, orgId)` pair. */
-export function provisionInputsMatch(
-  lastVariables: ProvisionChatSessionInput | undefined,
-  artistId: string | undefined,
-  orgId: string | undefined,
-): boolean {
-  return (
-    lastVariables !== undefined &&
-    lastVariables.artistId === artistId &&
-    lastVariables.orgId === orgId
-  );
 }
 
 /**

--- a/hooks/sessions/shouldProvisionChatSession.ts
+++ b/hooks/sessions/shouldProvisionChatSession.ts
@@ -9,11 +9,26 @@ interface ShouldProvisionChatSessionParams {
   isSuccess: boolean;
 }
 
+/** True when `lastVariables` matches the current `(artistId, orgId)` pair. */
+export function provisionInputsMatch(
+  lastVariables: ProvisionChatSessionInput | undefined,
+  artistId: string | undefined,
+  orgId: string | undefined,
+): boolean {
+  return (
+    lastVariables !== undefined &&
+    lastVariables.artistId === artistId &&
+    lastVariables.orgId === orgId
+  );
+}
+
 /**
  * Returns whether `useProvisionChatSession` should call `mutate()` for the
  * current `(artistId, orgId)` inputs. Prevents duplicate POSTs when react
  * re-renders with the same inputs, and avoids starting a second provision
  * while a mismatched request is still in flight (inputs changed mid-flight).
+ * Callers must re-run the effect when `isPending` settles so deferred inputs
+ * provision after the in-flight request completes.
  */
 export function shouldProvisionChatSession({
   enabled,
@@ -27,10 +42,7 @@ export function shouldProvisionChatSession({
     return false;
   }
 
-  const sameInputs =
-    lastVariables !== undefined &&
-    lastVariables.artistId === artistId &&
-    lastVariables.orgId === orgId;
+  const sameInputs = provisionInputsMatch(lastVariables, artistId, orgId);
 
   if (sameInputs && (isPending || isSuccess)) {
     return false;
@@ -39,7 +51,7 @@ export function shouldProvisionChatSession({
   if (
     isPending &&
     lastVariables !== undefined &&
-    (lastVariables.artistId !== artistId || lastVariables.orgId !== orgId)
+    !sameInputs
   ) {
     return false;
   }

--- a/hooks/sessions/useProvisionChatSession.ts
+++ b/hooks/sessions/useProvisionChatSession.ts
@@ -7,10 +7,8 @@ import {
   provisionChatSession,
   type ProvisionChatSessionInput,
 } from "@/lib/sessions/provisionChatSession";
-import {
-  provisionInputsMatch,
-  shouldProvisionChatSession,
-} from "@/hooks/sessions/shouldProvisionChatSession";
+import { provisionInputsMatch } from "@/hooks/sessions/provisionInputsMatch";
+import { shouldProvisionChatSession } from "@/hooks/sessions/shouldProvisionChatSession";
 
 /**
  * Discriminated lifecycle state for a chat-session provisioning attempt.

--- a/hooks/sessions/useProvisionChatSession.ts
+++ b/hooks/sessions/useProvisionChatSession.ts
@@ -7,7 +7,10 @@ import {
   provisionChatSession,
   type ProvisionChatSessionInput,
 } from "@/lib/sessions/provisionChatSession";
-import { shouldProvisionChatSession } from "@/hooks/sessions/shouldProvisionChatSession";
+import {
+  provisionInputsMatch,
+  shouldProvisionChatSession,
+} from "@/hooks/sessions/shouldProvisionChatSession";
 
 /**
  * Discriminated lifecycle state for a chat-session provisioning attempt.
@@ -72,14 +75,28 @@ export function useProvisionChatSession({
       return;
     }
     mutation.mutate({ artistId, orgId });
-    // `mutation.*` are read inside the body, not declared as deps. The
-    // dep array is the real input set; `shouldProvisionChatSession` bails
-    // idempotently when those inputs already match the in-flight or
-    // completed call, or when a mismatched call is still pending.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [enabled, artistId, orgId]);
+  }, [
+    enabled,
+    artistId,
+    orgId,
+    mutation.isPending,
+    mutation.isSuccess,
+    mutation.variables,
+    mutation.mutate,
+  ]);
 
-  if (!enabled || mutation.isIdle || mutation.isPending) {
+  const provisionMatchesInputs = provisionInputsMatch(
+    mutation.variables,
+    artistId,
+    orgId,
+  );
+
+  if (
+    !enabled ||
+    mutation.isIdle ||
+    mutation.isPending ||
+    (mutation.isSuccess && !provisionMatchesInputs)
+  ) {
     return { status: "bootstrapping" };
   }
   if (mutation.isError) {

--- a/hooks/sessions/useProvisionChatSession.ts
+++ b/hooks/sessions/useProvisionChatSession.ts
@@ -7,6 +7,7 @@ import {
   provisionChatSession,
   type ProvisionChatSessionInput,
 } from "@/lib/sessions/provisionChatSession";
+import { shouldProvisionChatSession } from "@/hooks/sessions/shouldProvisionChatSession";
 
 /**
  * Discriminated lifecycle state for a chat-session provisioning attempt.
@@ -58,15 +59,23 @@ export function useProvisionChatSession({
   });
 
   useEffect(() => {
-    if (!enabled) return;
-    const last = mutation.variables;
-    const sameInputs =
-      last !== undefined && last.artistId === artistId && last.orgId === orgId;
-    if (sameInputs && (mutation.isPending || mutation.isSuccess)) return;
+    if (
+      !shouldProvisionChatSession({
+        enabled,
+        artistId,
+        orgId,
+        lastVariables: mutation.variables,
+        isPending: mutation.isPending,
+        isSuccess: mutation.isSuccess,
+      })
+    ) {
+      return;
+    }
     mutation.mutate({ artistId, orgId });
     // `mutation.*` are read inside the body, not declared as deps. The
-    // dep array is the real input set; the effect bails idempotently
-    // when those inputs already match the in-flight or completed call.
+    // dep array is the real input set; `shouldProvisionChatSession` bails
+    // idempotently when those inputs already match the in-flight or
+    // completed call, or when a mismatched call is still pending.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [enabled, artistId, orgId]);
 

--- a/hooks/useNewChatBootstrap.ts
+++ b/hooks/useNewChatBootstrap.ts
@@ -16,17 +16,17 @@ export type NewChatBootstrapState = ProvisionChatSessionState;
 
 /**
  * Wires Privy + Organization + Artist providers into
- * `useProvisionChatSession`. This hook contains no provisioning logic
- * — it just resolves the inputs (auth state, selected org, selected
- * artist) and delegates to the provisioner.
+ * `useProvisionChatSession`. Waits for org localStorage hydration
+ * (`isOrgReady`) and artist roster load before enabling provision so
+ * artist/org switches mint one session, not several.
  */
 export function useNewChatBootstrap(): NewChatBootstrapState {
   const { authenticated } = usePrivy();
-  const { selectedOrgId } = useOrganization();
+  const { selectedOrgId, isOrgReady } = useOrganization();
   const { selectedArtist, isLoading: isArtistsLoading } = useArtistProvider();
 
   return useProvisionChatSession({
-    enabled: authenticated && !isArtistsLoading,
+    enabled: authenticated && isOrgReady && !isArtistsLoading,
     artistId: selectedArtist?.account_id,
     orgId: selectedOrgId ?? undefined,
   });

--- a/providers/OrganizationProvider.tsx
+++ b/providers/OrganizationProvider.tsx
@@ -5,6 +5,8 @@ import { isActiveChatRoomPath } from "@/lib/chat/isActiveChatRoomPath";
 
 interface OrganizationContextType {
   selectedOrgId: string | null;
+  /** False until localStorage org selection has been read on mount. */
+  isOrgReady: boolean;
   setSelectedOrgId: (orgId: string | null) => void;
   isOrgSettingsOpen: boolean;
   openOrgSettings: (orgId: string) => void;
@@ -79,6 +81,7 @@ const OrganizationProvider = ({ children }: { children: React.ReactNode }) => {
   const value = useMemo(
     () => ({
       selectedOrgId: isInitialized ? selectedOrgId : null,
+      isOrgReady: isInitialized,
       setSelectedOrgId,
       isOrgSettingsOpen,
       openOrgSettings,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures exactly one chat session is minted per artist/org switch and triggers a new provision after a pending switch completes. Delays provisioning until org storage is hydrated and the artist roster is loaded.

- **Bug Fixes**
  - Added `shouldProvisionChatSession` to gate `mutate()`, dedupe same inputs, block mismatched in-flight requests, and re-provision once they settle; covered by `vitest` tests.
  - Updated `useProvisionChatSession` to react to mutation state and use `provisionInputsMatch` to ignore stale success and keep bootstrapping until inputs match.
  - Exposed `isOrgReady` in `OrganizationProvider`; `useNewChatBootstrap` now enables only when `isOrgReady` and the artist roster are loaded.

- **Refactors**
  - Moved `provisionInputsMatch` to its own module for reuse and cleaner imports; added unit tests.

<sup>Written for commit 2684de8b30e7a127ed8c543b1ac86269ef124092. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate chat session creation by ensuring provisioning skips when identical requests are pending or already succeeded.
  * Blocked new provisioning while a mismatched in-flight request exists to avoid conflicting sessions.
* **Improvements**
  * Provisioning now waits for organization data to finish initializing before starting, reducing premature or multiple setup attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->