### PR TITLE
feat(chat): defer new-chat bootstrap wait from spinner to send button (#1767)

### DIFF
--- a/components/VercelChat/ChatInput.tsx
+++ b/components/VercelChat/ChatInput.tsx
@@ -22,6 +22,7 @@ export function ChatInput() {
     isLoadingSignedUrls,
     handleSendMessage,
     isGeneratingResponse,
+    isBootstrapPreparing,
     stop,
     setInput,
     input,
@@ -29,6 +30,10 @@ export function ChatInput() {
   } = useVercelChatContext();
   // Allow typing regardless of artist selection
   const isDisabled = false;
+  // Block sending until the new-chat session + sandbox finish provisioning;
+  // the input stays typeable so users aren't stuck on a spinner meanwhile.
+  const isSendDisabled =
+    isDisabled || hasPendingUploads || isLoadingSignedUrls || isBootstrapPreparing;
 
   const handleSend = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -42,8 +47,7 @@ export function ChatInput() {
     // Only check input requirements for sending new messages
     // Allow sending if there are text attachments even without typed input
     const hasContent = input !== "" || textAttachments.length > 0;
-    if (!hasContent || isDisabled || hasPendingUploads || isLoadingSignedUrls)
-      return;
+    if (!hasContent || isSendDisabled) return;
 
     handleSendMessage(event);
   };
@@ -81,15 +85,19 @@ export function ChatInput() {
               <PureAttachmentsButton />
               {/* YouTube connect button removed from ChatInput UI intentionally; preserved for future reuse */}
               <ModelSelect />
+              {isBootstrapPreparing && (
+                <span className="text-xs text-muted-foreground animate-pulse">
+                  Preparing your workspace…
+                </span>
+              )}
             </PromptInputTools>
             <PromptInputSubmit
-              disabled={isDisabled || hasPendingUploads || isLoadingSignedUrls}
+              disabled={isSendDisabled}
               status={status}
               className={cn(
                 "rounded-full hover:scale-105 active:scale-95 transition-all",
                 {
-                  "cursor-not-allowed opacity-50":
-                    isDisabled || hasPendingUploads || isLoadingSignedUrls,
+                  "cursor-not-allowed opacity-50": isSendDisabled,
                 }
               )}
             />

--- a/components/VercelChat/ChatInput.tsx
+++ b/components/VercelChat/ChatInput.tsx
@@ -13,6 +13,7 @@ import {
 } from "../ai-elements/prompt-input";
 import ModelSelect from "@/components/ModelSelect";
 import FileMentionsInput from "./FileMentionsInput";
+import WorkspaceStatusIndicator from "./WorkspaceStatusIndicator";
 
 export function ChatInput() {
   const {
@@ -22,7 +23,7 @@ export function ChatInput() {
     isLoadingSignedUrls,
     handleSendMessage,
     isGeneratingResponse,
-    isBootstrapPreparing,
+    workspaceStatus,
     stop,
     setInput,
     input,
@@ -30,10 +31,13 @@ export function ChatInput() {
   } = useVercelChatContext();
   // Allow typing regardless of artist selection
   const isDisabled = false;
-  // Block sending until the new-chat session + sandbox finish provisioning;
-  // the input stays typeable so users aren't stuck on a spinner meanwhile.
+  // Block sending until the workspace (session + sandbox) is ready; the
+  // input stays typeable so users aren't stuck on a spinner meanwhile.
   const isSendDisabled =
-    isDisabled || hasPendingUploads || isLoadingSignedUrls || isBootstrapPreparing;
+    isDisabled ||
+    hasPendingUploads ||
+    isLoadingSignedUrls ||
+    workspaceStatus !== "ready";
 
   const handleSend = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -67,6 +71,9 @@ export function ChatInput() {
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.3, ease: "easeOut" }}
       >
+        <div className="absolute right-3 top-3 z-20">
+          <WorkspaceStatusIndicator status={workspaceStatus} />
+        </div>
         <PromptInput
           onSubmit={handleSend}
           className={cn(
@@ -85,11 +92,6 @@ export function ChatInput() {
               <PureAttachmentsButton />
               {/* YouTube connect button removed from ChatInput UI intentionally; preserved for future reuse */}
               <ModelSelect />
-              {isBootstrapPreparing && (
-                <span className="text-xs text-muted-foreground animate-pulse">
-                  Preparing your workspace…
-                </span>
-              )}
             </PromptInputTools>
             <PromptInputSubmit
               disabled={isSendDisabled}

--- a/components/VercelChat/NewChatBootstrap.tsx
+++ b/components/VercelChat/NewChatBootstrap.tsx
@@ -4,6 +4,7 @@ import type { UIMessage } from "ai";
 import { useRef } from "react";
 import { useNewChatBootstrap } from "@/hooks/useNewChatBootstrap";
 import { Chat } from "@/components/VercelChat/chat";
+import type { WorkspaceStatus } from "@/components/VercelChat/WorkspaceStatusIndicator";
 import { generateUUID } from "@/lib/generateUUID";
 
 interface NewChatBootstrapProps {
@@ -14,10 +15,10 @@ interface NewChatBootstrapProps {
  * Thin renderer over `useNewChatBootstrap`. Mounted by `app/page.tsx`
  * (via HomePage) and `app/chat/page.tsx`. Renders `<Chat>` immediately
  * with a typeable input and provisions a recoup-api session + sandbox in
- * parallel — instead of blocking the whole view on a spinner. The Send
- * button stays disabled (`isBootstrapPreparing`) until the api-minted
- * `sessionId` + `chatId` land, so the workflow transport never fires
- * without the ids its validator requires (recoupable/chat#1747, #1767).
+ * parallel — instead of blocking the whole view on a spinner. Send stays
+ * disabled (via `workspaceStatus`, surfaced as the status dot) until the
+ * api-minted `sessionId` + `chatId` land, so the workflow transport never
+ * fires without the ids its validator requires (recoupable/chat#1747, #1767).
  *
  * Auto-login is handled app-wide by `<UserAutoLogin />` in `UserProvider`
  * (chat#1761) — do not call `useAutoLogin()` here.
@@ -32,20 +33,21 @@ export default function NewChatBootstrap({
   // target on the first send.
   const placeholderChatId = useRef(generateUUID()).current;
 
-  if (state.status === "error") {
-    return (
-      <div className="flex size-full items-center justify-center text-sm text-red-600">
-        {state.message}
-      </div>
-    );
-  }
+  // Provisioning failures surface as the red "off" dot (input stays
+  // visible, Send disabled) rather than replacing the whole view.
+  const workspaceStatus: WorkspaceStatus =
+    state.status === "ready"
+      ? "ready"
+      : state.status === "error"
+        ? "off"
+        : "provisioning";
 
   return (
     <Chat
       id={placeholderChatId}
       sessionId={state.status === "ready" ? state.sessionId : undefined}
       workflowChatId={state.status === "ready" ? state.chatId : undefined}
-      isBootstrapPreparing={state.status !== "ready"}
+      workspaceStatus={workspaceStatus}
       initialMessages={initialMessages}
     />
   );

--- a/components/VercelChat/NewChatBootstrap.tsx
+++ b/components/VercelChat/NewChatBootstrap.tsx
@@ -1,35 +1,36 @@
 "use client";
 
 import type { UIMessage } from "ai";
-import { Loader } from "lucide-react";
+import { useRef } from "react";
 import { useNewChatBootstrap } from "@/hooks/useNewChatBootstrap";
 import { Chat } from "@/components/VercelChat/chat";
+import { generateUUID } from "@/lib/generateUUID";
 
 interface NewChatBootstrapProps {
   initialMessages?: UIMessage[];
 }
 
 /**
- * Thin renderer over `useNewChatBootstrap`. Mounted by
- * `app/page.tsx` (via HomePage) and `app/chat/page.tsx`; provisions
- * a recoup-api session + sandbox before mounting `<Chat>` so the
- * workflow transport (`/api/chat/workflow`) has the `sessionId` +
- * `chatId` its validator requires (recoupable/chat#1747).
+ * Thin renderer over `useNewChatBootstrap`. Mounted by `app/page.tsx`
+ * (via HomePage) and `app/chat/page.tsx`. Renders `<Chat>` immediately
+ * with a typeable input and provisions a recoup-api session + sandbox in
+ * parallel — instead of blocking the whole view on a spinner. The Send
+ * button stays disabled (`isBootstrapPreparing`) until the api-minted
+ * `sessionId` + `chatId` land, so the workflow transport never fires
+ * without the ids its validator requires (recoupable/chat#1747, #1767).
+ *
+ * Auto-login is handled app-wide by `<UserAutoLogin />` in `UserProvider`
+ * (chat#1761) — do not call `useAutoLogin()` here.
  */
 export default function NewChatBootstrap({
   initialMessages,
 }: NewChatBootstrapProps) {
   const state = useNewChatBootstrap();
-
-  if (state.status === "ready") {
-    return (
-      <Chat
-        id={state.chatId}
-        sessionId={state.sessionId}
-        initialMessages={initialMessages}
-      />
-    );
-  }
+  // Stable client id so the <Chat> instance (and anything typed into it)
+  // survives the preparing → ready transition. The api-minted chat id
+  // arrives via `workflowChatId` and takes over as the transport/URL
+  // target on the first send.
+  const placeholderChatId = useRef(generateUUID()).current;
 
   if (state.status === "error") {
     return (
@@ -40,8 +41,12 @@ export default function NewChatBootstrap({
   }
 
   return (
-    <div className="flex size-full items-center justify-center">
-      <Loader className="size-5 animate-spin text-muted-foreground" />
-    </div>
+    <Chat
+      id={placeholderChatId}
+      sessionId={state.status === "ready" ? state.sessionId : undefined}
+      workflowChatId={state.status === "ready" ? state.chatId : undefined}
+      isBootstrapPreparing={state.status !== "ready"}
+      initialMessages={initialMessages}
+    />
   );
 }

--- a/components/VercelChat/WorkspaceStatusIndicator.tsx
+++ b/components/VercelChat/WorkspaceStatusIndicator.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { Tooltip } from "@/components/common/Tooltip";
+
+/**
+ * Lifecycle of the chat workspace (recoup-api session + sandbox) backing
+ * the workflow transport:
+ * - `off`          — no workspace (provisioning failed / unavailable)
+ * - `provisioning` — session + sandbox being created; Send stays gated
+ * - `ready`        — workspace live; Send enabled
+ */
+export type WorkspaceStatus = "off" | "provisioning" | "ready";
+
+const STATUS_CONFIG: Record<
+  WorkspaceStatus,
+  { dotClassName: string; pulse: boolean; tooltip: string }
+> = {
+  off: {
+    dotClassName: "bg-red-500",
+    pulse: false,
+    tooltip: "Workspace unavailable — refresh to try again.",
+  },
+  provisioning: {
+    dotClassName: "bg-yellow-500",
+    pulse: true,
+    tooltip: "Preparing your workspace — type now; send unlocks when it's ready.",
+  },
+  ready: {
+    dotClassName: "bg-green-500",
+    pulse: false,
+    tooltip: "Workspace ready.",
+  },
+};
+
+/**
+ * Stoplight status dot for the chat workspace: red = off, yellow =
+ * provisioning, green = ready. Hover for context. Pure display component —
+ * the status is owned by the chat context and passed in, so this stays
+ * open for reuse without modification (recoupable/chat#1767).
+ */
+export default function WorkspaceStatusIndicator({
+  status,
+  className,
+}: {
+  status: WorkspaceStatus;
+  className?: string;
+}) {
+  const { dotClassName, pulse, tooltip } = STATUS_CONFIG[status];
+
+  return (
+    <Tooltip content={tooltip}>
+      <span
+        role="status"
+        aria-label={tooltip}
+        className={cn(
+          "inline-flex size-3 items-center justify-center",
+          className,
+        )}
+      >
+        <span
+          className={cn(
+            "size-2 rounded-full",
+            dotClassName,
+            pulse && "animate-pulse",
+          )}
+        />
+      </span>
+    </Tooltip>
+  );
+}

--- a/components/VercelChat/WorkspaceStatusIndicator.tsx
+++ b/components/VercelChat/WorkspaceStatusIndicator.tsx
@@ -24,7 +24,7 @@ const STATUS_CONFIG: Record<
   provisioning: {
     dotClassName: "bg-yellow-500",
     pulse: true,
-    tooltip: "Preparing your workspace — type now; send unlocks when it's ready.",
+    tooltip: "Preparing your workspace",
   },
   ready: {
     dotClassName: "bg-green-500",

--- a/components/VercelChat/chat.tsx
+++ b/components/VercelChat/chat.tsx
@@ -18,14 +18,15 @@ import FileDragOverlay from "./FileDragOverlay";
 import { Loader } from "lucide-react";
 import { memo } from "react";
 import { useOrganization } from "@/providers/OrganizationProvider";
+import type { WorkspaceStatus } from "./WorkspaceStatusIndicator";
 
 interface ChatProps {
   id: string;
   /**
    * Session id. Always present from the canonical session-scoped route;
    * absent on the new-chat bootstrap path until provisioning resolves
-   * (see `NewChatBootstrap`). Send is gated on `isBootstrapPreparing`
-   * while it's absent, so the workflow transport never fires without it.
+   * (see `NewChatBootstrap`). Send is gated while `workspaceStatus` is not
+   * `ready`, so the workflow transport never fires without it.
    */
   sessionId?: string;
   /**
@@ -34,8 +35,12 @@ interface ChatProps {
    * resolves; falls back to `id` otherwise.
    */
   workflowChatId?: string;
-  /** True while session + sandbox provisioning is in flight; gates Send. */
-  isBootstrapPreparing?: boolean;
+  /**
+   * Workspace (session + sandbox) lifecycle; gates Send and drives the
+   * status indicator. Defaults to `ready` for existing chats opened from
+   * the canonical route.
+   */
+  workspaceStatus?: WorkspaceStatus;
   initialMessages?: UIMessage[];
 }
 
@@ -43,7 +48,7 @@ export function Chat({
   id,
   sessionId,
   workflowChatId,
-  isBootstrapPreparing,
+  workspaceStatus,
   initialMessages,
 }: ChatProps) {
   const { selectedOrgId } = useOrganization();
@@ -55,7 +60,7 @@ export function Chat({
       chatId={id}
       sessionId={sessionId}
       workflowChatId={workflowChatId}
-      isBootstrapPreparing={isBootstrapPreparing}
+      workspaceStatus={workspaceStatus}
       initialMessages={initialMessages}
     >
       <ChatContent id={id} />

--- a/components/VercelChat/chat.tsx
+++ b/components/VercelChat/chat.tsx
@@ -21,12 +21,31 @@ import { useOrganization } from "@/providers/OrganizationProvider";
 
 interface ChatProps {
   id: string;
-  /** Session id from bootstrap or canonical session-scoped route. */
-  sessionId: string;
+  /**
+   * Session id. Always present from the canonical session-scoped route;
+   * absent on the new-chat bootstrap path until provisioning resolves
+   * (see `NewChatBootstrap`). Send is gated on `isBootstrapPreparing`
+   * while it's absent, so the workflow transport never fires without it.
+   */
+  sessionId?: string;
+  /**
+   * Api-minted chat id from bootstrap, used when `id` is a client
+   * placeholder. Becomes the transport/URL target once provisioning
+   * resolves; falls back to `id` otherwise.
+   */
+  workflowChatId?: string;
+  /** True while session + sandbox provisioning is in flight; gates Send. */
+  isBootstrapPreparing?: boolean;
   initialMessages?: UIMessage[];
 }
 
-export function Chat({ id, sessionId, initialMessages }: ChatProps) {
+export function Chat({
+  id,
+  sessionId,
+  workflowChatId,
+  isBootstrapPreparing,
+  initialMessages,
+}: ChatProps) {
   const { selectedOrgId } = useOrganization();
   const providerKey = `${id}-${selectedOrgId ?? "personal"}`;
 
@@ -35,6 +54,8 @@ export function Chat({ id, sessionId, initialMessages }: ChatProps) {
       key={providerKey}
       chatId={id}
       sessionId={sessionId}
+      workflowChatId={workflowChatId}
+      isBootstrapPreparing={isBootstrapPreparing}
       initialMessages={initialMessages}
     >
       <ChatContent id={id} />

--- a/hooks/useChatTransport.ts
+++ b/hooks/useChatTransport.ts
@@ -6,8 +6,12 @@ import { usePrivy } from "@privy-io/react-auth";
 interface UseChatTransportOptions {
   /** Chat row id (also the AI SDK `useChat({ id })` instance id). */
   chatId: string;
-  /** Session id from bootstrap or canonical route — required for workflow transport. */
-  sessionId: string;
+  /**
+   * Session id from bootstrap or canonical route. Absent only while a new
+   * chat is still provisioning; Send is gated until it lands, so the
+   * transport is never invoked without it.
+   */
+  sessionId?: string;
 }
 
 /**
@@ -39,7 +43,7 @@ export function useChatTransport({
         body: async () => {
           const recoupAccessToken = await getAccessToken().catch(() => null);
           const body: {
-            sessionId: string;
+            sessionId: string | undefined;
             chatId: string;
             recoupAccessToken?: string;
           } = { sessionId, chatId };

--- a/hooks/useChatTransport.ts
+++ b/hooks/useChatTransport.ts
@@ -1,4 +1,4 @@
-import { useMemo, useCallback } from "react";
+import { useMemo, useCallback, useRef } from "react";
 import { DefaultChatTransport } from "ai";
 import { getClientApiBaseUrl } from "@/lib/api/getClientApiBaseUrl";
 import { usePrivy } from "@privy-io/react-auth";
@@ -27,6 +27,17 @@ export function useChatTransport({
   const { getAccessToken } = usePrivy();
   const baseUrl = getClientApiBaseUrl();
 
+  // Read the latest ids at request time via refs. `useChat` captures the
+  // transport from the mount render and does not swap it when `chatId` /
+  // `sessionId` change — so a new chat that mounts during provisioning
+  // (sessionId still undefined, chatId a placeholder) would otherwise POST
+  // those stale values on first send. Refs keep the transport instance
+  // stable while always sending the ids current as of the request.
+  const chatIdRef = useRef(chatId);
+  const sessionIdRef = useRef(sessionId);
+  chatIdRef.current = chatId;
+  sessionIdRef.current = sessionId;
+
   const getHeaders = useCallback(async () => {
     const accessToken = await getAccessToken();
     return accessToken ? { Authorization: `Bearer ${accessToken}` } : undefined;
@@ -46,12 +57,12 @@ export function useChatTransport({
             sessionId: string | undefined;
             chatId: string;
             recoupAccessToken?: string;
-          } = { sessionId, chatId };
+          } = { sessionId: sessionIdRef.current, chatId: chatIdRef.current };
           if (recoupAccessToken) body.recoupAccessToken = recoupAccessToken;
           return body;
         },
       }),
-    [baseUrl, chatId, sessionId, getAccessToken],
+    [baseUrl, getAccessToken],
   );
 
   return { transport, getHeaders };

--- a/hooks/useCreateArtistTool.ts
+++ b/hooks/useCreateArtistTool.ts
@@ -54,12 +54,16 @@ export function useCreateArtistTool(result: CreateArtistResult) {
           await refetchConversations();
 
           if (success) {
-            // Update the URL to point to the new conversation
-            window.history.replaceState(
-              {},
-              "",
-              getChatPath(sessionId, result.newRoomId as string),
-            );
+            // Update the URL to point to the new conversation. sessionId is
+            // always set on an active (post-bootstrap) chat where this tool
+            // runs; guarded only to satisfy the optional context type.
+            if (sessionId) {
+              window.history.replaceState(
+                {},
+                "",
+                getChatPath(sessionId, result.newRoomId as string),
+              );
+            }
             setIsSuccess(true);
           } else {
             console.error("Failed to copy messages");

--- a/hooks/useMessageLoader.ts
+++ b/hooks/useMessageLoader.ts
@@ -7,7 +7,7 @@ import { getChatMessages } from "@/lib/messages/getChatMessages";
  * Loads persisted UI messages for a session-scoped chat from recoup-api.
  */
 export function useMessageLoader(
-  sessionId: string,
+  sessionId: string | undefined,
   chatId: string | undefined,
   userId: string | undefined,
   setMessages: (messages: UIMessage[]) => void,
@@ -17,7 +17,7 @@ export function useMessageLoader(
   const [error, setError] = useState<Error | null>(null);
 
   useEffect(() => {
-    if (!chatId) {
+    if (!chatId || !sessionId) {
       setIsLoading(false);
       return;
     }

--- a/hooks/useVercelChat.ts
+++ b/hooks/useVercelChat.ts
@@ -27,8 +27,18 @@ import { getChatPath } from "@/lib/chat/getChatPath";
 
 interface UseVercelChatProps {
   id: string;
-  /** Session id from bootstrap or `/sessions/[sessionId]/chats/[chatId]`. */
-  sessionId: string;
+  /**
+   * Session id from `/sessions/[sessionId]/chats/[chatId]` (always
+   * present) or the new-chat bootstrap (absent until provisioning
+   * resolves). Send is gated upstream while it's absent, so the transport
+   * never fires without it.
+   */
+  sessionId?: string;
+  /**
+   * Api-minted chat id from bootstrap when `id` is a client placeholder.
+   * Used as the transport / message-load / URL target; falls back to `id`.
+   */
+  workflowChatId?: string;
   initialMessages?: UIMessage[];
   attachments?: FileUIPart[];
   textAttachments?: TextAttachment[];
@@ -42,6 +52,7 @@ interface UseVercelChatProps {
 export function useVercelChat({
   id,
   sessionId,
+  workflowChatId,
   initialMessages,
   attachments = [],
   textAttachments = [],
@@ -59,8 +70,12 @@ export function useVercelChat({
   const [input, setInput] = useState("");
   const [model, setModel] = useLocalStorage("RECOUP_MODEL", DEFAULT_MODEL);
   const { refetchCredits } = usePaymentProvider();
+  // The api-minted chat id once bootstrap resolves; before then `id` is a
+  // client placeholder. Drives the transport, message load, and URL so
+  // sends/persistence target the row recoup-api actually created.
+  const transportChatId = workflowChatId ?? id;
   const { transport, getHeaders } = useChatTransport({
-    chatId: id,
+    chatId: transportChatId,
     sessionId,
   });
   const { authenticated, getAccessToken } = usePrivy();
@@ -277,9 +292,14 @@ export function useVercelChat({
   // Keep messagesRef in sync with messages
   messagesLengthRef.current = messages.length;
 
+  // Only load persisted history for an existing chat opened from a
+  // canonical `/sessions/[sessionId]/chats/[chatId]` URL (route `chatId`
+  // present). A new chat from the bootstrap has nothing to load, so we
+  // skip the fetch — avoiding a spinner flashing over the input the user
+  // is already typing into while provisioning resolves.
   const { isLoading: isMessagesLoading, hasError } = useMessageLoader(
     sessionId,
-    messages.length === 0 ? id : undefined,
+    messages.length === 0 && chatId ? transportChatId : undefined,
     userId,
     setMessages,
   );
@@ -290,8 +310,13 @@ export function useVercelChat({
   const isGeneratingResponse = ["streaming", "submitted"].includes(status);
 
   const silentlyUpdateUrl = useCallback(() => {
-    window.history.replaceState({}, "", getChatPath(sessionId, id));
-  }, [id, sessionId]);
+    if (!sessionId) return;
+    window.history.replaceState(
+      {},
+      "",
+      getChatPath(sessionId, transportChatId),
+    );
+  }, [transportChatId, sessionId]);
 
   const handleSendMessage = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -311,7 +336,12 @@ export function useVercelChat({
 
     if (!chatId) {
       // New chat from `/` or `/chat` — sidebar + URL update on first send.
-      addOptimisticConversation("New Chat", id, sessionId, messageContent);
+      addOptimisticConversation(
+        "New Chat",
+        transportChatId,
+        sessionId,
+        messageContent,
+      );
       silentlyUpdateUrl();
     }
   };

--- a/providers/VercelChatProvider.tsx
+++ b/providers/VercelChatProvider.tsx
@@ -17,7 +17,7 @@ import { TextAttachment } from "@/types/textAttachment";
 // Interface for the context data
 interface VercelChatContextType {
   id: string | undefined;
-  sessionId: string;
+  sessionId: string | undefined;
   messages: UIMessage[];
   availableModels: GatewayLanguageModelEntry[];
   status: ChatStatus;
@@ -48,6 +48,8 @@ interface VercelChatContextType {
   removeTextAttachment: (index: number) => void;
   model: string;
   setModel: (model: string) => void;
+  /** True while the new-chat session + sandbox are still provisioning. */
+  isBootstrapPreparing: boolean;
 }
 
 // Create the context
@@ -60,9 +62,15 @@ interface VercelChatProviderProps {
   children: ReactNode;
   chatId: string;
   /**
-   * Session id for recoup-api `/api/chat/workflow` (required on every mount).
+   * Session id for recoup-api `/api/chat/workflow`. Absent only on the
+   * new-chat bootstrap path until provisioning resolves; Send is gated on
+   * `isBootstrapPreparing` until it lands.
    */
-  sessionId: string;
+  sessionId?: string;
+  /** Api-minted chat id from bootstrap when `chatId` is a placeholder. */
+  workflowChatId?: string;
+  /** True while session + sandbox provisioning is in flight; gates Send. */
+  isBootstrapPreparing?: boolean;
   initialMessages?: UIMessage[];
 }
 
@@ -73,6 +81,8 @@ export function VercelChatProvider({
   children,
   chatId,
   sessionId,
+  workflowChatId,
+  isBootstrapPreparing = false,
   initialMessages,
 }: VercelChatProviderProps) {
   const {
@@ -121,6 +131,7 @@ export function VercelChatProvider({
   } = useVercelChat({
     id: chatId,
     sessionId,
+    workflowChatId,
     initialMessages,
     attachments,
     textAttachments,
@@ -170,6 +181,7 @@ export function VercelChatProvider({
     setTextAttachments,
     addTextAttachment,
     removeTextAttachment,
+    isBootstrapPreparing,
   };
 
   // Send chat status and messages to ArtistProvider

--- a/providers/VercelChatProvider.tsx
+++ b/providers/VercelChatProvider.tsx
@@ -13,6 +13,7 @@ import { ChatStatus, FileUIPart, UIMessage } from "ai";
 import { useArtistProvider } from "./ArtistProvider";
 import { GatewayLanguageModelEntry } from "@ai-sdk/gateway";
 import { TextAttachment } from "@/types/textAttachment";
+import type { WorkspaceStatus } from "@/components/VercelChat/WorkspaceStatusIndicator";
 
 // Interface for the context data
 interface VercelChatContextType {
@@ -48,8 +49,8 @@ interface VercelChatContextType {
   removeTextAttachment: (index: number) => void;
   model: string;
   setModel: (model: string) => void;
-  /** True while the new-chat session + sandbox are still provisioning. */
-  isBootstrapPreparing: boolean;
+  /** Workspace (session + sandbox) lifecycle; gates Send + drives the status dot. */
+  workspaceStatus: WorkspaceStatus;
 }
 
 // Create the context
@@ -69,8 +70,8 @@ interface VercelChatProviderProps {
   sessionId?: string;
   /** Api-minted chat id from bootstrap when `chatId` is a placeholder. */
   workflowChatId?: string;
-  /** True while session + sandbox provisioning is in flight; gates Send. */
-  isBootstrapPreparing?: boolean;
+  /** Workspace (session + sandbox) lifecycle; gates Send + drives the status dot. */
+  workspaceStatus?: WorkspaceStatus;
   initialMessages?: UIMessage[];
 }
 
@@ -82,7 +83,7 @@ export function VercelChatProvider({
   chatId,
   sessionId,
   workflowChatId,
-  isBootstrapPreparing = false,
+  workspaceStatus = "ready",
   initialMessages,
 }: VercelChatProviderProps) {
   const {
@@ -181,7 +182,7 @@ export function VercelChatProvider({
     setTextAttachments,
     addTextAttachment,
     removeTextAttachment,
-    isBootstrapPreparing,
+    workspaceStatus,
   };
 
   // Send chat status and messages to ArtistProvider


### PR DESCRIPTION
## What

New chats landing on `/` or `/chat` block the whole view on a full-screen spinner while `POST /api/sessions` + `POST /api/sandbox` resolve. Measured cold provisioning is **~12 s, dominated by `POST /api/sandbox` (~11 s)** — so the user stares at a spinner before they can even see the input.

This renders `<Chat>` **immediately** with a typeable input and provisions in parallel. The **Send button** stays disabled with a subtle "Preparing your workspace…" cue until the api-minted `sessionId` + `chatId` land, so the workflow transport never fires without the ids its validator requires.

## How

- **`NewChatBootstrap`** — render `<Chat>` eagerly with a stable client placeholder chat id (survives the preparing → ready transition so typed text isn't lost); drop the spinner. The api-minted chat id arrives via `workflowChatId` and takes over as the transport/URL target on first send.
- Thread `sessionId?`, `workflowChatId`, `isBootstrapPreparing` through `Chat` → `VercelChatProvider` → `useVercelChat` (provider kept **inline** — no extraction refactor).
- **`useVercelChat`** — `transportChatId = workflowChatId ?? id` drives the transport, optimistic conversation, and URL. History is loaded **only** on a canonical `/sessions/[sessionId]/chats/[chatId]` route, so no spinner flashes over the input during the ready transition (this also removes a needless empty fetch that exists on `test` today).
- **`ChatInput`** — gate Send on `isBootstrapPreparing`; input stays typeable.
- **`useChatTransport` / `useMessageLoader`** — `sessionId` optional + guard.
- **`useCreateArtistTool`** — guard the one context `sessionId` consumer.

## Notes

- `sessionId` becomes `string | undefined` **only** on the new-chat path; Send is gated so the transport never fires without it. `tsc` confirmed the only affected context consumer was `useCreateArtistTool`.
- Foundation for the longer-term non-blocking-sandbox work (Chat mounted before provisioning completes).
- Supersedes the stale option-A branch in #1764 (skips its provider-extraction refactor that conflicted with #1765).

## Verification

- `pnpm exec tsc --noEmit` — clean (only pre-existing stale-`.next` errors for the page #1765 deleted, confirmed present on clean `test`).
- `pnpm lint` — clean.
- `pnpm exec vitest run` — 62/62 pass.

Tracking: recoupable/chat#1767

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render the chat UI immediately on new chats and provision the workspace in parallel; the Send button stays disabled behind a stoplight status dot (tooltip: “Preparing your workspace”) until `sessionId` and `chatId` are ready. Removes the full-screen spinner and lets users start typing sooner, addressing recoupable/chat#1767.

- New Features
  - Eager `<Chat>` render with a stable placeholder chat id; Send gated by `workspaceStatus` dot and tooltip.
  - `workflowChatId` takes over transport and URL once ready; input stays typeable. Errors show a red dot and disabled Send.
  - Load history only on canonical `/sessions/[sessionId]/chats/[chatId]` routes.

- Bug Fixes
  - Workflow transport reads live `sessionId`/`chatId` via refs so the first send posts correct ids and avoids 400s from stale captures in `useChat`.
  - Guarded optional `sessionId` in `useMessageLoader` and `useCreateArtistTool`.

<sup>Written for commit 3e729b6fdb8fcde8ae879f5f2059205e9cb566dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat initialization now begins immediately while workspace provisioning occurs in the background, reducing perceived startup time.
  * Added "Preparing your workspace…" status indicator during the initial setup phase.

* **Improvements**
  * Message input remains typeable during workspace preparation, providing improved user feedback and responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->