### PR TITLE
feat: show X (Twitter) + LinkedIn in artist Connectors tab (chat#1793)

### DIFF
--- a/lib/composio/__tests__/allowedArtistConnectors.test.ts
+++ b/lib/composio/__tests__/allowedArtistConnectors.test.ts
@@ -2,14 +2,11 @@ import { describe, it, expect } from "vitest";
 import { ALLOWED_ARTIST_CONNECTORS } from "../allowedArtistConnectors";
 
 describe("ALLOWED_ARTIST_CONNECTORS", () => {
-  it("includes tiktok, instagram, youtube, and twitter", () => {
+  it("includes tiktok, instagram, youtube, twitter, and linkedin", () => {
     expect(ALLOWED_ARTIST_CONNECTORS).toContain("tiktok");
     expect(ALLOWED_ARTIST_CONNECTORS).toContain("instagram");
     expect(ALLOWED_ARTIST_CONNECTORS).toContain("youtube");
     expect(ALLOWED_ARTIST_CONNECTORS).toContain("twitter");
-  });
-
-  it("does not include linkedin (label/owner-only)", () => {
-    expect(ALLOWED_ARTIST_CONNECTORS).not.toContain("linkedin");
+    expect(ALLOWED_ARTIST_CONNECTORS).toContain("linkedin");
   });
 });

--- a/lib/composio/__tests__/allowedArtistConnectors.test.ts
+++ b/lib/composio/__tests__/allowedArtistConnectors.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import { ALLOWED_ARTIST_CONNECTORS } from "../allowedArtistConnectors";
+
+describe("ALLOWED_ARTIST_CONNECTORS", () => {
+  it("includes tiktok, instagram, youtube, and twitter", () => {
+    expect(ALLOWED_ARTIST_CONNECTORS).toContain("tiktok");
+    expect(ALLOWED_ARTIST_CONNECTORS).toContain("instagram");
+    expect(ALLOWED_ARTIST_CONNECTORS).toContain("youtube");
+    expect(ALLOWED_ARTIST_CONNECTORS).toContain("twitter");
+  });
+
+  it("does not include linkedin (label/owner-only)", () => {
+    expect(ALLOWED_ARTIST_CONNECTORS).not.toContain("linkedin");
+  });
+});

--- a/lib/composio/__tests__/connectorDisplay.test.ts
+++ b/lib/composio/__tests__/connectorDisplay.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { isValidElement } from "react";
+import { getConnectorIcon } from "../getConnectorIcon";
+import { formatConnectorName } from "../formatConnectorName";
+import { getConnectorMeta } from "../connectorMetadata";
+
+/**
+ * Display coverage for the artist-facing social connectors. Each slug must
+ * render a branded icon (not the generic Link2 fallback), a clean name, and a
+ * real description — otherwise X / LinkedIn / YouTube look broken in the tab.
+ */
+describe("connector display: X, LinkedIn, YouTube", () => {
+  const fallbackIconType = (getConnectorIcon("unknown-slug-xyz") as { type: unknown }).type;
+
+  it("getConnectorIcon returns a branded (non-fallback) icon for twitter, linkedin, youtube", () => {
+    for (const slug of ["twitter", "linkedin", "youtube"]) {
+      const el = getConnectorIcon(slug) as { type: unknown };
+      expect(isValidElement(el)).toBe(true);
+      expect(el.type).not.toBe(fallbackIconType);
+    }
+  });
+
+  it("formatConnectorName maps twitter and linkedin to clean display names", () => {
+    expect(formatConnectorName("X (Twitter)", "twitter")).toBe("X (Twitter)");
+    expect(formatConnectorName("LinkedIn", "linkedin")).toBe("LinkedIn");
+  });
+
+  it("connectorMetadata has non-default descriptions for twitter and linkedin", () => {
+    const fallback = getConnectorMeta("unknown-slug-xyz").description;
+    expect(getConnectorMeta("twitter").description).not.toBe(fallback);
+    expect(getConnectorMeta("linkedin").description).not.toBe(fallback);
+  });
+});

--- a/lib/composio/allowedArtistConnectors.ts
+++ b/lib/composio/allowedArtistConnectors.ts
@@ -11,6 +11,7 @@ export const ALLOWED_ARTIST_CONNECTORS = [
   "instagram",
   "youtube",
   "twitter",
+  "linkedin",
 ] as const;
 
 export type AllowedArtistConnector = (typeof ALLOWED_ARTIST_CONNECTORS)[number];

--- a/lib/composio/allowedArtistConnectors.ts
+++ b/lib/composio/allowedArtistConnectors.ts
@@ -2,9 +2,10 @@
  * Connector slugs that artists are allowed to connect.
  * Only these connectors will be shown in the artist settings Connectors tab.
  *
- * Why separate from the API's ALLOWED_ARTIST_CONNECTORS: gives the frontend
- * independent control over what's displayed. New connectors can be enabled
- * on the API first and surfaced in the UI when ready.
+ * This is the source of truth for artist-connector visibility. The API
+ * (`GET /api/connectors`) is unopinionated and returns every supported
+ * connector; the frontend filters that list down to this allow-list via
+ * `useConnectors({ allowedSlugs })`.
  */
 export const ALLOWED_ARTIST_CONNECTORS = [
   "tiktok",

--- a/lib/composio/allowedArtistConnectors.ts
+++ b/lib/composio/allowedArtistConnectors.ts
@@ -10,6 +10,7 @@ export const ALLOWED_ARTIST_CONNECTORS = [
   "tiktok",
   "instagram",
   "youtube",
+  "twitter",
 ] as const;
 
 export type AllowedArtistConnector = (typeof ALLOWED_ARTIST_CONNECTORS)[number];

--- a/lib/composio/connectorMetadata.ts
+++ b/lib/composio/connectorMetadata.ts
@@ -17,6 +17,8 @@ export const connectorMetadata: Record<string, ConnectorMeta> = {
   tiktok: { description: "Post and manage TikTok content" },
   instagram: { description: "Post and manage Instagram content" },
   youtube: { description: "Post and manage YouTube content" },
+  twitter: { description: "Post and manage content on X (Twitter)" },
+  linkedin: { description: "Post and manage LinkedIn content" },
 };
 
 /**

--- a/lib/composio/formatConnectorName.ts
+++ b/lib/composio/formatConnectorName.ts
@@ -12,6 +12,8 @@ const CONNECTOR_DISPLAY_NAMES: Record<string, string> = {
   tiktok: "TikTok",
   instagram: "Instagram",
   youtube: "YouTube",
+  twitter: "X (Twitter)",
+  linkedin: "LinkedIn",
 };
 
 export function formatConnectorName(name: string, slug?: string): string {

--- a/lib/composio/getConnectorIcon.tsx
+++ b/lib/composio/getConnectorIcon.tsx
@@ -4,8 +4,11 @@ import {
   SiGoogledocs,
   SiTiktok,
   SiInstagram,
+  SiYoutube,
+  SiX,
 } from "@icons-pack/react-simple-icons";
-import { Link2 } from "lucide-react";
+// LinkedIn was removed from Simple Icons on brand request, so use Lucide's glyph.
+import { Link2, Linkedin } from "lucide-react";
 
 /**
  * Get branded icon for a connector.
@@ -20,6 +23,9 @@ export function getConnectorIcon(slug: string, size = 24): React.ReactNode {
     googledocs: <SiGoogledocs {...iconProps} color="#4285F4" />,
     tiktok: <SiTiktok {...iconProps} />,
     instagram: <SiInstagram {...iconProps} color="#E4405F" />,
+    youtube: <SiYoutube {...iconProps} color="#FF0000" />,
+    twitter: <SiX {...iconProps} />,
+    linkedin: <Linkedin {...iconProps} color="#0A66C2" />,
   };
 
   return (


### PR DESCRIPTION
## What

Mirrors the api change on the frontend: adds `twitter` to `ALLOWED_ARTIST_CONNECTORS` (`lib/composio/allowedArtistConnectors.ts`) so **X (Twitter)** shows in the artist-settings Connectors tab. **LinkedIn stays excluded** (label/owner-only).

This is the chat half of the "artist-vs-label availability" point in `recoupable/chat#1793`. The api half is recoupable/api#680.

## ⚠️ Merge gate

Per the issue, **confirm the artist-vs-label split with Patrick before merging** (X for artists, LinkedIn label-only). Keep this and api#680 consistent.

## TDD

- New `lib/composio/__tests__/allowedArtistConnectors.test.ts` asserts `twitter` included, `linkedin` excluded; RED before GREEN.
- `eslint` clean. Consumer (`ArtistConnectorsTab.tsx`) just spreads the list — no type breakage.

## Merge order

docs#244 → api#679 (whitelist) → api#680 + **this PR** (artist availability).

Tracking issue: recoupable/chat#1793

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows X (Twitter) and LinkedIn in the artist Connectors tab by adding `twitter` and `linkedin` to `ALLOWED_ARTIST_CONNECTORS`, and adds branded icons, clean names, and real descriptions for X, LinkedIn, and YouTube. Clarifies that chat is the source of truth—API `GET /api/connectors` returns all connectors and the frontend filters them—fulfilling chat#1793.

<sup>Written for commit e83ac2345cacf34e4369ba5c39a5a1052796cd93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1805?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

