### PR TITLE
fix(chat): persist selected model before send so the workflow bills it

### DIFF
--- a/hooks/usePersistSelectedModel.ts
+++ b/hooks/usePersistSelectedModel.ts
@@ -1,0 +1,52 @@
+"use client";
+
+import { useCallback, useRef } from "react";
+import { updateChat } from "@/lib/chats/updateChat";
+import {
+  shouldPersistChatModel,
+  type PersistedChatModel,
+} from "@/lib/chats/shouldPersistChatModel";
+
+interface UsePersistSelectedModelInput {
+  sessionId: string | undefined;
+  chatId: string;
+  model: string;
+  getAccessToken: () => Promise<string | null>;
+}
+
+/**
+ * Returns a function that persists the picker's selected model to
+ * `chats.model_id` before a send.
+ *
+ * The chat-workflow path bills the model it reads from `chats.model_id` at
+ * request time, so the write must land first — the returned function is
+ * meant to be `await`ed before `sendMessage` so a new chat's very first turn
+ * bills the selected model, not the default. Redundant writes are skipped
+ * via `shouldPersistChatModel`, and a failed PATCH never blocks the send.
+ */
+export function usePersistSelectedModel({
+  sessionId,
+  chatId,
+  model,
+  getAccessToken,
+}: UsePersistSelectedModelInput): () => Promise<void> {
+  // The {chatId, model} we last wrote, so we only PATCH when the selection
+  // actually changes for the active chat.
+  const lastPersistedModelRef = useRef<PersistedChatModel>(null);
+
+  return useCallback(async () => {
+    if (!sessionId || !chatId) return;
+    if (!shouldPersistChatModel(lastPersistedModelRef.current, chatId, model)) {
+      return;
+    }
+
+    try {
+      const accessToken = await getAccessToken();
+      if (!accessToken) return;
+      await updateChat({ accessToken, sessionId, chatId, modelId: model });
+      lastPersistedModelRef.current = { chatId, model };
+    } catch (error) {
+      console.error("Failed to persist selected model before send:", error);
+    }
+  }, [sessionId, chatId, model, getAccessToken]);
+}

--- a/hooks/useVercelChat.ts
+++ b/hooks/useVercelChat.ts
@@ -295,13 +295,20 @@ export function useVercelChat({
 
   const append = async (message: UIMessage) => {
     const headers = await getHeaders();
+    // Retry/Edit and programmatic sends bypass handleSubmit, so persist the
+    // selected model here too before the workflow reads chats.model_id.
+    await persistSelectedModel();
     sendMessage(message, { body: chatRequestBody, headers });
   };
 
   const handleReload = useCallback(async () => {
     const headers = await getHeaders();
+    // Retry/Edit (MessageParts + message-editor) call reload() → regenerate,
+    // bypassing handleSubmit; persist the selected model first so the
+    // regenerated turn bills it, not the previous/default model.
+    await persistSelectedModel();
     await regenerate({ body: chatRequestBody, headers });
-  }, [getHeaders, regenerate, chatRequestBody]);
+  }, [getHeaders, regenerate, chatRequestBody, persistSelectedModel]);
 
   // Keep messagesRef in sync with messages
   messagesLengthRef.current = messages.length;

--- a/hooks/useVercelChat.ts
+++ b/hooks/useVercelChat.ts
@@ -24,6 +24,11 @@ import { useDeleteTrailingMessages } from "./useDeleteTrailingMessages";
 import { getFileContents } from "@/lib/sandboxes/getFileContents";
 import getMimeFromPath from "@/lib/files/getMimeFromPath";
 import { getChatPath } from "@/lib/chat/getChatPath";
+import { updateChat } from "@/lib/chats/updateChat";
+import {
+  shouldPersistChatModel,
+  type PersistedChatModel,
+} from "@/lib/chats/shouldPersistChatModel";
 
 interface UseVercelChatProps {
   id: string;
@@ -65,6 +70,9 @@ export function useVercelChat({
   const userId = userData?.account_id || userData?.id; // Use account_id if available, fallback to id
   const artistId = selectedArtist?.account_id;
   const messagesLengthRef = useRef<number>();
+  // The {chatId, model} we last wrote to chats.model_id, so we only PATCH
+  // when the selection actually changes for the active chat.
+  const lastPersistedModelRef = useRef<PersistedChatModel>(null);
   const { addOptimisticConversation } = useConversationsProvider();
   const { data: availableModels = [] } = useAvailableModels();
   const [input, setInput] = useState("");
@@ -274,6 +282,31 @@ export function useVercelChat({
       text: messageText,
       files: nonAudioAttachments.length > 0 ? nonAudioAttachments : undefined,
     };
+
+    // Persist the picker's model to chats.model_id before sending. The
+    // chat-workflow path bills the model it reads from chats.model_id at
+    // request time, so the write must land first — awaited here so a new
+    // chat's very first turn bills the selected model, not the default.
+    if (
+      sessionId &&
+      transportChatId &&
+      shouldPersistChatModel(lastPersistedModelRef.current, transportChatId, model)
+    ) {
+      try {
+        const accessToken = await getAccessToken();
+        if (accessToken) {
+          await updateChat({
+            accessToken,
+            sessionId,
+            chatId: transportChatId,
+            modelId: model,
+          });
+          lastPersistedModelRef.current = { chatId: transportChatId, model };
+        }
+      } catch (error) {
+        console.error("Failed to persist selected model before send:", error);
+      }
+    }
 
     sendMessage(payload, { body: chatRequestBody, headers });
     setInput("");

--- a/hooks/useVercelChat.ts
+++ b/hooks/useVercelChat.ts
@@ -24,11 +24,7 @@ import { useDeleteTrailingMessages } from "./useDeleteTrailingMessages";
 import { getFileContents } from "@/lib/sandboxes/getFileContents";
 import getMimeFromPath from "@/lib/files/getMimeFromPath";
 import { getChatPath } from "@/lib/chat/getChatPath";
-import { updateChat } from "@/lib/chats/updateChat";
-import {
-  shouldPersistChatModel,
-  type PersistedChatModel,
-} from "@/lib/chats/shouldPersistChatModel";
+import { usePersistSelectedModel } from "./usePersistSelectedModel";
 
 interface UseVercelChatProps {
   id: string;
@@ -70,9 +66,6 @@ export function useVercelChat({
   const userId = userData?.account_id || userData?.id; // Use account_id if available, fallback to id
   const artistId = selectedArtist?.account_id;
   const messagesLengthRef = useRef<number>();
-  // The {chatId, model} we last wrote to chats.model_id, so we only PATCH
-  // when the selection actually changes for the active chat.
-  const lastPersistedModelRef = useRef<PersistedChatModel>(null);
   const { addOptimisticConversation } = useConversationsProvider();
   const { data: availableModels = [] } = useAvailableModels();
   const [input, setInput] = useState("");
@@ -87,6 +80,16 @@ export function useVercelChat({
     sessionId,
   });
   const { authenticated, getAccessToken } = usePrivy();
+
+  // Persists the picker's selected model to chats.model_id; awaited before
+  // send so the workflow bills the selected model (it reads chats.model_id
+  // at request time), not the default.
+  const persistSelectedModel = usePersistSelectedModel({
+    sessionId,
+    chatId: transportChatId,
+    model,
+    getAccessToken,
+  });
 
   // Load artist files for mentions (from Supabase)
   const { files: allArtistFiles = [] } = useArtistFilesForMentions();
@@ -283,30 +286,8 @@ export function useVercelChat({
       files: nonAudioAttachments.length > 0 ? nonAudioAttachments : undefined,
     };
 
-    // Persist the picker's model to chats.model_id before sending. The
-    // chat-workflow path bills the model it reads from chats.model_id at
-    // request time, so the write must land first — awaited here so a new
-    // chat's very first turn bills the selected model, not the default.
-    if (
-      sessionId &&
-      transportChatId &&
-      shouldPersistChatModel(lastPersistedModelRef.current, transportChatId, model)
-    ) {
-      try {
-        const accessToken = await getAccessToken();
-        if (accessToken) {
-          await updateChat({
-            accessToken,
-            sessionId,
-            chatId: transportChatId,
-            modelId: model,
-          });
-          lastPersistedModelRef.current = { chatId: transportChatId, model };
-        }
-      } catch (error) {
-        console.error("Failed to persist selected model before send:", error);
-      }
-    }
+    // Land the selected model in chats.model_id before the send fires.
+    await persistSelectedModel();
 
     sendMessage(payload, { body: chatRequestBody, headers });
     setInput("");

--- a/lib/chats/__tests__/buildPatchChatBody.test.ts
+++ b/lib/chats/__tests__/buildPatchChatBody.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { buildPatchChatBody } from "@/lib/chats/buildPatchChatBody";
+
+describe("buildPatchChatBody", () => {
+  it("includes only provided fields", () => {
+    expect(buildPatchChatBody({ title: "My chat" })).toEqual({
+      title: "My chat",
+    });
+    expect(
+      buildPatchChatBody({ modelId: "anthropic/claude-opus-4.6" }),
+    ).toEqual({ modelId: "anthropic/claude-opus-4.6" });
+    expect(
+      buildPatchChatBody({
+        title: "My chat",
+        modelId: "openai/gpt-5.4-mini",
+      }),
+    ).toEqual({ title: "My chat", modelId: "openai/gpt-5.4-mini" });
+  });
+
+  it("throws when no fields are provided", () => {
+    expect(() => buildPatchChatBody({})).toThrow(
+      "At least one of title or modelId is required",
+    );
+  });
+});

--- a/lib/chats/__tests__/shouldPersistChatModel.test.ts
+++ b/lib/chats/__tests__/shouldPersistChatModel.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { shouldPersistChatModel } from "@/lib/chats/shouldPersistChatModel";
+
+describe("shouldPersistChatModel", () => {
+  it("persists when nothing has been persisted yet (new chat, first send)", () => {
+    expect(shouldPersistChatModel(null, "chat-1", "anthropic/claude-opus-4.6")).toBe(true);
+  });
+
+  it("persists when the chat changed since the last persist", () => {
+    expect(
+      shouldPersistChatModel(
+        { chatId: "chat-1", model: "anthropic/claude-opus-4.6" },
+        "chat-2",
+        "anthropic/claude-opus-4.6",
+      ),
+    ).toBe(true);
+  });
+
+  it("persists when the model changed for the same chat", () => {
+    expect(
+      shouldPersistChatModel(
+        { chatId: "chat-1", model: "openai/gpt-5.4-mini" },
+        "chat-1",
+        "anthropic/claude-opus-4.6",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not persist when the same model is already persisted for the same chat", () => {
+    expect(
+      shouldPersistChatModel(
+        { chatId: "chat-1", model: "anthropic/claude-opus-4.6" },
+        "chat-1",
+        "anthropic/claude-opus-4.6",
+      ),
+    ).toBe(false);
+  });
+});

--- a/lib/chats/buildPatchChatBody.ts
+++ b/lib/chats/buildPatchChatBody.ts
@@ -1,0 +1,22 @@
+export type PatchChatBody = {
+  title?: string;
+  modelId?: string;
+};
+
+/**
+ * Builds the JSON body for `PATCH /api/sessions/{sessionId}/chats/{chatId}`.
+ * At least one field is required (matches api `PatchSessionChatBody`).
+ */
+export function buildPatchChatBody(fields: PatchChatBody): PatchChatBody {
+  const body: PatchChatBody = {};
+  if (fields.title !== undefined) {
+    body.title = fields.title;
+  }
+  if (fields.modelId !== undefined) {
+    body.modelId = fields.modelId;
+  }
+  if (Object.keys(body).length === 0) {
+    throw new Error("At least one of title or modelId is required");
+  }
+  return body;
+}

--- a/lib/chats/shouldPersistChatModel.ts
+++ b/lib/chats/shouldPersistChatModel.ts
@@ -1,0 +1,25 @@
+export type PersistedChatModel = { chatId: string; model: string } | null;
+
+/**
+ * Decides whether the picker's selected model must be persisted to
+ * `chats.model_id` before the next send.
+ *
+ * The chat-workflow path bills the model it reads from `chats.model_id` at
+ * request time, so the selection has to be written before the send fires.
+ * We persist when we haven't persisted for this chat yet (covers a new
+ * chat's first turn) or when the model changed since the last persist for
+ * this chat — and skip the redundant PATCH otherwise.
+ *
+ * @param last - The {chatId, model} we last persisted, or null if none yet.
+ * @param chatId - The chat about to receive the message.
+ * @param model - The currently selected model id.
+ */
+export function shouldPersistChatModel(
+  last: PersistedChatModel,
+  chatId: string,
+  model: string,
+): boolean {
+  if (!last) return true;
+  if (last.chatId !== chatId) return true;
+  return last.model !== model;
+}

--- a/lib/chats/updateChat.ts
+++ b/lib/chats/updateChat.ts
@@ -1,10 +1,12 @@
 import { getClientApiBaseUrl } from "@/lib/api/getClientApiBaseUrl";
+import { buildPatchChatBody } from "@/lib/chats/buildPatchChatBody";
 
 export type UpdateChatParams = {
   accessToken: string;
   sessionId: string;
   chatId: string;
-  title: string;
+  title?: string;
+  modelId?: string;
 };
 
 export type UpdateChatResponse = {
@@ -31,6 +33,7 @@ export async function updateChat({
   sessionId,
   chatId,
   title,
+  modelId,
 }: UpdateChatParams): Promise<UpdateChatResponse> {
   const response = await fetch(
     `${getClientApiBaseUrl()}/api/sessions/${encodeURIComponent(sessionId)}/chats/${encodeURIComponent(chatId)}`,
@@ -40,7 +43,7 @@ export async function updateChat({
         "Content-Type": "application/json",
         Authorization: `Bearer ${accessToken}`,
       },
-      body: JSON.stringify({ title }),
+      body: JSON.stringify(buildPatchChatBody({ title, modelId })),
     },
   );
 

--- a/lib/chats/updateChat.ts
+++ b/lib/chats/updateChat.ts
@@ -24,7 +24,7 @@ export type UpdateChatResponse = {
 };
 
 /**
- * Renames (or otherwise patches) a session-scoped chat via recoup-api
+ * Patches a session-scoped chat (title and/or modelId) via recoup-api
  * `PATCH /api/sessions/{sessionId}/chats/{chatId}`. Returns the updated
  * row under `{ chat }`.
  */


### PR DESCRIPTION
Fixes the model-selector billing bug tracked in #1767 — *"every new chat bills the default model, no matter what you pick."*

## Root cause
The chat-workflow path bills the model it reads from `chats.model_id` at request time (`api/lib/chat/handleChatWorkflowStream.ts:93`). The chat UI never wrote the picker selection there, so `chats.model_id` stayed at its column default and that's what got billed.

## Approach (chat-only, follows our open-agents discussion)
The chat row already exists from new-chat bootstrap (`POST /api/sessions` mints both session + chat before the first send), so we don't need an api/DB change — we just **persist the selected model before sending, and await it** so the write lands before the workflow reads `chats.model_id`:

- `shouldPersistChatModel(last, chatId, model)` — pure guard: persist on a new chat's first send or when the model changed for the active chat; skip the redundant PATCH otherwise.
- In `useVercelChat.handleSubmit`, before `sendMessage`: `await updateChat({ modelId })` when the guard says so, tracked by a ref.

This is intentionally **not** the 3-hook sync machinery from #1779 (which fails the repro — see [analysis](https://github.com/recoupable/chat/pull/1779#issuecomment-4626497105) / [live test](https://github.com/recoupable/chat/pull/1779#issuecomment-4626560741)). It reuses #1779's good leaf utilities (`buildPatchChatBody`, `updateChat(modelId)` — credit @John).

## Why not set it at chat creation (open-agents `sessions/route.ts:266`)
open-agents sources the model from a saved `defaultModelId` preference, which recoup doesn't have. Recoup's picker is a localStorage global and the chat row exists pre-send, so PATCH-before-send is the simpler equivalent and honors the new-chat picker on the very first message.

## Tests
- `shouldPersistChatModel` — 4 cases (new chat, chat changed, model changed, no-op) — TDD red→green.
- `buildPatchChatBody` — carried over (2 cases).
- `tsc` clean for touched files; lint clean.

## Manual verification
Repro on preview: new chat → pick a non-default model → send → `usage_events.model_id` should equal the selected model (not the default). Will post results as a comment.

Supersedes #1779 (left open for @John to close).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist the selected chat model to `chats.model_id` before every send (first message, retry/edit/regenerate, and `append`) so the workflow bills the chosen model, not the default. Fixes the “new chat bills default model” bug and closes gaps on resend paths.

- **Bug Fixes**
  - Persist `modelId` to `chats.model_id` and await it before `sendMessage`, `append`, and `regenerate` (retry/edit).
  - Encapsulate persist-before-send in `usePersistSelectedModel` and call it from `useVercelChat`.
  - Skip redundant PATCHes via `shouldPersistChatModel`; wire `updateChat({ modelId })` through `buildPatchChatBody` and add unit tests.

<sup>Written for commit 53893071739cd43ccbce5446cea47a7bcbecb582. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat model selections are now automatically saved and persist across all sessions, ensuring your preferences remain consistent.
  * You can now update a chat's model selection after creation, providing greater flexibility in managing your conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->