### PR TITLE
fix: point prod API base to api.recoupable.dev (domain cutover)

### DIFF
--- a/lib/consts.ts
+++ b/lib/consts.ts
@@ -2,7 +2,7 @@ import { Address } from "viem";
 
 export const IS_PROD = process.env.NEXT_PUBLIC_VERCEL_ENV === "production";
 export const NEW_API_BASE_URL = IS_PROD
-  ? "https://api.recoupable.com"
+  ? "https://api.recoupable.dev"
   : "https://test-recoup-api.vercel.app";
 export const API_OVERRIDE_STORAGE_KEY = "recoup_api_override";
 export const ACCOUNT_OVERRIDE_STORAGE_KEY = "recoup_account_override";


### PR DESCRIPTION
## What

One-line change in `lib/consts.ts`: the production branch of `NEW_API_BASE_URL` `https://api.recoupable.com` → `https://api.recoupable.dev`. Non-prod base (`test-recoup-api.vercel.app`) unchanged.

## Why

Part of the `recoupable.com` → `.dev` domain cutover ([#1819](https://github.com/recoupable/chat/issues/1819), item 3). `api.recoupable.com` was retired with the `.com` apex and no longer resolves, so every client API call from the live `chat.recoupable.dev` failed:

```
GET https://api.recoupable.com/api/ai/models → net::ERR_NAME_NOT_RESOLVED
```

(model selector stuck on default, etc.). The new `api.recoupable.dev` custom domain is already live — `GET /api/ai/models` returns 200 — so this is a host swap.

## Verification

- `pnpm exec vitest run` on the suites that consume `NEW_API_BASE_URL` (`lib/chat`, `lib/composio`, `lib/tasks`, `lib/api`): **41 passed / 11 files**. Tests build their expected URLs from the constant and run with `IS_PROD=false`, so they're unaffected by the prod-only literal.
- `tsc --noEmit`: no errors implicating `consts.ts` (the only failing file, `lib/emails/__tests__/extractSendEmailResults.test.ts`, is pre-existing `UIMessage` type drift from the in-flight ai-sdk upgrade on `main`, unrelated to this change).
- Will confirm on the Vercel preview that `/api/ai/models` resolves 200 and the model selector populates.

## Merge note

Targets `test` per repo flow. No docs/contract change (host swap only), so no docs PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the production value of `NEW_API_BASE_URL` from `https://api.recoupable.com` to `https://api.recoupable.dev` to complete the domain cutover and fix failed requests from `chat.recoupable.dev` (e.g., `/api/ai/models`). Non-prod base stays `https://test-recoup-api.vercel.app`.

<sup>Written for commit 69d9045e2276832be6d052ef922390fb9ae23c3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

