### PR TITLE
fix: move apex recoupable.com → recoupable.dev (chat Website + legal redirects)

### DIFF
--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,7 +1,7 @@
 import { redirect } from "next/navigation";
 
 const PrivacyPage = () => {
-  redirect("https://www.recoupable.com/privacy-policy");
+  redirect("https://recoupable.dev/privacy-policy");
   return null; // Fallback render (unreachable)
 };
 

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,7 +1,7 @@
 import { redirect } from "next/navigation";
 
 const TermsPage = () => {
-  redirect("https://www.recoupable.com/terms-of-service");
+  redirect("https://recoupable.dev/terms-of-use");
   return null; // Fallback render (unreachable)
 };
 

--- a/components/Sidebar/UserProfileDropdown/ExternalLinksGroup.tsx
+++ b/components/Sidebar/UserProfileDropdown/ExternalLinksGroup.tsx
@@ -8,9 +8,9 @@ import { DOCS_BASE_URL } from "@/lib/consts";
 const ExternalLinksGroup = () => (
   <DropdownMenuGroup>
     <DropdownMenuItem asChild className="cursor-pointer">
-      <a href="https://recoupable.com" target="_blank" rel="noopener noreferrer">
+      <a href="https://recoupable.dev" target="_blank" rel="noopener noreferrer">
         <House className="h-4 w-4" />
-        recoupable.com
+        recoupable.dev
         <ExternalLink className="h-3 w-3 ml-auto text-muted-foreground" />
       </a>
     </DropdownMenuItem>


### PR DESCRIPTION
Part of the recoupable.com → recoupable.dev apex migration. Tracking issue: recoupable/chat#1819.

`recoupable.dev` is live (200). This PR is **mergeable** on its own — all targets are verified live.

## Changes
- **`components/Sidebar/UserProfileDropdown/ExternalLinksGroup.tsx`** — Website link `href` and visible label `recoupable.com` → `recoupable.dev`.
- **`app/privacy/page.tsx`** — redirect `https://www.recoupable.com/privacy-policy` → `https://recoupable.dev/privacy-policy` (verified 200).
- **`app/terms/page.tsx`** — redirect `https://www.recoupable.com/terms-of-service` → `https://recoupable.dev/terms-of-use`. Note the path changed from `terms-of-service` to `terms-of-use` (recoupable.dev/terms-of-service is 404; /terms-of-use is 200).

## Gate
`pnpm exec tsc --noEmit` — clean except the pre-existing `lib/emails/__tests__/extractSendEmailResults.test.ts` UIMessage `content` errors (unrelated to this change). No new errors in the touched files.

Refs recoupable/chat#1819

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the app to the new apex domain recoupable.dev. Updates the user menu link and legal redirects to point to live pages.

- **Migration**
  - User dropdown: Website href and label now recoupable.dev
  - /privacy → https://recoupable.dev/privacy-policy
  - /terms → https://recoupable.dev/terms-of-use (path changed from terms-of-service)

<sup>Written for commit 40ced00b1bf488e9ac7b41279c66aa355c1ff41f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1825?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated site links to point to the new `recoupable.dev` domain.
  * Redirects for the Privacy and Terms pages now go to the correct policy pages on the updated domain.
  * The user profile dropdown’s external link now opens the updated site address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->