### PR TITLE
fix: repoint dead .com hosts to live .dev (#1819 §A+§B)

### DIFF
--- a/app/docs/account/constants.ts
+++ b/app/docs/account/constants.ts
@@ -1,5 +1,7 @@
+import { API_PUBLIC_BASE_URL } from "@/lib/consts";
+
 export const codeExamples = {
-  curl: `curl -X GET "https://api.recoupable.com/api/account" \\
+  curl: `curl -X GET "${API_PUBLIC_BASE_URL}/api/account" \\
   -H "Content-Type: application/json" \\
   -d '{"accountId": "YOUR_ACCOUNT_ID"}'`,
   python: `import requests
@@ -12,9 +14,9 @@ params = {
     "accountId": "YOUR_ACCOUNT_ID"
 }
 
-response = requests.get("https://api.recoupable.com/api/account", headers=headers, params=params)
+response = requests.get("${API_PUBLIC_BASE_URL}/api/account", headers=headers, params=params)
 data = response.json()`,
-  javascript: `fetch("https://api.recoupable.com/api/account?accountId=YOUR_ACCOUNT_ID", {
+  javascript: `fetch("${API_PUBLIC_BASE_URL}/api/account?accountId=YOUR_ACCOUNT_ID", {
   headers: {
     "Content-Type": "application/json"
   }
@@ -39,7 +41,7 @@ interface AccountSocialsResponse {
 }
 
 const fetchAccountSocials = async (accountId: string) => {
-  const response = await fetch(\`https://api.recoupable.com/api/account?accountId=\${accountId}\`, {
+  const response = await fetch(\`${API_PUBLIC_BASE_URL}/api/account?accountId=\${accountId}\`, {
     headers: {
       "Content-Type": "application/json"
     }

--- a/app/docs/fans/constants.ts
+++ b/app/docs/fans/constants.ts
@@ -1,5 +1,7 @@
+import { API_PUBLIC_BASE_URL } from "@/lib/consts";
+
 export const codeExamples = {
-  curl: `curl -X GET "https://api.recoupable.com/api/fans?artist_account_id=YOUR_ARTIST_ACCOUNT_ID&page=1&limit=20" \\
+  curl: `curl -X GET "${API_PUBLIC_BASE_URL}/api/fans?artist_account_id=YOUR_ARTIST_ACCOUNT_ID&page=1&limit=20" \\
   -H "Content-Type: application/json"`,
   python: `import requests
 
@@ -13,9 +15,9 @@ params = {
     "limit": 20
 }
 
-response = requests.get("https://api.recoupable.com/api/fans", headers=headers, params=params)
+response = requests.get("${API_PUBLIC_BASE_URL}/api/fans", headers=headers, params=params)
 data = response.json()`,
-  javascript: `fetch("https://api.recoupable.com/api/fans?artist_account_id=YOUR_ARTIST_ACCOUNT_ID&page=1&limit=20", {
+  javascript: `fetch("${API_PUBLIC_BASE_URL}/api/fans?artist_account_id=YOUR_ARTIST_ACCOUNT_ID&page=1&limit=20", {
   headers: {
     "Content-Type": "application/json"
   }
@@ -51,7 +53,7 @@ const fetchArtistFans = async (
   limit: number = 20
 ) => {
   const response = await fetch(
-    \`https://api.recoupable.com/api/fans?artist_account_id=\${artistAccountId}&page=\${page}&limit=\${limit}\`, 
+    \`${API_PUBLIC_BASE_URL}/api/fans?artist_account_id=\${artistAccountId}&page=\${page}&limit=\${limit}\`, 
     {
       headers: {
         "Content-Type": "application/json"

--- a/app/docs/fans/page.tsx
+++ b/app/docs/fans/page.tsx
@@ -30,7 +30,7 @@ export default function FansDocs() {
         <div className="mb-6">
           <h3 className="text-lg md:text-xl font-semibold mb-2">Endpoint</h3>
           <code className="block bg-gray-100 p-2 md:p-4 rounded text-sm md:text-base break-all">
-            GET https://api.recoupable.com/api/fans
+            GET https://api.recoupable.dev/api/fans
           </code>
         </div>
 

--- a/app/docs/posts/constants.ts
+++ b/app/docs/posts/constants.ts
@@ -1,5 +1,7 @@
+import { API_PUBLIC_BASE_URL } from "@/lib/consts";
+
 export const codeExamples = {
-  curl: `curl -X GET "https://api.recoupable.com/api/posts?artist_account_id=YOUR_ARTIST_ACCOUNT_ID&page=1&limit=20" \\
+  curl: `curl -X GET "${API_PUBLIC_BASE_URL}/api/posts?artist_account_id=YOUR_ARTIST_ACCOUNT_ID&page=1&limit=20" \\
   -H "Content-Type: application/json"`,
   python: `import requests
 
@@ -13,9 +15,9 @@ params = {
     "limit": 20
 }
 
-response = requests.get("https://api.recoupable.com/api/posts", headers=headers, params=params)
+response = requests.get("${API_PUBLIC_BASE_URL}/api/posts", headers=headers, params=params)
 data = response.json()`,
-  javascript: `fetch("https://api.recoupable.com/api/posts?artist_account_id=YOUR_ARTIST_ACCOUNT_ID&page=1&limit=20", {
+  javascript: `fetch("${API_PUBLIC_BASE_URL}/api/posts?artist_account_id=YOUR_ARTIST_ACCOUNT_ID&page=1&limit=20", {
   headers: {
     "Content-Type": "application/json"
   }
@@ -45,7 +47,7 @@ const fetchArtistPosts = async (
   limit: number = 20
 ) => {
   const response = await fetch(
-    \`https://api.recoupable.com/api/posts?artist_account_id=\${artistAccountId}&page=\${page}&limit=\${limit}\`, 
+    \`${API_PUBLIC_BASE_URL}/api/posts?artist_account_id=\${artistAccountId}&page=\${page}&limit=\${limit}\`, 
     {
       headers: {
         "Content-Type": "application/json"

--- a/app/docs/posts/page.tsx
+++ b/app/docs/posts/page.tsx
@@ -29,7 +29,7 @@ export default function PostsDocs() {
         <div className="mb-6">
           <h3 className="text-lg md:text-xl font-semibold mb-2">Endpoint</h3>
           <code className="block bg-gray-100 p-2 md:p-4 rounded text-sm md:text-base break-all">
-            GET https://api.recoupable.com/api/posts
+            GET https://api.recoupable.dev/api/posts
           </code>
         </div>
 

--- a/components/ApiKeyPage/ApiKeyManager.tsx
+++ b/components/ApiKeyPage/ApiKeyManager.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Key } from "lucide-react";
 import { ApiKeyForm } from "./ApiKeyForm";
 import { ApiKeyList } from "./ApiKeyList";
+import { DOCS_BASE_URL } from "@/lib/consts";
 
 interface ApiKeyManagerProps {
   className?: string;
@@ -20,7 +21,7 @@ export default function ApiKeyManager({ className }: ApiKeyManagerProps) {
         <CardDescription>
           Create an API key to access Recoup programmatically.{" "}
           <a
-            href="https://docs.recoupable.com"
+            href={DOCS_BASE_URL}
             className="text-blue-600 underline hover:text-blue-800"
             target="_blank"
             rel="noopener noreferrer"

--- a/components/Sidebar/UserProfileDropdown/ExternalLinksGroup.tsx
+++ b/components/Sidebar/UserProfileDropdown/ExternalLinksGroup.tsx
@@ -3,6 +3,7 @@ import {
   DropdownMenuGroup,
   DropdownMenuItem,
 } from "@/components/ui/dropdown-menu";
+import { DOCS_BASE_URL } from "@/lib/consts";
 
 const ExternalLinksGroup = () => (
   <DropdownMenuGroup>
@@ -14,7 +15,7 @@ const ExternalLinksGroup = () => (
       </a>
     </DropdownMenuItem>
     <DropdownMenuItem asChild className="cursor-pointer">
-      <a href="https://developers.recoupable.com" target="_blank" rel="noopener noreferrer">
+      <a href={DOCS_BASE_URL} target="_blank" rel="noopener noreferrer">
         <HelpCircle className="h-4 w-4" />
         Help & Docs
         <ExternalLink className="h-3 w-3 ml-auto text-muted-foreground" />

--- a/hooks/useElapsedMs.ts
+++ b/hooks/useElapsedMs.ts
@@ -6,7 +6,7 @@ import { useState, useEffect } from "react";
  * Returns a live elapsed duration (ms) counting up from a task's `startedAt`
  * timestamp. Stops ticking once `durationMs` becomes available (task finished).
  *
- * @see https://developers.recoupable.com/api-reference/tasks/runs#response-runs-items-started-at-one-of-0
+ * @see https://docs.recoupable.dev/api-reference/tasks/runs#response-runs-items-started-at-one-of-0
  */
 export function useElapsedMs(
   startedAt: string | null,

--- a/lib/chat/__tests__/getChatUrl.test.ts
+++ b/lib/chat/__tests__/getChatUrl.test.ts
@@ -4,7 +4,7 @@ import { getChatUrl } from "@/lib/chat/getChatUrl";
 describe("getChatUrl", () => {
   it("builds an absolute session-scoped chat URL", () => {
     expect(getChatUrl("sess-1", "chat-2")).toBe(
-      "https://chat.recoupable.com/sessions/sess-1/chats/chat-2",
+      "https://chat.recoupable.dev/sessions/sess-1/chats/chat-2",
     );
   });
 });

--- a/lib/chat/getChatUrl.ts
+++ b/lib/chat/getChatUrl.ts
@@ -1,5 +1,6 @@
 import { getChatPath } from "@/lib/chat/getChatPath";
+import { APP_BASE_URL } from "@/lib/consts";
 
 export function getChatUrl(sessionId: string, chatId: string): string {
-  return `https://chat.recoupable.com${getChatPath(sessionId, chatId)}`;
+  return `${APP_BASE_URL}${getChatPath(sessionId, chatId)}`;
 }

--- a/lib/chat/getConversations.tsx
+++ b/lib/chat/getConversations.tsx
@@ -42,7 +42,7 @@ const apiChatsResponseSchema = z.object({
  * boundary — a malformed row (missing/wrongly typed field) raises and
  * we fall back to `[]` rather than letting bad data flow into the UI.
  *
- * @see https://developers.recoupable.com/api-reference/chat/chats
+ * @see https://docs.recoupable.dev/api-reference/chat/chats
  */
 const getConversations = async (
   accessToken: string,

--- a/lib/consts.ts
+++ b/lib/consts.ts
@@ -4,6 +4,9 @@ export const IS_PROD = process.env.NEXT_PUBLIC_VERCEL_ENV === "production";
 export const NEW_API_BASE_URL = IS_PROD
   ? "https://api.recoupable.dev"
   : "https://test-recoup-api.vercel.app";
+export const APP_BASE_URL = "https://chat.recoupable.dev";
+export const DOCS_BASE_URL = "https://docs.recoupable.dev";
+export const API_PUBLIC_BASE_URL = "https://api.recoupable.dev";
 export const API_OVERRIDE_STORAGE_KEY = "recoup_api_override";
 export const ACCOUNT_OVERRIDE_STORAGE_KEY = "recoup_account_override";
 export const IN_PROCESS_PROTOCOL_ADDRESS = IS_PROD

--- a/lib/tasks/deleteTask.ts
+++ b/lib/tasks/deleteTask.ts
@@ -12,7 +12,7 @@ interface DeleteTaskResponse {
 /**
  * Deletes a task via the Recoup API.
  * Missing or empty token still issues a request; the API enforces auth.
- * @see https://docs.recoupable.com/tasks/delete
+ * @see https://docs.recoupable.dev/tasks/delete
  */
 export async function deleteTask(
   accessToken: string | null | undefined,

--- a/lib/tasks/getTasks.ts
+++ b/lib/tasks/getTasks.ts
@@ -24,7 +24,7 @@ export interface GetTasksResponse {
 
 /**
  * Fetches tasks from the Recoup API
- * @see https://docs.recoupable.com/tasks/get
+ * @see https://docs.recoupable.dev/tasks/get
  */
 export async function getTasks(
   accessToken: string,

--- a/lib/tasks/updateTask.ts
+++ b/lib/tasks/updateTask.ts
@@ -17,7 +17,7 @@ export interface UpdateTaskParams {
 
 /**
  * Updates an existing task via the Recoup API
- * @see https://docs.recoupable.com/tasks/update
+ * @see https://docs.recoupable.dev/tasks/update
  */
 export async function updateTask(
   accessToken: string,


### PR DESCRIPTION
Part of the recoupable.com -> .dev migration (tracking issue recoupable/chat#1819, sections A + B). Repoints dead `.com` hosts to their verified-live `.dev` equivalents and DRYs the URLs through shared constants.

## DRY constants added (`lib/consts.ts`)
- `APP_BASE_URL = "https://chat.recoupable.dev"` — public chat app origin
- `DOCS_BASE_URL = "https://docs.recoupable.dev"` — docs host
- `API_PUBLIC_BASE_URL = "https://api.recoupable.dev"` — canonical public API host for in-app doc examples

(`NEW_API_BASE_URL` already points at `api.recoupable.dev` on main.)

## Changes
- `lib/chat/getChatUrl.ts` — `chat.recoupable.com` -> `APP_BASE_URL`
- `components/ApiKeyPage/ApiKeyManager.tsx` — docs link -> `DOCS_BASE_URL`
- `components/Sidebar/UserProfileDropdown/ExternalLinksGroup.tsx` — `developers.recoupable.com` Help & Docs link -> `DOCS_BASE_URL`. Apex `recoupable.com` home link left intact (still live 200).
- `app/docs/{account,fans,posts}/constants.ts` — in-app API example snippets `api.recoupable.com/api/...` -> `api.recoupable.dev/...` via `API_PUBLIC_BASE_URL` interpolation in the template literals
- `app/docs/{fans,posts}/page.tsx` — endpoint `<code>` literals -> `api.recoupable.dev`
- JSDoc `@see` hosts -> `docs.recoupable.dev`: `lib/tasks/{deleteTask,getTasks,updateTask}.ts`, `hooks/useElapsedMs.ts`, `lib/chat/getConversations.tsx`
- `lib/chat/__tests__/getChatUrl.test.ts` — assertion updated to the new `.dev` origin (behavioral test for the changed function)

## Left untouched (out of scope)
- Apex `recoupable.com` / `www.recoupable.com` links and the `privacy`/`terms` redirects (all still live 200)
- `RECOUP_FROM_EMAIL` and any email addresses

## Gate results
- `pnpm exec tsc --noEmit`: only the pre-existing `lib/emails/__tests__/extractSendEmailResults.test.ts` UIMessage type-drift errors remain (unrelated). No new errors mention any touched file.
- `pnpm exec vitest run lib/chat`: 6 files, 19 tests passed
- `pnpm exec vitest run lib/tasks`: 7 files, 16 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repointed dead recoupable.com hosts to their live .dev equivalents and centralized URLs in shared constants to avoid drift. Apex recoupable.com links remain as-is.

- **Refactors**
  - Added `APP_BASE_URL`, `DOCS_BASE_URL`, `API_PUBLIC_BASE_URL` in `lib/consts.ts`.
  - `getChatUrl` now uses `APP_BASE_URL` (chat.recoupable.dev); updated test.
  - In-app docs and code examples now use `API_PUBLIC_BASE_URL` (api.recoupable.dev); endpoint labels updated.
  - Help & Docs links now use `DOCS_BASE_URL` (docs.recoupable.dev).
  - Updated JSDoc `@see` links to docs.recoupable.dev.

<sup>Written for commit 5d0016a8749c77de44da4d15b5b70a73649ae875. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

