### PR TITLE
feat: catalog landing header + onboarding empty state

### DIFF
--- a/components/Catalog/CatalogLandingHeader.tsx
+++ b/components/Catalog/CatalogLandingHeader.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import Link from "next/link";
+import { Sparkles } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import useCatalogs from "@/hooks/useCatalogs";
+import useArtistCatalogSongs from "@/hooks/useArtistCatalogSongs";
+
+interface CatalogLandingHeaderProps {
+  catalogId: string;
+}
+
+/**
+ * Landing header for a catalog deep-link (e.g. a warm lead arriving from a
+ * marketing valuation). Shows the catalog name, how many tracks it holds, and
+ * a single clear next action — open the agent pre-asked about this catalog —
+ * so the work the lead just did has an obvious continuation.
+ */
+const CatalogLandingHeader = ({ catalogId }: CatalogLandingHeaderProps) => {
+  const { data: catalogsData } = useCatalogs();
+  const catalog = catalogsData?.catalogs?.find((c) => c.id === catalogId);
+
+  const { data, isLoading } = useArtistCatalogSongs({
+    catalogId,
+    pageSize: 1,
+  });
+  const trackCount = data?.pages?.[0]?.pagination?.total_count ?? 0;
+
+  const name = catalog?.name ?? "Your catalog";
+  const prompt = `Tell me about my catalog "${name}" — what stands out across these tracks, and what should I do next?`;
+
+  return (
+    <div className="rounded-xl bg-card shadow p-5 mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <div className="min-w-0">
+        <h1 className="text-lg md:text-xl font-semibold truncate">{name}</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          {isLoading ? (
+            <Skeleton className="h-4 w-24" />
+          ) : (
+            <>
+              {trackCount} {trackCount === 1 ? "track" : "tracks"} in this catalog
+            </>
+          )}
+        </p>
+      </div>
+      <Button asChild className="shrink-0">
+        <Link href={`/?q=${encodeURIComponent(prompt)}`}>
+          <Sparkles />
+          Ask the agent about this catalog
+        </Link>
+      </Button>
+    </div>
+  );
+};
+
+export default CatalogLandingHeader;

--- a/components/Catalog/CatalogSongsPage.tsx
+++ b/components/Catalog/CatalogSongsPage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import CatalogSongsPageContent from "./CatalogSongsPageContent";
+import CatalogLandingHeader from "./CatalogLandingHeader";
 import { useRouter } from "next/navigation";
 import { ArrowLeft } from "lucide-react";
 
@@ -27,7 +28,7 @@ const CatalogSongsPage = ({ catalogId }: CatalogSongsPageProps) => {
           Back to Catalogs
         </button>
       </div>
-      <h1 className="text-lg md:text-xl font-medium pb-4">Catalog Songs</h1>
+      <CatalogLandingHeader catalogId={catalogId} />
       <CatalogSongsPageContent catalogId={catalogId} />
     </div>
   );

--- a/components/Catalog/CatalogsPageContent.tsx
+++ b/components/Catalog/CatalogsPageContent.tsx
@@ -2,6 +2,7 @@
 
 import useCatalogs from "@/hooks/useCatalogs";
 import CatalogCard from "./CatalogCard";
+import EmptyCatalogsState from "./EmptyCatalogsState";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useUserProvider } from "@/providers/UserProvder";
 
@@ -35,7 +36,7 @@ const CatalogsPageContent = () => {
   const catalogs = data?.catalogs || [];
 
   if (!catalogs.length) {
-    return <p className="text-sm text-muted-foreground">No catalogs found.</p>;
+    return <EmptyCatalogsState />;
   }
 
   return (

--- a/components/Catalog/EmptyCatalogsState.tsx
+++ b/components/Catalog/EmptyCatalogsState.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import Link from "next/link";
+import { Sparkles, BarChart3 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+const VALUATION_URL = "https://recoupable.com/valuation";
+const AGENT_PROMPT =
+  "Help me set up my first catalog and understand what my music is worth.";
+
+/**
+ * Onboarding empty state for an account with no catalogs yet. Replaces the bare
+ * "No catalogs found." text with a guided next step: run a free valuation (the
+ * same flow that materializes a catalog) or ask the agent to help build one.
+ */
+const EmptyCatalogsState = () => {
+  return (
+    <div className="rounded-xl bg-card shadow p-8 text-center max-w-xl mx-auto">
+      <h2 className="text-lg font-semibold">No catalogs yet</h2>
+      <p className="text-sm text-muted-foreground mt-2">
+        A catalog is your collection of tracks with their play counts and
+        estimated value. Run a free valuation to measure your catalog, or ask the
+        agent to help you build one.
+      </p>
+      <div className="flex flex-col sm:flex-row gap-3 justify-center mt-6">
+        <Button asChild>
+          <a href={VALUATION_URL} target="_blank" rel="noreferrer">
+            <BarChart3 />
+            Measure your catalog value
+          </a>
+        </Button>
+        <Button asChild variant="outline">
+          <Link href={`/?q=${encodeURIComponent(AGENT_PROMPT)}`}>
+            <Sparkles />
+            Ask the agent
+          </Link>
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default EmptyCatalogsState;


### PR DESCRIPTION
## What

Phase 3 (chat) of recoupable/chat#1801 — makes `/catalogs/[id]` a real landing for a warm lead arriving from a marketing valuation, instead of a bare song table.

- **Landing header** (`CatalogLandingHeader`): catalog name + **track count** (real `total_count` from the songs query) + one clear next action — **"Ask the agent about this catalog"**, which opens a chat pre-seeded with a question about the catalog via the existing `/?q=` mechanism. This is the activation moment.
- **Onboarding empty state** (`EmptyCatalogsState`): replaces the bare `"No catalogs found."` with guided next steps — **"Measure your catalog value"** (→ `recoupable.com/valuation`, closing the loop) and **"Ask the agent"**.

Both new components are one-export-per-file (SRP) and mirror existing shadcn `Button`/`Skeleton` + shadow-as-border styling.

## Scoped honestly — what's deferred and why

The issue's Done-when also asks for **per-track play counts** and a **valuation band** on this page. Those are **not** in this PR because the data isn't reachable yet:
- chat's catalog model (`GET /api/catalogs/songs`) returns no play counts, and there is **no** "play counts by ISRC / by catalog" API endpoint — only `GET /api/research/playcounts?spotify_album_id=` (per-album) and `/research/tracks/{id}/measurements` (per-track).
- there is no persisted, fetchable valuation band (it's computed client-side in marketing today).

Surfacing both cleanly needs a **new `GET /api/catalogs/measurements?catalogId=`** endpoint (catalog → snapshot → `song_measurements`, latest per ISRC + a derived total). I did **not** fake numbers. Tracked as a follow-up on the issue so this PR ships a complete, honest slice.

## Verification
- `tsc --noEmit`: no type errors in the changed files.
- `eslint`: clean.
- Vercel preview build is the compile check; **visual QA on the preview still recommended** before merge (I can't drive a browser with prod env locally).

Part of recoupable/chat#1801 (Phase 3). PR targets `test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turns `/catalogs/[id]` into a proper landing with a header that shows the catalog name, live track count, and a single “Ask the agent” action. Adds an onboarding empty state that routes users to run a valuation or ask the agent. Part of recoupable/chat#1801 (Phase 3); per-track play counts and the valuation band are deferred pending a catalog measurements endpoint.

- **New Features**
  - Added `CatalogLandingHeader`: shows catalog name and real `total_count` from the songs query, plus a button that opens chat pre-seeded via `/?q=`.
  - Added `EmptyCatalogsState`: replaces “No catalogs found.” with actions to “Measure your catalog value” (external valuation) or “Ask the agent”.
  - Integrated on `/catalogs/[id]` by replacing the old “Catalog Songs” header, and in catalogs list by swapping the empty state.

<sup>Written for commit 9072a5e9cd223b97e874d3e2dc724345bd50f5e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

