### PR TITLE
feat(chat): repoint chat transport to canonical POST /api/chat

### DIFF
--- a/hooks/useChatTransport.ts
+++ b/hooks/useChatTransport.ts
@@ -16,7 +16,7 @@ interface UseChatTransportOptions {
 
 /**
  * Chat transport for chat.recoupable.com → recoup-api
- * `POST /api/chat/workflow`. Injects `sessionId`, `chatId`, and
+ * `POST /api/chat`. Injects `sessionId`, `chatId`, and
  * `recoupAccessToken` at the transport boundary so callers only pass
  * per-message fields (model, etc.) via `sendMessage`.
  */
@@ -46,7 +46,7 @@ export function useChatTransport({
   const transport = useMemo(
     () =>
       new DefaultChatTransport({
-        api: `${baseUrl}/api/chat/workflow`,
+        api: `${baseUrl}/api/chat`,
         headers: async (): Promise<Record<string, string>> => {
           const accessToken = await getAccessToken().catch(() => null);
           return accessToken ? { Authorization: `Bearer ${accessToken}` } : {};

--- a/providers/VercelChatProvider.tsx
+++ b/providers/VercelChatProvider.tsx
@@ -63,7 +63,7 @@ interface VercelChatProviderProps {
   children: ReactNode;
   chatId: string;
   /**
-   * Session id for recoup-api `/api/chat/workflow`. Absent only on the
+   * Session id for recoup-api `/api/chat`. Absent only on the
    * new-chat bootstrap path until provisioning resolves; Send is gated on
    * `isBootstrapPreparing` until it lands.
    */


### PR DESCRIPTION
**Step 3** of the `/api/chat/workflow` → `/api/chat` rename ([chat#1767](https://github.com/recoupable/chat/issues/1767)).

`useChatTransport` now POSTs to `${baseUrl}/api/chat` (was `/api/chat/workflow`), against the canonical endpoint added in [api#645](https://github.com/recoupable/api/pull/645) and documented in [docs#235](https://github.com/recoupable/docs/pull/235).

## Changes
- `hooks/useChatTransport.ts` — transport `api:` → `/api/chat` (+ docstring)
- `providers/VercelChatProvider.tsx` — comment-only ref updated

## ⚠️ Deploy coordination (critical)
api#645 **deletes** `/api/chat/workflow` (no alias). This PR and api#645's promotion to prod, plus the open-agents repoint (step 4), must deploy **in the same window**:
- If chat deploys *before* api prod has `/api/chat` → chat 404s.
- If api prod removes `/workflow` *before* chat deploys this → chat 404s.

## Verification
- No `/api/chat/workflow` refs remain in chat; tsc + lint clean.
- E2E on preview after deploy: send a chat → DevTools shows the transport POSTing `/api/chat` (200, streams). (No unit test — single transport URL string in a hook with no existing test infra.)

## Follow-up
4. open-agents — repoint `CHAT_API_POST_PATH` → `/api/chat`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched chat transport to POST to `${baseUrl}/api/chat` (was `/api/chat/workflow`). Aligns with the canonical API and prevents 404s when the old endpoint is removed.

- **Migration**
  - Requires `api#645` to be live; deploy chat and API together to avoid 404s.
  - Follow-up: repoint open-agents `CHAT_API_POST_PATH` to `/api/chat`.

<sup>Written for commit b3c21c0ebb21c3dbb4f78056f2548df2634849c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

