### PR TITLE
feat: prefill the input with the ?q= prompt while provisioning (chat#1848 follow-up)

### DIFF
--- a/hooks/useInitialMessageAutoSend.ts
+++ b/hooks/useInitialMessageAutoSend.ts
@@ -1,0 +1,84 @@
+import { useEffect, useRef } from "react";
+import type { UIMessage } from "ai";
+import { generateUUID } from "@/lib/generateUUID";
+import { getInitialMessageText } from "@/lib/chat/getInitialMessageText";
+import { shouldAutoSendInitialMessage } from "@/lib/chat/shouldAutoSendInitialMessage";
+
+interface UseInitialMessageAutoSendParams {
+  /** The ?q= deep-link message from /chat?q=… (AGENTS cards). */
+  initialMessages?: UIMessage[];
+  /** useChat transport status — only "ready" may send. */
+  status: string;
+  messagesLength: number;
+  userId?: string;
+  authenticated: boolean;
+  /** Api-minted session id; absent until the bootstrap provisions. */
+  sessionId?: string;
+  input: string;
+  setInput: (value: string) => void;
+  /** The programmatic send path (handleSendQueryMessages). */
+  send: (message: UIMessage) => void;
+}
+
+/**
+ * The whole ?q= deep-link behavior, self-contained so useVercelChat
+ * stays closed against changes here (OCP — this hook is the extension
+ * point, like useChatTransport / usePersistSelectedModel):
+ *
+ * 1. Prefills the input with the prompt immediately — instant feedback
+ *    that the AGENTS click landed while the workspace provisions.
+ * 2. Auto-fires once provisioning lands (chat#1847: sending earlier
+ *    POSTs /api/chat without a sessionId and 400s), sending whatever is
+ *    in the input at that moment — an edit made while waiting sends the
+ *    edited text, a cleared input sends nothing — exactly like
+ *    pressing Send. One-shot refs guard re-prefill and double-sends.
+ */
+export function useInitialMessageAutoSend({
+  initialMessages,
+  status,
+  messagesLength,
+  userId,
+  authenticated,
+  sessionId,
+  input,
+  setInput,
+  send,
+}: UseInitialMessageAutoSendParams): void {
+  const initialMessageText = getInitialMessageText(initialMessages);
+  const didPrefillRef = useRef(false);
+  const didAutoFireRef = useRef(false);
+
+  useEffect(() => {
+    if (!initialMessageText || didPrefillRef.current) return;
+    if (messagesLength > 0 || input) return;
+    didPrefillRef.current = true;
+    setInput(initialMessageText);
+  }, [initialMessageText, messagesLength, input, setInput]);
+
+  useEffect(() => {
+    const mayAutoSend = shouldAutoSendInitialMessage({
+      hasInitialMessages: Boolean(initialMessageText),
+      status,
+      messagesLength,
+      userId,
+      authenticated,
+      sessionId,
+    });
+    if (!mayAutoSend || didAutoFireRef.current) return;
+    didAutoFireRef.current = true;
+    const text = input.trim() ? input : "";
+    if (!text) return;
+    send({ id: generateUUID(), role: "user", parts: [{ type: "text", text }] });
+    setInput("");
+  }, [
+    initialMessageText,
+    status,
+    messagesLength,
+    userId,
+    authenticated,
+    sessionId,
+    input,
+    setInput,
+    send,
+  ]);
+}

--- a/hooks/useInitialMessageAutoSend.ts
+++ b/hooks/useInitialMessageAutoSend.ts
@@ -1,5 +1,7 @@
 import { useEffect, useRef } from "react";
 import type { UIMessage } from "ai";
+import { usePrivy } from "@privy-io/react-auth";
+import { useUserProvider } from "@/providers/UserProvder";
 import { generateUUID } from "@/lib/generateUUID";
 import { getInitialMessageText } from "@/lib/chat/getInitialMessageText";
 import { shouldAutoSendInitialMessage } from "@/lib/chat/shouldAutoSendInitialMessage";
@@ -10,8 +12,6 @@ interface UseInitialMessageAutoSendParams {
   /** useChat transport status — only "ready" may send. */
   status: string;
   messagesLength: number;
-  userId?: string;
-  authenticated: boolean;
   /** Api-minted session id; absent until the bootstrap provisions. */
   sessionId?: string;
   input: string;
@@ -23,7 +23,9 @@ interface UseInitialMessageAutoSendParams {
 /**
  * The whole ?q= deep-link behavior, self-contained so useVercelChat
  * stays closed against changes here (OCP — this hook is the extension
- * point, like useChatTransport / usePersistSelectedModel):
+ * point, like useChatTransport / usePersistSelectedModel). Auth state
+ * is sourced from usePrivy/useUserProvider directly; params carry only
+ * what is chat-instance-scoped.
  *
  * 1. Prefills the input with the prompt immediately — instant feedback
  *    that the AGENTS click landed while the workspace provisions.
@@ -37,13 +39,15 @@ export function useInitialMessageAutoSend({
   initialMessages,
   status,
   messagesLength,
-  userId,
-  authenticated,
   sessionId,
   input,
   setInput,
   send,
 }: UseInitialMessageAutoSendParams): void {
+  const { authenticated } = usePrivy();
+  const { userData } = useUserProvider();
+  const userId = userData?.account_id || userData?.id;
+
   const initialMessageText = getInitialMessageText(initialMessages);
   const didPrefillRef = useRef(false);
   const didAutoFireRef = useRef(false);

--- a/hooks/useVercelChat.ts
+++ b/hooks/useVercelChat.ts
@@ -25,6 +25,7 @@ import { getFileContents } from "@/lib/sandboxes/getFileContents";
 import getMimeFromPath from "@/lib/files/getMimeFromPath";
 import { getChatPath } from "@/lib/chat/getChatPath";
 import { shouldAutoSendInitialMessage } from "@/lib/chat/shouldAutoSendInitialMessage";
+import { getInitialMessageText } from "@/lib/chat/getInitialMessageText";
 import { usePersistSelectedModel } from "./usePersistSelectedModel";
 
 interface UseVercelChatProps {
@@ -384,31 +385,57 @@ export function useVercelChat({
     [silentlyUpdateUrl, sendMessage, chatRequestBody, getHeaders],
   );
 
+  const initialMessageText = getInitialMessageText(initialMessages);
+  const didPrefillInputRef = useRef(false);
+  const didAutoFireRef = useRef(false);
+
+  useEffect(() => {
+    // Prefill the input with the ?q= prompt so the click gives instant
+    // feedback while the workspace provisions — no dead space wondering
+    // whether it worked. Runs once, and never over an existing
+    // conversation or anything already typed.
+    if (!initialMessageText || didPrefillInputRef.current) return;
+    if (messages.length > 0 || input) return;
+    didPrefillInputRef.current = true;
+    setInput(initialMessageText);
+  }, [initialMessageText, messages.length, input, setInput]);
+
   useEffect(() => {
     // Gates mirror the manual Send button, including the provisioned
     // sessionId — without it the transport POSTs /api/chat with no
     // sessionId and 400s (chat#1847). The effect re-runs when the
     // bootstrap lands, so the ?q= message queues instead of failing.
     const mayAutoSend = shouldAutoSendInitialMessage({
-      hasInitialMessages: Boolean(
-        initialMessages && initialMessages.length > 0,
-      ),
+      hasInitialMessages: Boolean(initialMessageText),
       status,
       messagesLength: messages.length,
       userId,
       authenticated,
       sessionId,
     });
-    if (!mayAutoSend || !initialMessages) return;
-    handleSendQueryMessages(initialMessages[0]);
+    if (!mayAutoSend || didAutoFireRef.current) return;
+    didAutoFireRef.current = true;
+    // Fire whatever is in the input — the customer may have edited the
+    // prefilled prompt while waiting (send their version) or cleared it
+    // (they opted out; send nothing), exactly as if they pressed Send.
+    const text = input.trim() ? input : "";
+    if (!text) return;
+    handleSendQueryMessages({
+      id: generateUUID(),
+      role: "user",
+      parts: [{ type: "text", text }],
+    });
+    setInput("");
   }, [
-    initialMessages,
+    initialMessageText,
     status,
     userId,
     handleSendQueryMessages,
     messages.length,
     authenticated,
     sessionId,
+    input,
+    setInput,
   ]);
 
   return {

--- a/hooks/useVercelChat.ts
+++ b/hooks/useVercelChat.ts
@@ -24,8 +24,7 @@ import { useDeleteTrailingMessages } from "./useDeleteTrailingMessages";
 import { getFileContents } from "@/lib/sandboxes/getFileContents";
 import getMimeFromPath from "@/lib/files/getMimeFromPath";
 import { getChatPath } from "@/lib/chat/getChatPath";
-import { shouldAutoSendInitialMessage } from "@/lib/chat/shouldAutoSendInitialMessage";
-import { getInitialMessageText } from "@/lib/chat/getInitialMessageText";
+import { useInitialMessageAutoSend } from "./useInitialMessageAutoSend";
 import { usePersistSelectedModel } from "./usePersistSelectedModel";
 
 interface UseVercelChatProps {
@@ -385,58 +384,19 @@ export function useVercelChat({
     [silentlyUpdateUrl, sendMessage, chatRequestBody, getHeaders],
   );
 
-  const initialMessageText = getInitialMessageText(initialMessages);
-  const didPrefillInputRef = useRef(false);
-  const didAutoFireRef = useRef(false);
-
-  useEffect(() => {
-    // Prefill the input with the ?q= prompt so the click gives instant
-    // feedback while the workspace provisions — no dead space wondering
-    // whether it worked. Runs once, and never over an existing
-    // conversation or anything already typed.
-    if (!initialMessageText || didPrefillInputRef.current) return;
-    if (messages.length > 0 || input) return;
-    didPrefillInputRef.current = true;
-    setInput(initialMessageText);
-  }, [initialMessageText, messages.length, input, setInput]);
-
-  useEffect(() => {
-    // Gates mirror the manual Send button, including the provisioned
-    // sessionId — without it the transport POSTs /api/chat with no
-    // sessionId and 400s (chat#1847). The effect re-runs when the
-    // bootstrap lands, so the ?q= message queues instead of failing.
-    const mayAutoSend = shouldAutoSendInitialMessage({
-      hasInitialMessages: Boolean(initialMessageText),
-      status,
-      messagesLength: messages.length,
-      userId,
-      authenticated,
-      sessionId,
-    });
-    if (!mayAutoSend || didAutoFireRef.current) return;
-    didAutoFireRef.current = true;
-    // Fire whatever is in the input — the customer may have edited the
-    // prefilled prompt while waiting (send their version) or cleared it
-    // (they opted out; send nothing), exactly as if they pressed Send.
-    const text = input.trim() ? input : "";
-    if (!text) return;
-    handleSendQueryMessages({
-      id: generateUUID(),
-      role: "user",
-      parts: [{ type: "text", text }],
-    });
-    setInput("");
-  }, [
-    initialMessageText,
+  // The ?q= deep-link behavior (prefill + provisioning-gated auto-fire)
+  // lives entirely in this hook — extend it there, not here (chat#1847).
+  useInitialMessageAutoSend({
+    initialMessages,
     status,
+    messagesLength: messages.length,
     userId,
-    handleSendQueryMessages,
-    messages.length,
     authenticated,
     sessionId,
     input,
     setInput,
-  ]);
+    send: handleSendQueryMessages,
+  });
 
   return {
     // States

--- a/hooks/useVercelChat.ts
+++ b/hooks/useVercelChat.ts
@@ -390,8 +390,6 @@ export function useVercelChat({
     initialMessages,
     status,
     messagesLength: messages.length,
-    userId,
-    authenticated,
     sessionId,
     input,
     setInput,

--- a/lib/chat/__tests__/getInitialMessageText.test.ts
+++ b/lib/chat/__tests__/getInitialMessageText.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import type { UIMessage } from "ai";
+import { getInitialMessageText } from "@/lib/chat/getInitialMessageText";
+
+const message = (parts: UIMessage["parts"]): UIMessage[] => [
+  { id: "m1", role: "user", parts },
+];
+
+describe("getInitialMessageText", () => {
+  it("extracts the text of the first text part", () => {
+    expect(
+      getInitialMessageText(message([{ type: "text", text: "hello" }])),
+    ).toBe("hello");
+  });
+
+  it("skips non-text parts", () => {
+    expect(
+      getInitialMessageText(
+        message([
+          { type: "file", url: "https://x/y.png", mediaType: "image/png" },
+          { type: "text", text: "caption" },
+        ]),
+      ),
+    ).toBe("caption");
+  });
+
+  it("returns undefined when there is nothing to prefill", () => {
+    expect(getInitialMessageText(undefined)).toBeUndefined();
+    expect(getInitialMessageText([])).toBeUndefined();
+    expect(getInitialMessageText(message([]))).toBeUndefined();
+    expect(
+      getInitialMessageText(message([{ type: "text", text: "" }])),
+    ).toBeUndefined();
+  });
+});

--- a/lib/chat/getInitialMessageText.ts
+++ b/lib/chat/getInitialMessageText.ts
@@ -1,0 +1,17 @@
+import type { UIMessage } from "ai";
+
+/**
+ * Text of the first text part of a ?q= deep-link's initial message —
+ * used to prefill the chat input while the workspace provisions, so the
+ * click gives instant feedback instead of dead space (chat#1848
+ * follow-up). Undefined when there is nothing meaningful to prefill.
+ */
+export function getInitialMessageText(
+  initialMessages?: UIMessage[],
+): string | undefined {
+  const parts = initialMessages?.[0]?.parts ?? [];
+  for (const part of parts) {
+    if (part.type === "text" && part.text) return part.text;
+  }
+  return undefined;
+}


### PR DESCRIPTION
Follow-up to [#1848](https://github.com/recoupable/chat/pull/1848) / [#1847](https://github.com/recoupable/chat/issues/1847). The queued `?q=` send fixed the 400, but the provisioning wait became dead space — nothing on screen confirms the AGENTS click landed.

## What

- **Instant feedback**: the input is prefilled with the `?q=` prompt the moment the page renders (one-shot; never over an existing conversation or already-typed text).
- **Auto-fire on ready**: when the workspace provisions (same `shouldAutoSendInitialMessage` gate as #1848), the message fires **from the live input** — an edit made while waiting sends the edited text; a cleared input sends nothing (opt-out). Exactly the semantics of pressing Send yourself.
- One-shot ref guards double-sends; `lib/chat/getInitialMessageText.ts` extracted (SRP) with a 3-case unit suite (TDD RED→GREEN).

Full suite **83 passed**; tsc no new errors vs main; prettier clean.

## Verification

Preview verification (real login → prompt visible in the input during "Preparing your workspace" → auto-fires on ready → 200 + streamed response) to follow as a PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefills the chat input with the `?q=` prompt during provisioning and auto-sends it when the workspace is ready. This gives instant feedback, uses the live input on send (edits respected, cleared input sends nothing), and prevents double-sends.

- New Features
  - Prefill: On first render, set the input to the deep-link `?q=` text; never overwrites existing messages or typed text.
  - Auto-fire: When ready, send from the current input under `shouldAutoSendInitialMessage`; respects edits, skips if cleared; one-shot refs guard against double-sends.

- Refactors
  - Extracted `useInitialMessageAutoSend` to encapsulate prefill + auto-send; `useVercelChat` now composes it. Added `getInitialMessageText` (unit-tested) to read the first text part.
  - `useInitialMessageAutoSend` now sources auth state internally via `@privy-io/react-auth` and `useUserProvider`; hook params carry only chat-instance-scoped data.

<sup>Written for commit 1a4f98af0255f54de23a957a231ef25f2ba8677b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

