### PR TITLE
docs: PRs target main; retire the test-branch PR flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,25 +10,17 @@ This file provides guidance to coding agents like Claude Code (claude.ai/code) a
 2. Push commits to the current feature branch
 3. **NEVER push directly to `main` or `test` branches** - always use feature branches and PRs
 4. Before pushing, verify the current branch is not `main` or `test`
-5. **Open PRs against the `test` branch**, not `main`
-6. After pushing, check if a PR exists for the branch. If not, create one with `gh pr create --base test`
+5. **Open PRs against `main`** (the `test` branch is retired as a PR target; never target it)
+6. After pushing, check if a PR exists for the branch. If not, create one with `gh pr create --base main`
 7. **After creating a PR, always wait for explicit user approval before merging.** Never merge PRs autonomously.
 
 ### Starting a New Task
 
-When starting a new task, **first sync the `test` branch with `main`**:
-
-```bash
-git checkout test && git pull origin test && git fetch origin main && git merge origin/main && git push origin test
-```
-
-Then checkout main, pull latest, and create your feature branch from there:
+Branch from the latest `main`:
 
 ```bash
 git checkout main && git pull origin main && git checkout -b <branch-name>
 ```
-
-The sync step is the **only** time you should push directly to `test`.
 
 ## Build Commands
 


### PR DESCRIPTION
## What

PRs in this repo now target `main`. The `test` branch is retired as a PR target; the sync-`test`-with-`main` task-start ritual is removed from the agent instructions.

## Why

Requested by @sweetmantech 2026-07-03 during recoupable/chat#1841: four PRs were opened against `test` because these instructions mandated it; the convention is now main-only. Sibling PRs update the other repos' instructions and the dev skills (recoupable/skills#68).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `main` the only PR target and retire the `test` branch. Removes the "sync test with main" step and updates PR creation commands in AGENTS.md.

- **Migration**
  - Open all PRs against `main`; never target `test`.
  - Branch from the latest `main`.
  - Use `gh pr create --base main`.

<sup>Written for commit 92f786a0b302f797d5172dccbfbad488e3e13b8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1843?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

