### PR TITLE
fix: gate ?q= auto-send on the provisioned sessionId (chat#1847)

### DIFF
--- a/hooks/useVercelChat.ts
+++ b/hooks/useVercelChat.ts
@@ -24,6 +24,7 @@ import { useDeleteTrailingMessages } from "./useDeleteTrailingMessages";
 import { getFileContents } from "@/lib/sandboxes/getFileContents";
 import getMimeFromPath from "@/lib/files/getMimeFromPath";
 import { getChatPath } from "@/lib/chat/getChatPath";
+import { shouldAutoSendInitialMessage } from "@/lib/chat/shouldAutoSendInitialMessage";
 import { usePersistSelectedModel } from "./usePersistSelectedModel";
 
 interface UseVercelChatProps {
@@ -107,7 +108,9 @@ export function useVercelChat({
   }, [input]);
 
   // Resolve selected sandbox files for mention context and file attachments.
-  const [mentionAttachments, setMentionAttachments] = useState<FileUIPart[]>([]);
+  const [mentionAttachments, setMentionAttachments] = useState<FileUIPart[]>(
+    [],
+  );
   const [mentionTextContext, setMentionTextContext] = useState("");
   const [isLoadingSignedUrls, setIsLoadingSignedUrls] = useState(false);
 
@@ -115,7 +118,8 @@ export function useVercelChat({
     let cancelled = false;
     const run = async () => {
       if (!selectedFileIds.length) {
-        if (!cancelled) setMentionAttachments((prev) => (prev.length ? [] : prev));
+        if (!cancelled)
+          setMentionAttachments((prev) => (prev.length ? [] : prev));
         if (!cancelled) setMentionTextContext((prev) => (prev ? "" : prev));
         if (!cancelled) setIsLoadingSignedUrls((prev) => (prev ? false : prev));
         return;
@@ -124,7 +128,8 @@ export function useVercelChat({
       const idSet = new Set(selectedFileIds);
       const selected = allArtistFiles.filter((f) => idSet.has(f.id));
       if (selected.length === 0) {
-        if (!cancelled) setMentionAttachments((prev) => (prev.length ? [] : prev));
+        if (!cancelled)
+          setMentionAttachments((prev) => (prev.length ? [] : prev));
         if (!cancelled) setMentionTextContext((prev) => (prev ? "" : prev));
         if (!cancelled) setIsLoadingSignedUrls((prev) => (prev ? false : prev));
         return;
@@ -176,11 +181,14 @@ export function useVercelChat({
 
         if (!cancelled) setMentionAttachments(nextAttachments);
         if (!cancelled)
-          setMentionTextContext(textBlocks.length ? textBlocks.join("\n\n") : "");
+          setMentionTextContext(
+            textBlocks.length ? textBlocks.join("\n\n") : "",
+          );
         if (!cancelled) setIsLoadingSignedUrls(false);
       } catch (e) {
         console.error(e);
-        if (!cancelled) setMentionAttachments((prev) => (prev.length ? [] : prev));
+        if (!cancelled)
+          setMentionAttachments((prev) => (prev.length ? [] : prev));
         if (!cancelled) setMentionTextContext((prev) => (prev ? "" : prev));
         if (!cancelled) setIsLoadingSignedUrls((prev) => (prev ? false : prev));
       }
@@ -377,19 +385,21 @@ export function useVercelChat({
   );
 
   useEffect(() => {
-    const isFullyLoggedIn = userId;
-    const isReady = status === "ready";
-    const hasMessages = messages.length > 1;
-    const hasInitialMessages = initialMessages && initialMessages.length > 0;
-    // Wait for authentication before sending initial message to avoid 401 errors
-    if (
-      !hasInitialMessages ||
-      !isReady ||
-      hasMessages ||
-      !isFullyLoggedIn ||
-      !authenticated
-    )
-      return;
+    // Gates mirror the manual Send button, including the provisioned
+    // sessionId — without it the transport POSTs /api/chat with no
+    // sessionId and 400s (chat#1847). The effect re-runs when the
+    // bootstrap lands, so the ?q= message queues instead of failing.
+    const mayAutoSend = shouldAutoSendInitialMessage({
+      hasInitialMessages: Boolean(
+        initialMessages && initialMessages.length > 0,
+      ),
+      status,
+      messagesLength: messages.length,
+      userId,
+      authenticated,
+      sessionId,
+    });
+    if (!mayAutoSend || !initialMessages) return;
     handleSendQueryMessages(initialMessages[0]);
   }, [
     initialMessages,
@@ -398,6 +408,7 @@ export function useVercelChat({
     handleSendQueryMessages,
     messages.length,
     authenticated,
+    sessionId,
   ]);
 
   return {

--- a/lib/chat/__tests__/shouldAutoSendInitialMessage.test.ts
+++ b/lib/chat/__tests__/shouldAutoSendInitialMessage.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { shouldAutoSendInitialMessage } from "@/lib/chat/shouldAutoSendInitialMessage";
+
+const ready = {
+  hasInitialMessages: true,
+  status: "ready",
+  messagesLength: 0,
+  userId: "acct-1",
+  authenticated: true,
+  sessionId: "sess-1",
+};
+
+describe("shouldAutoSendInitialMessage", () => {
+  it("sends when authenticated, ready, and the session is provisioned", () => {
+    expect(shouldAutoSendInitialMessage(ready)).toBe(true);
+  });
+
+  it("does NOT send while the bootstrap session is still provisioning (chat#1847)", () => {
+    expect(
+      shouldAutoSendInitialMessage({ ...ready, sessionId: undefined }),
+    ).toBe(false);
+  });
+
+  it("does not send without an initial message", () => {
+    expect(
+      shouldAutoSendInitialMessage({ ...ready, hasInitialMessages: false }),
+    ).toBe(false);
+  });
+
+  it("does not send while the chat transport is busy", () => {
+    expect(
+      shouldAutoSendInitialMessage({ ...ready, status: "streaming" }),
+    ).toBe(false);
+  });
+
+  it("does not re-send once the conversation has messages", () => {
+    expect(shouldAutoSendInitialMessage({ ...ready, messagesLength: 2 })).toBe(
+      false,
+    );
+  });
+
+  it("does not send before login completes", () => {
+    expect(shouldAutoSendInitialMessage({ ...ready, userId: undefined })).toBe(
+      false,
+    );
+    expect(
+      shouldAutoSendInitialMessage({ ...ready, authenticated: false }),
+    ).toBe(false);
+  });
+});

--- a/lib/chat/shouldAutoSendInitialMessage.ts
+++ b/lib/chat/shouldAutoSendInitialMessage.ts
@@ -1,0 +1,38 @@
+interface ShouldAutoSendInitialMessageParams {
+  hasInitialMessages: boolean;
+  /** useChat transport status — only "ready" may send. */
+  status: string;
+  messagesLength: number;
+  userId?: string;
+  authenticated: boolean;
+  /**
+   * Api-minted session id from the new-chat bootstrap (or the canonical
+   * route). Absent while provisioning — sending then would POST /api/chat
+   * without a sessionId and 400 (chat#1847): the ?q= auto-send used to
+   * race the bootstrap and lose, while the manual Send button was
+   * correctly gated on the same condition.
+   */
+  sessionId?: string;
+}
+
+/**
+ * Decides whether the ?q= deep-link initial message may auto-send.
+ * Mirrors the manual-send gates (auth + transport ready + nothing sent
+ * yet) and additionally requires the provisioned sessionId — the effect
+ * re-runs when it lands, so the message queues rather than failing.
+ */
+export function shouldAutoSendInitialMessage({
+  hasInitialMessages,
+  status,
+  messagesLength,
+  userId,
+  authenticated,
+  sessionId,
+}: ShouldAutoSendInitialMessageParams): boolean {
+  if (!hasInitialMessages) return false;
+  if (status !== "ready") return false;
+  if (messagesLength > 1) return false;
+  if (!userId || !authenticated) return false;
+  if (!sessionId) return false;
+  return true;
+}


### PR DESCRIPTION
Fixes [#1847](https://github.com/recoupable/chat/issues/1847) — customer-reported (2026-07-04): clicking any AGENTS card as a logged-in user showed the prefilled message, then "An error occurred, please try again!".

## Root cause

The `?q=` deep-link auto-send effect in `useVercelChat.ts` gated on `authenticated + useChat ready` but **not** on the new-chat bootstrap — it fired while `sessionId` was still `undefined`, so the transport POSTed `/api/chat` with no `sessionId` and the api validator 400'd (`missing_fields: ["sessionId"]`) → generic error toast. The manual Send button was already correctly gated on provisioning (#1747/#1767); the auto-send path skipped that gate and lost the race every time for logged-in users. Captured live in the issue: the failing `POST /api/chat` lands **before** `POST /api/sessions` returns.

## What

- `lib/chat/shouldAutoSendInitialMessage.ts` — the gate extracted as a pure function (SRP), mirroring the manual-send conditions **plus `sessionId`**.
- `hooks/useVercelChat.ts` — the auto-send effect uses it, with `sessionId` added to the dep array: when the bootstrap lands, the effect re-runs and the queued `?q=` message sends. No UX change beyond "it works" — the message simply waits for the workspace dot to go ready, same as manual send.

## Tests (TDD, RED→GREEN)

6-case unit suite for the gate: happy path, **provisioning race (the #1847 case)**, no initial message, busy transport (double-send guard), already-has-messages, pre-auth. Full repo suite **80 passed**; `tsc --noEmit` no new errors vs main (22 pre-existing); prettier clean.

## Verification

Preview verification (real login → `/chat?q=…` → assistant responds, `POST /api/chat` only after `POST /api/sessions`) to follow as a PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1847: the /chat?q= auto-send now waits for a provisioned sessionId, preventing 400s and the generic error toast for logged-in users. The initial message queues and sends once the new chat session is ready.

- Bug Fixes
  - Gate deep-link auto-send using a new `shouldAutoSendInitialMessage` check that mirrors manual-send and requires a valid `sessionId`.
  - Add `sessionId` to the effect dependencies so it re-runs after bootstrap; send occurs only when authenticated, status is ready, and no prior messages exist.

- Refactors
  - Extracted the gate into `lib/chat/shouldAutoSendInitialMessage` (pure function).
  - Added a 6-case unit test suite covering the provisioning race and related states.

<sup>Written for commit bbef98dcd7f8125807ee938ef9dd9953e2fbd462. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1848?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved auto-sending of deep-linked initial chat messages so they only send when the chat is ready and the session is available.
  * Added stricter checks to avoid sending messages in incomplete or unauthenticated chat states.

* **Bug Fixes**
  * Reduced cases where an initial message could send too early or when chat history already contains content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->