### PR TITLE
fix(socials): key artist-social lists on social_id (not the dropped id)

### DIFF
--- a/app/docs/account/constants.ts
+++ b/app/docs/account/constants.ts
@@ -91,7 +91,7 @@ export const responseProperties = [
     description: "List of social media accounts associated with the account",
   },
   {
-    name: "socials[].id",
+    name: "socials[].social_id",
     type: "string",
     description: "Unique identifier for the social account",
   },

--- a/components/VercelChat/tools/ArtistSocial.tsx
+++ b/components/VercelChat/tools/ArtistSocial.tsx
@@ -12,7 +12,7 @@ export const ArtistSocial = ({ social }: { social: SocialType }) => {
 
   return (
     <Link
-      key={social.id}
+      key={social.social_id}
       href={`https://${social.profile_url}`}
       target="_blank"
       rel="noopener noreferrer"

--- a/components/VercelChat/tools/GetArtistSocialsResult.tsx
+++ b/components/VercelChat/tools/GetArtistSocialsResult.tsx
@@ -47,7 +47,7 @@ export default function GetArtistSocialsResult({
 
           <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
             {socials.map((social) => (
-              <ArtistSocial key={social.id} social={social} />
+              <ArtistSocial key={social.social_id} social={social} />
             ))}
           </div>
         </div>

--- a/types/Social.ts
+++ b/types/Social.ts
@@ -1,5 +1,6 @@
 export interface Social {
   id: string;
+  social_id: string;
   username: string;
   avatar: string | null;
   profile_url: string;


### PR DESCRIPTION
Part of recoupable/chat#1833 — companion to **recoupable/api#735** (which drops the dead `account_socials.id` from `/api/artists/{id}/socials`, keeping `social_id`). Base: `main`.

## Change
- `types/Social.ts`: add `social_id` (shared type — `id` kept for other consumers).
- `GetArtistSocialsResult.tsx` + `ArtistSocial.tsx`: React `key={social.id}` → `key={social.social_id}`.
- docs field name `socials[].id` → `socials[].social_id`.

Merge alongside/after api#735 (the api response then carries `social_id`, not `id`). `tsc` clean — no `Social` type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use social_id for React keys in artist social lists and add social_id to the Social type to match the API. Prevents key warnings/mismatches when `account_socials.id` is removed; pairs with recoupable/api#735.

- **Bug Fixes**
  - Use key={social.social_id} in GetArtistSocialsResult and ArtistSocial.
  - Add social_id to Social type (keep id for other consumers).
  - Update docs field name to socials[].social_id.

<sup>Written for commit a28647fa87a89729c7834d17c82567eb82591c4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

