### PR TITLE
HOLD MERGE — chat brand email → @recoupable.dev

### DIFF
--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -34,7 +34,7 @@ export default function GlobalError({ error, reset }: GlobalErrorProps) {
       <p className="text-sm text-gray-500">
         Still having trouble?{" "}
         <a
-          href="mailto:support@recoupable.com"
+          href="mailto:support@recoupable.dev"
           className="text-blue-600 hover:text-blue-700 underline"
         >
           Get help from our team

--- a/lib/consts.ts
+++ b/lib/consts.ts
@@ -15,7 +15,7 @@ export const IN_PROCESS_PROTOCOL_ADDRESS = IS_PROD
 export const PAYMASTER_URL = `https://api.developer.coinbase.com/rpc/v1/${
   IS_PROD ? "base" : "base-sepolia"
 }/${process.env.PAYMASTER_KEY}`;
-export const RECOUP_FROM_EMAIL = "Agent by Recoup <agent@recoupable.com>";
+export const RECOUP_FROM_EMAIL = "Agent by Recoup <agent@recoupable.dev>";
 
 // STACK EVENTS
 export const MESSAGE_SENT_EVENT = "message_sent";


### PR DESCRIPTION
## ⚠️ HOLD MERGE

**Do not merge until `recoupable.dev` is a verified sending domain in Resend.** `RECOUP_FROM_EMAIL` is the agent's outbound from-address — an unverified domain bounces every email. Per [#1819](https://github.com/recoupable/chat/issues/1819) decision (2026-06-29).

## What

- `lib/consts.ts` — `RECOUP_FROM_EMAIL` `agent@recoupable.com` → `agent@recoupable.dev`
- `app/global-error.tsx` — the "Get help from our team" support `mailto:` → `@recoupable.dev`

String-literal changes only. Apex (Website link + legal redirects) is a separate mergeable PR (#1825).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch outbound agent from-address and support email to @recoupable.dev. String-only change; no behavior impact.

- **Migration**
  - Hold merge until `recoupable.dev` is verified as a sending domain in Resend to avoid bounces (see #1819).

<sup>Written for commit c2a13e756fd4a485a3f00909bd5718312562c3e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1826?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

