### PR TITLE
feat(chat): typeable input while bootstrap prepares (#1767)

### DIFF
--- a/components/VercelChat/NewChatBootstrap.tsx
+++ b/components/VercelChat/NewChatBootstrap.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import type { UIMessage } from "ai";
-import { useState } from "react";
-import { useNewChatBootstrap } from "@/hooks/useNewChatBootstrap";
+import { useEffect, useState } from "react";
+import { useChatSessionProvision } from "@/providers/ChatSessionProvisionProvider";
 import { Chat } from "@/components/VercelChat/chat";
 import NewChatPreparingShell from "@/components/VercelChat/NewChatPreparingShell";
 
@@ -19,10 +19,27 @@ interface NewChatBootstrapProps {
 export default function NewChatBootstrap({
   initialMessages,
 }: NewChatBootstrapProps) {
-  const state = useNewChatBootstrap();
+  const { state, consumedChatId, resetProvision } = useChatSessionProvision();
   const [draftInput, setDraftInput] = useState("");
 
-  if (state.status === "ready") {
+  const isConsumedReady =
+    state.status === "ready" &&
+    consumedChatId !== null &&
+    state.chatId === consumedChatId;
+
+  useEffect(() => {
+    if (isConsumedReady) {
+      resetProvision();
+    }
+  }, [isConsumedReady, resetProvision]);
+
+  useEffect(() => {
+    if (state.status === "bootstrapping" || state.status === "idle") {
+      setDraftInput("");
+    }
+  }, [state.status]);
+
+  if (state.status === "ready" && !isConsumedReady) {
     return (
       <Chat
         id={state.chatId}

--- a/components/VercelChat/NewChatBootstrap.tsx
+++ b/components/VercelChat/NewChatBootstrap.tsx
@@ -1,31 +1,33 @@
 "use client";
 
 import type { UIMessage } from "ai";
-import { Loader } from "lucide-react";
+import { useState } from "react";
 import { useNewChatBootstrap } from "@/hooks/useNewChatBootstrap";
 import { Chat } from "@/components/VercelChat/chat";
+import NewChatPreparingShell from "@/components/VercelChat/NewChatPreparingShell";
 
 interface NewChatBootstrapProps {
   initialMessages?: UIMessage[];
 }
 
 /**
- * Thin renderer over `useNewChatBootstrap`. Mounted by
- * `app/page.tsx` (via HomePage) and `app/chat/page.tsx`; provisions
- * a recoup-api session + sandbox before mounting `<Chat>` so the
- * workflow transport (`/api/chat/workflow`) has the `sessionId` +
- * `chatId` its validator requires (recoupable/chat#1747).
+ * New-chat entry for `/` and `/chat`. Provisioning runs at app level
+ * (`ChatSessionProvisionProvider`); while ids are pending this shows a
+ * typeable input instead of a full-screen spinner. `<Chat>` mounts only
+ * when `sessionId` + `chatId` are ready (#1765).
  */
 export default function NewChatBootstrap({
   initialMessages,
 }: NewChatBootstrapProps) {
   const state = useNewChatBootstrap();
+  const [draftInput, setDraftInput] = useState("");
 
   if (state.status === "ready") {
     return (
       <Chat
         id={state.chatId}
         sessionId={state.sessionId}
+        initialInput={draftInput}
         initialMessages={initialMessages}
       />
     );
@@ -40,8 +42,6 @@ export default function NewChatBootstrap({
   }
 
   return (
-    <div className="flex size-full items-center justify-center">
-      <Loader className="size-5 animate-spin text-muted-foreground" />
-    </div>
+    <NewChatPreparingShell input={draftInput} onInputChange={setDraftInput} />
   );
 }

--- a/components/VercelChat/NewChatBootstrap.tsx
+++ b/components/VercelChat/NewChatBootstrap.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { UIMessage } from "ai";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useChatSessionProvision } from "@/providers/ChatSessionProvisionProvider";
 import { Chat } from "@/components/VercelChat/chat";
 import NewChatPreparingShell from "@/components/VercelChat/NewChatPreparingShell";
@@ -21,25 +21,31 @@ export default function NewChatBootstrap({
 }: NewChatBootstrapProps) {
   const { state, consumedChatId, resetProvision } = useChatSessionProvision();
   const [draftInput, setDraftInput] = useState("");
+  const staleResetStartedRef = useRef(false);
 
-  const isConsumedReady =
-    state.status === "ready" &&
-    consumedChatId !== null &&
-    state.chatId === consumedChatId;
-
+  // Returning to `/` or `/chat` after a prior first-send still has a
+  // successful mutation in the root provider — reset once on mount so
+  // we mint a fresh session instead of appending to the old chat.
   useEffect(() => {
-    if (isConsumedReady) {
+    if (staleResetStartedRef.current) return;
+    if (
+      state.status === "ready" &&
+      consumedChatId !== null &&
+      state.chatId === consumedChatId
+    ) {
+      staleResetStartedRef.current = true;
       resetProvision();
     }
-  }, [isConsumedReady, resetProvision]);
+  }, [state, consumedChatId, resetProvision]);
 
   useEffect(() => {
     if (state.status === "bootstrapping" || state.status === "idle") {
       setDraftInput("");
+      staleResetStartedRef.current = false;
     }
   }, [state.status]);
 
-  if (state.status === "ready" && !isConsumedReady) {
+  if (state.status === "ready") {
     return (
       <Chat
         id={state.chatId}

--- a/components/VercelChat/NewChatPreparingShell.tsx
+++ b/components/VercelChat/NewChatPreparingShell.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import cn from "classnames";
+import { Loader2 } from "lucide-react";
+import { motion } from "framer-motion";
+import ChatGreeting from "@/components/Chat/ChatGreeting";
+import FileMentionsInput from "./FileMentionsInput";
+import {
+  PromptInput,
+  PromptInputSubmit,
+  PromptInputToolbar,
+} from "../ai-elements/prompt-input";
+
+interface NewChatPreparingShellProps {
+  input: string;
+  onInputChange: (value: string) => void;
+}
+
+/**
+ * Empty new-chat layout shown while session + sandbox provision. Users
+ * can type immediately; Send stays disabled until bootstrap completes.
+ */
+export default function NewChatPreparingShell({
+  input,
+  onInputChange,
+}: NewChatPreparingShellProps) {
+  return (
+    <div className="px-4 md:px-0 pb-4 flex flex-col h-full items-center w-full relative">
+      <div className="absolute w-full h-6 bg-gradient-to-t from-transparent via-background/80 to-background z-10 top-0" />
+      <div className="flex-1" />
+      <div className="w-full max-w-3xl mx-auto">
+        <ChatGreeting isVisible />
+        <div className="mt-1 md:mt-6 relative px-4">
+          <motion.div
+            className="w-full relative"
+            initial={{ opacity: 0, y: -16 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.3, ease: "easeOut" }}
+          >
+            <PromptInput
+              onSubmit={(event) => event.preventDefault()}
+              className={cn(
+                "overflow-visible",
+                "rounded-2xl border border-border bg-background/70 backdrop-blur",
+                "shadow-sm",
+              )}
+            >
+              <FileMentionsInput
+                value={input}
+                onChange={onInputChange}
+                disabled={false}
+              />
+              <PromptInputToolbar className="justify-end gap-2">
+                <span className="text-xs text-muted-foreground">
+                  Preparing…
+                </span>
+                <PromptInputSubmit
+                  disabled
+                  aria-label="Preparing chat"
+                  className="cursor-not-allowed opacity-50 rounded-full"
+                >
+                  <Loader2 className="size-4 animate-spin" />
+                </PromptInputSubmit>
+              </PromptInputToolbar>
+            </PromptInput>
+          </motion.div>
+        </div>
+      </div>
+      <div className="flex-1" />
+    </div>
+  );
+}

--- a/components/VercelChat/NewChatPreparingShell.tsx
+++ b/components/VercelChat/NewChatPreparingShell.tsx
@@ -51,7 +51,10 @@ export default function NewChatPreparingShell({
                 disabled={false}
               />
               <PromptInputToolbar className="justify-end gap-2">
-                <span className="text-xs text-muted-foreground">
+                <span
+                  aria-live="polite"
+                  className="text-xs text-muted-foreground"
+                >
                   Preparing…
                 </span>
                 <PromptInputSubmit

--- a/components/VercelChat/chat.tsx
+++ b/components/VercelChat/chat.tsx
@@ -23,10 +23,17 @@ interface ChatProps {
   id: string;
   /** Session id from bootstrap or canonical session-scoped route. */
   sessionId: string;
+  /** Text typed while bootstrap was preparing, restored on first mount. */
+  initialInput?: string;
   initialMessages?: UIMessage[];
 }
 
-export function Chat({ id, sessionId, initialMessages }: ChatProps) {
+export function Chat({
+  id,
+  sessionId,
+  initialInput,
+  initialMessages,
+}: ChatProps) {
   const { selectedOrgId } = useOrganization();
   const providerKey = `${id}-${selectedOrgId ?? "personal"}`;
 
@@ -35,6 +42,7 @@ export function Chat({ id, sessionId, initialMessages }: ChatProps) {
       key={providerKey}
       chatId={id}
       sessionId={sessionId}
+      initialInput={initialInput}
       initialMessages={initialMessages}
     >
       <ChatContent id={id} />

--- a/hooks/sessions/useProvisionChatSession.ts
+++ b/hooks/sessions/useProvisionChatSession.ts
@@ -30,6 +30,12 @@ interface UseProvisionChatSessionInput {
   orgId: string | undefined;
 }
 
+export interface UseProvisionChatSessionResult {
+  state: ProvisionChatSessionState;
+  /** Clears the mutation so the next enabled cycle mints a fresh session. */
+  reset: () => void;
+}
+
 /**
  * Wraps `provisionChatSession` in a react-query mutation that re-fires
  * whenever `(artistId, orgId)` change — so each artist/org switch mints
@@ -44,7 +50,7 @@ export function useProvisionChatSession({
   enabled,
   artistId,
   orgId,
-}: UseProvisionChatSessionInput): ProvisionChatSessionState {
+}: UseProvisionChatSessionInput): UseProvisionChatSessionResult {
   const { getAccessToken } = usePrivy();
 
   const mutation = useMutation({
@@ -64,27 +70,30 @@ export function useProvisionChatSession({
       last !== undefined && last.artistId === artistId && last.orgId === orgId;
     if (sameInputs && (mutation.isPending || mutation.isSuccess)) return;
     mutation.mutate({ artistId, orgId });
-    // `mutation.*` are read inside the body, not declared as deps. The
-    // dep array is the real input set; the effect bails idempotently
-    // when those inputs already match the in-flight or completed call.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mutation.* read for idempotency; inputs are [enabled, artistId, orgId]
   }, [enabled, artistId, orgId]);
 
   if (!enabled || mutation.isIdle || mutation.isPending) {
-    return { status: "bootstrapping" };
+    return { state: { status: "bootstrapping" }, reset: mutation.reset };
   }
   if (mutation.isError) {
     return {
-      status: "error",
-      message:
-        mutation.error instanceof Error
-          ? mutation.error.message
-          : "Failed to start a new chat. Please try again.",
+      state: {
+        status: "error",
+        message:
+          mutation.error instanceof Error
+            ? mutation.error.message
+            : "Failed to start a new chat. Please try again.",
+      },
+      reset: mutation.reset,
     };
   }
   return {
-    status: "ready",
-    sessionId: mutation.data.sessionId,
-    chatId: mutation.data.chatId,
+    state: {
+      status: "ready",
+      sessionId: mutation.data.sessionId,
+      chatId: mutation.data.chatId,
+    },
+    reset: mutation.reset,
   };
 }

--- a/hooks/sessions/useProvisionChatSession.ts
+++ b/hooks/sessions/useProvisionChatSession.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useMutation } from "@tanstack/react-query";
 import { usePrivy } from "@privy-io/react-auth";
 import {
@@ -52,6 +52,7 @@ export function useProvisionChatSession({
   orgId,
 }: UseProvisionChatSessionInput): UseProvisionChatSessionResult {
   const { getAccessToken } = usePrivy();
+  const [mintGeneration, setMintGeneration] = useState(0);
 
   const mutation = useMutation({
     mutationFn: async (input: ProvisionChatSessionInput) => {
@@ -63,6 +64,11 @@ export function useProvisionChatSession({
     },
   });
 
+  const reset = useCallback(() => {
+    mutation.reset();
+    setMintGeneration((generation) => generation + 1);
+  }, [mutation]);
+
   useEffect(() => {
     if (!enabled) return;
     const last = mutation.variables;
@@ -70,11 +76,11 @@ export function useProvisionChatSession({
       last !== undefined && last.artistId === artistId && last.orgId === orgId;
     if (sameInputs && (mutation.isPending || mutation.isSuccess)) return;
     mutation.mutate({ artistId, orgId });
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- mutation.* read for idempotency; inputs are [enabled, artistId, orgId]
-  }, [enabled, artistId, orgId]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mutation.* read for idempotency; inputs are [enabled, artistId, orgId, mintGeneration]
+  }, [enabled, artistId, orgId, mintGeneration]);
 
   if (!enabled || mutation.isIdle || mutation.isPending) {
-    return { state: { status: "bootstrapping" }, reset: mutation.reset };
+    return { state: { status: "bootstrapping" }, reset };
   }
   if (mutation.isError) {
     return {
@@ -85,7 +91,7 @@ export function useProvisionChatSession({
             ? mutation.error.message
             : "Failed to start a new chat. Please try again.",
       },
-      reset: mutation.reset,
+      reset,
     };
   }
   return {
@@ -94,6 +100,6 @@ export function useProvisionChatSession({
       sessionId: mutation.data.sessionId,
       chatId: mutation.data.chatId,
     },
-    reset: mutation.reset,
+    reset,
   };
 }

--- a/hooks/useNewChatBootstrap.ts
+++ b/hooks/useNewChatBootstrap.ts
@@ -1,12 +1,7 @@
 "use client";
 
-import { usePrivy } from "@privy-io/react-auth";
-import { useOrganization } from "@/providers/OrganizationProvider";
-import { useArtistProvider } from "@/providers/ArtistProvider";
-import {
-  useProvisionChatSession,
-  type ProvisionChatSessionState,
-} from "./sessions/useProvisionChatSession";
+import { useChatSessionProvision } from "@/providers/ChatSessionProvisionProvider";
+import type { ProvisionChatSessionState } from "./sessions/useProvisionChatSession";
 
 /**
  * Re-exported here so legacy imports of `NewChatBootstrapState` from
@@ -15,19 +10,10 @@ import {
 export type NewChatBootstrapState = ProvisionChatSessionState;
 
 /**
- * Wires Privy + Organization + Artist providers into
- * `useProvisionChatSession`. This hook contains no provisioning logic
- * — it just resolves the inputs (auth state, selected org, selected
- * artist) and delegates to the provisioner.
+ * Reads app-level chat session provision state. Provisioning starts in
+ * `ChatSessionProvisionProvider` right after login; this hook does not
+ * trigger POSTs itself.
  */
 export function useNewChatBootstrap(): NewChatBootstrapState {
-  const { authenticated } = usePrivy();
-  const { selectedOrgId } = useOrganization();
-  const { selectedArtist, isLoading: isArtistsLoading } = useArtistProvider();
-
-  return useProvisionChatSession({
-    enabled: authenticated && !isArtistsLoading,
-    artistId: selectedArtist?.account_id,
-    orgId: selectedOrgId ?? undefined,
-  });
+  return useChatSessionProvision();
 }

--- a/hooks/useNewChatBootstrap.ts
+++ b/hooks/useNewChatBootstrap.ts
@@ -15,5 +15,5 @@ export type NewChatBootstrapState = ProvisionChatSessionState;
  * trigger POSTs itself.
  */
 export function useNewChatBootstrap(): NewChatBootstrapState {
-  return useChatSessionProvision();
+  return useChatSessionProvision().state;
 }

--- a/hooks/useVercelChat.ts
+++ b/hooks/useVercelChat.ts
@@ -24,6 +24,7 @@ import { useDeleteTrailingMessages } from "./useDeleteTrailingMessages";
 import { getFileContents } from "@/lib/sandboxes/getFileContents";
 import getMimeFromPath from "@/lib/files/getMimeFromPath";
 import { getChatPath } from "@/lib/chat/getChatPath";
+import { useChatSessionProvision } from "@/providers/ChatSessionProvisionProvider";
 
 interface UseVercelChatProps {
   id: string;
@@ -57,6 +58,7 @@ export function useVercelChat({
   const artistId = selectedArtist?.account_id;
   const messagesLengthRef = useRef<number>();
   const { addOptimisticConversation } = useConversationsProvider();
+  const { markProvisionConsumed } = useChatSessionProvision();
   const { data: availableModels = [] } = useAvailableModels();
   const [input, setInput] = useState(() => initialInput ?? "");
   const [model, setModel] = useLocalStorage("RECOUP_MODEL", DEFAULT_MODEL);
@@ -314,17 +316,29 @@ export function useVercelChat({
     if (!chatId) {
       // New chat from `/` or `/chat` — sidebar + URL update on first send.
       addOptimisticConversation("New Chat", id, sessionId, messageContent);
+      markProvisionConsumed(id);
       silentlyUpdateUrl();
     }
   };
 
   const handleSendQueryMessages = useCallback(
     async (initialMessage: UIMessage) => {
+      if (!chatId) {
+        markProvisionConsumed(id);
+      }
       silentlyUpdateUrl();
       const headers = await getHeaders();
       sendMessage(initialMessage, { body: chatRequestBody, headers });
     },
-    [silentlyUpdateUrl, sendMessage, chatRequestBody, getHeaders],
+    [
+      chatId,
+      id,
+      markProvisionConsumed,
+      silentlyUpdateUrl,
+      sendMessage,
+      chatRequestBody,
+      getHeaders,
+    ],
   );
 
   useEffect(() => {

--- a/hooks/useVercelChat.ts
+++ b/hooks/useVercelChat.ts
@@ -29,6 +29,7 @@ interface UseVercelChatProps {
   id: string;
   /** Session id from bootstrap or `/sessions/[sessionId]/chats/[chatId]`. */
   sessionId: string;
+  initialInput?: string;
   initialMessages?: UIMessage[];
   attachments?: FileUIPart[];
   textAttachments?: TextAttachment[];
@@ -42,6 +43,7 @@ interface UseVercelChatProps {
 export function useVercelChat({
   id,
   sessionId,
+  initialInput,
   initialMessages,
   attachments = [],
   textAttachments = [],
@@ -56,7 +58,7 @@ export function useVercelChat({
   const messagesLengthRef = useRef<number>();
   const { addOptimisticConversation } = useConversationsProvider();
   const { data: availableModels = [] } = useAvailableModels();
-  const [input, setInput] = useState("");
+  const [input, setInput] = useState(() => initialInput ?? "");
   const [model, setModel] = useLocalStorage("RECOUP_MODEL", DEFAULT_MODEL);
   const { refetchCredits } = usePaymentProvider();
   const { transport, getHeaders } = useChatTransport({

--- a/providers/ChatSessionProvisionProvider.tsx
+++ b/providers/ChatSessionProvisionProvider.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { createContext, useContext, type ReactNode } from "react";
+import { usePrivy } from "@privy-io/react-auth";
+import { useOrganization } from "@/providers/OrganizationProvider";
+import { useArtistProvider } from "@/providers/ArtistProvider";
+import {
+  useProvisionChatSession,
+  type ProvisionChatSessionState,
+} from "@/hooks/sessions/useProvisionChatSession";
+
+const ChatSessionProvisionContext =
+  createContext<ProvisionChatSessionState | null>(null);
+
+/**
+ * Starts session + sandbox provisioning as soon as auth, org, and artist
+ * roster are ready — before the user opens `/` or `/chat`. `NewChatBootstrap`
+ * reads the same state and mounts `<Chat>` only when `status === "ready"`,
+ * keeping `sessionId` required (#1765) while shortening the spinner wait
+ * (recoupable/chat#1767, option B).
+ */
+export function ChatSessionProvisionProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const { authenticated } = usePrivy();
+  const { selectedOrgId } = useOrganization();
+  const { selectedArtist, isLoading: isArtistsLoading } = useArtistProvider();
+
+  const state = useProvisionChatSession({
+    enabled: authenticated && !isArtistsLoading,
+    artistId: selectedArtist?.account_id,
+    orgId: selectedOrgId ?? undefined,
+  });
+
+  return (
+    <ChatSessionProvisionContext.Provider value={state}>
+      {children}
+    </ChatSessionProvisionContext.Provider>
+  );
+}
+
+export function useChatSessionProvision(): ProvisionChatSessionState {
+  const state = useContext(ChatSessionProvisionContext);
+  if (state === null) {
+    throw new Error(
+      "useChatSessionProvision must be used within ChatSessionProvisionProvider",
+    );
+  }
+  return state;
+}

--- a/providers/ChatSessionProvisionProvider.tsx
+++ b/providers/ChatSessionProvisionProvider.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { createContext, useContext, type ReactNode } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
 import { usePrivy } from "@privy-io/react-auth";
 import { useOrganization } from "@/providers/OrganizationProvider";
 import { useArtistProvider } from "@/providers/ArtistProvider";
@@ -9,8 +16,15 @@ import {
   type ProvisionChatSessionState,
 } from "@/hooks/sessions/useProvisionChatSession";
 
+interface ChatSessionProvisionContextValue {
+  state: ProvisionChatSessionState;
+  consumedChatId: string | null;
+  resetProvision: () => void;
+  markProvisionConsumed: (chatId: string) => void;
+}
+
 const ChatSessionProvisionContext =
-  createContext<ProvisionChatSessionState | null>(null);
+  createContext<ChatSessionProvisionContextValue | null>(null);
 
 /**
  * Starts session + sandbox provisioning as soon as auth, org, and artist
@@ -27,26 +41,46 @@ export function ChatSessionProvisionProvider({
   const { authenticated } = usePrivy();
   const { selectedOrgId } = useOrganization();
   const { selectedArtist, isLoading: isArtistsLoading } = useArtistProvider();
+  const [consumedChatId, setConsumedChatId] = useState<string | null>(null);
 
-  const state = useProvisionChatSession({
+  const { state, reset: resetMutation } = useProvisionChatSession({
     enabled: authenticated && !isArtistsLoading,
     artistId: selectedArtist?.account_id,
     orgId: selectedOrgId ?? undefined,
   });
 
+  const resetProvision = useCallback(() => {
+    resetMutation();
+    setConsumedChatId(null);
+  }, [resetMutation]);
+
+  const markProvisionConsumed = useCallback((chatId: string) => {
+    setConsumedChatId(chatId);
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      state,
+      consumedChatId,
+      resetProvision,
+      markProvisionConsumed,
+    }),
+    [state, consumedChatId, resetProvision, markProvisionConsumed],
+  );
+
   return (
-    <ChatSessionProvisionContext.Provider value={state}>
+    <ChatSessionProvisionContext.Provider value={value}>
       {children}
     </ChatSessionProvisionContext.Provider>
   );
 }
 
-export function useChatSessionProvision(): ProvisionChatSessionState {
-  const state = useContext(ChatSessionProvisionContext);
-  if (state === null) {
+export function useChatSessionProvision(): ChatSessionProvisionContextValue {
+  const context = useContext(ChatSessionProvisionContext);
+  if (context === null) {
     throw new Error(
       "useChatSessionProvision must be used within ChatSessionProvisionProvider",
     );
   }
-  return state;
+  return context;
 }

--- a/providers/Providers.tsx
+++ b/providers/Providers.tsx
@@ -12,6 +12,7 @@ import WagmiProvider from "./WagmiProvider";
 import { MiniAppProvider } from "./MiniAppProvider";
 import { ThemeProvider } from "./ThemeProvider";
 import { OrganizationProvider } from "./OrganizationProvider";
+import { ChatSessionProvisionProvider } from "./ChatSessionProvisionProvider";
 import ApiOverrideSync from "./ApiOverrideSync";
 import { AccountOverrideProvider } from "./AccountOverrideProvider";
 
@@ -34,11 +35,13 @@ const Providers = ({ children }: { children: React.ReactNode }) => (
               <UserProvider>
                 <OrganizationProvider>
                   <ArtistProvider>
-                    <SidebarExpansionProvider>
-                      <ConversationsProvider>
-                        <PaymentProvider>{children}</PaymentProvider>
-                      </ConversationsProvider>
-                    </SidebarExpansionProvider>
+                    <ChatSessionProvisionProvider>
+                      <SidebarExpansionProvider>
+                        <ConversationsProvider>
+                          <PaymentProvider>{children}</PaymentProvider>
+                        </ConversationsProvider>
+                      </SidebarExpansionProvider>
+                    </ChatSessionProvisionProvider>
                   </ArtistProvider>
                 </OrganizationProvider>
               </UserProvider>

--- a/providers/VercelChatProvider.tsx
+++ b/providers/VercelChatProvider.tsx
@@ -63,6 +63,7 @@ interface VercelChatProviderProps {
    * Session id for recoup-api `/api/chat/workflow` (required on every mount).
    */
   sessionId: string;
+  initialInput?: string;
   initialMessages?: UIMessage[];
 }
 
@@ -73,6 +74,7 @@ export function VercelChatProvider({
   children,
   chatId,
   sessionId,
+  initialInput,
   initialMessages,
 }: VercelChatProviderProps) {
   const {
@@ -121,6 +123,7 @@ export function VercelChatProvider({
   } = useVercelChat({
     id: chatId,
     sessionId,
+    initialInput,
     initialMessages,
     attachments,
     textAttachments,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Users can type while a new chat session provisions. Provisioning runs at the app level; typed text is restored on mount; the next session is queued after first send; and stale provisions reset once when returning.

- **New Features**
  - Added `NewChatPreparingShell` with a typeable input and “Preparing…” state; Send is disabled and announced via aria-live until ready.
  - Preserve drafted text and pass it as `initialInput` through `Chat` → `VercelChatProvider` → `useVercelChat`.
  - Replaced the full-screen spinner in `NewChatBootstrap` with the preparing shell.

- **Refactors**
  - Centralized bootstrap in `ChatSessionProvisionProvider`; `NewChatBootstrap` resets a stale provision once on mount after a prior send and clears draft input on idle/bootstrapping; `useNewChatBootstrap` is read-only.
  - `useProvisionChatSession` now returns `{ state, reset }` and uses a mint-generation counter to force fresh sessions on reset; `useVercelChat` marks a provision as consumed on first send (including query flow); updated `Providers` to include the new provider.

<sup>Written for commit c560e93d324f8ce85175ead7fb837a8ec74f4a4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1773?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * You can type and keep a draft in the message input while a new chat session is being prepared.
  * A preparation UI now appears during session initialization showing a “Preparing…” status and disabling submission.

* **Improvements**
  * Initial input can be seeded when starting/restoring chats, improving continuity across sessions.
  * Session provisioning is more robust and can be reset/marked as consumed to avoid duplicate provisioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->