### PR TITLE
feat: homepage tasks module — recent runs + one-click starter task (Catalog HQ 2/3, chat#1850)

### DIFF
--- a/components/Chat/ChatGreeting.tsx
+++ b/components/Chat/ChatGreeting.tsx
@@ -2,13 +2,17 @@ import { useArtistProvider } from "@/providers/ArtistProvider";
 import ImageWithFallback from "@/components/ImageWithFallback";
 import ValuationHero from "@/components/Home/ValuationHero";
 import useHomeValuation from "@/hooks/useHomeValuation";
+import TasksModule from "@/components/Home/TasksModule";
 import { VALUATION_URL } from "@/lib/consts";
 
 /**
- * The empty chat's artist header (recoupable/chat#1850): the artist-scoped
- * catalog valuation hero when the account has measured data for the current
- * scope, otherwise the "Ask me about" greeting plus a CTA into the valuation
- * funnel. All context arrives via provider-backed hooks — no props beyond
+ * The empty chat's home header (recoupable/chat#1850), valuation first —
+ * it's the headline number customers arrive with from the marketing
+ * funnel: the artist-scoped catalog valuation hero when the account has
+ * measured data for the current scope, otherwise the "Ask me about"
+ * greeting plus a CTA into the valuation funnel; the "label at work"
+ * tasks module renders beneath it (self-hiding when it has nothing to
+ * show). All context arrives via provider-backed hooks — no props beyond
  * the fade flag the chat empty state already owned, so the chat component
  * needs no knowledge of what this header shows.
  */
@@ -24,13 +28,14 @@ export function ChatGreeting({ isVisible }: { isVisible: boolean }) {
 
   if (valuation.show) {
     return (
-      <div className={`mb-6 mt-4 py-3 ${fadeClass}`}>
+      <div className={`mb-6 mt-4 flex flex-col gap-4 py-3 ${fadeClass}`}>
         <ValuationHero
           artistName={valuation.artistName}
           artistImage={valuation.artistImage}
           valuation={valuation.valuation}
           measuredTrackCount={valuation.measuredTrackCount}
         />
+        <TasksModule />
       </div>
     );
   }
@@ -60,7 +65,7 @@ export function ChatGreeting({ isVisible }: { isVisible: boolean }) {
         )}
         {isArtistSelected ? artistName : "your roster"}
       </span>
-      <div className="mt-4">
+      <div className="mb-4 mt-4">
         <a
           href={VALUATION_URL}
           target="_blank"
@@ -69,6 +74,9 @@ export function ChatGreeting({ isVisible }: { isVisible: boolean }) {
         >
           Get a free catalog valuation &rarr;
         </a>
+      </div>
+      <div className="text-left text-sm font-normal tracking-normal">
+        <TasksModule />
       </div>
     </div>
   );

--- a/components/Home/HomePage.tsx
+++ b/components/Home/HomePage.tsx
@@ -2,7 +2,6 @@
 
 import { useMiniKit } from "@coinbase/onchainkit/minikit";
 import NewChatBootstrap from "../VercelChat/NewChatBootstrap";
-import TasksModule from "./TasksModule";
 import { useEffect } from "react";
 import { UIMessage } from "ai";
 
@@ -17,9 +16,6 @@ const HomePage = ({ initialMessages }: { initialMessages?: UIMessage[] }) => {
 
   return (
     <div className="flex flex-col size-full items-center">
-      <div className="flex w-full max-w-3xl flex-col gap-4 px-4 pt-6 empty:hidden md:px-0">
-        <TasksModule />
-      </div>
       <NewChatBootstrap initialMessages={initialMessages} />
     </div>
   );

--- a/components/Home/HomePage.tsx
+++ b/components/Home/HomePage.tsx
@@ -2,6 +2,7 @@
 
 import { useMiniKit } from "@coinbase/onchainkit/minikit";
 import NewChatBootstrap from "../VercelChat/NewChatBootstrap";
+import TasksModule from "./TasksModule";
 import { useEffect } from "react";
 import { UIMessage } from "ai";
 
@@ -16,6 +17,9 @@ const HomePage = ({ initialMessages }: { initialMessages?: UIMessage[] }) => {
 
   return (
     <div className="flex flex-col size-full items-center">
+      <div className="flex w-full max-w-3xl flex-col gap-4 px-4 pt-6 empty:hidden md:px-0">
+        <TasksModule />
+      </div>
       <NewChatBootstrap initialMessages={initialMessages} />
     </div>
   );

--- a/components/Home/HomeRunRow.tsx
+++ b/components/Home/HomeRunRow.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+import { cn } from "@/lib/utils";
+import type { TaskRunItem } from "@/lib/tasks/getTaskRuns";
+import { getTaskDisplayName } from "@/lib/tasks/getTaskDisplayName";
+import { getStatusColor } from "@/lib/tasks/getStatusColor";
+import { getStatusLabel } from "@/lib/tasks/getStatusLabel";
+import { formatTimestamp } from "@/lib/tasks/formatTimestamp";
+
+/**
+ * Compact task-run row for the homepage tasks module. Links to the
+ * existing run detail page. Per-run sent-email subjects are not exposed
+ * by `GET /api/tasks/runs` yet, so this shows what is available: run
+ * name, status, and finished-at (recoupable/chat#1850).
+ */
+const HomeRunRow = ({ run }: { run: TaskRunItem }) => (
+  <Link
+    href={`/tasks/${run.id}`}
+    className="group -mx-2 flex items-center justify-between gap-3 rounded-lg px-2 py-2.5 transition-colors hover:bg-muted"
+  >
+    <div className="min-w-0">
+      <p className="truncate text-sm font-medium text-foreground">
+        {getTaskDisplayName(run.taskIdentifier)}
+      </p>
+      <p className="text-xs text-muted-foreground">
+        {formatTimestamp(run.finishedAt ?? run.createdAt)}
+      </p>
+    </div>
+    <span
+      className={cn(
+        "shrink-0 rounded-full px-2 py-1 text-xs font-medium",
+        getStatusColor(run.status),
+      )}
+    >
+      {getStatusLabel(run.status)}
+    </span>
+  </Link>
+);
+
+export default HomeRunRow;

--- a/components/Home/StarterTaskCard.tsx
+++ b/components/Home/StarterTaskCard.tsx
@@ -4,21 +4,23 @@ import { useArtistProvider } from "@/providers/ArtistProvider";
 import { useCreateStarterTask } from "@/hooks/useCreateStarterTask";
 
 /**
- * Empty-state suggestion for the homepage tasks module: one click creates
- * the "Weekly valuation + streams report, Mondays" task via the existing
- * task-creation path (recoupable/chat#1850).
+ * Empty-state suggestion for the homepage tasks module: one click
+ * schedules an existing /agents Report template for the selected artist,
+ * Mondays at 9am, via the existing task-creation path
+ * (recoupable/chat#1850). Hidden when no Report template exists.
  */
 const StarterTaskCard = () => {
   const { selectedArtist } = useArtistProvider();
-  const { handleCreateStarterTask, isCreating, isScheduled } =
+  const { handleCreateStarterTask, isCreating, isScheduled, starterTemplate } =
     useCreateStarterTask();
   const artistName = selectedArtist?.name || "your artist";
+
+  if (!starterTemplate) return null;
 
   if (isScheduled) {
     return (
       <p className="text-sm text-muted-foreground" role="status">
-        Scheduled: weekly valuation + streams report for {artistName}, Mondays
-        at 9am.
+        Scheduled: {starterTemplate.title} for {artistName}, Mondays at 9am.
       </p>
     );
   }
@@ -27,10 +29,10 @@ const StarterTaskCard = () => {
     <div className="flex flex-col items-start justify-between gap-3 sm:flex-row sm:items-center">
       <div>
         <p className="text-sm font-medium text-foreground">
-          Weekly valuation + streams report for {artistName}, Mondays
+          {starterTemplate.title} for {artistName}, Mondays
         </p>
         <p className="text-xs text-muted-foreground">
-          Valuation, ranges, and stream deltas in your inbox every Monday.
+          {starterTemplate.description}
         </p>
       </div>
       <button

--- a/components/Home/StarterTaskCard.tsx
+++ b/components/Home/StarterTaskCard.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useArtistProvider } from "@/providers/ArtistProvider";
+import { useCreateStarterTask } from "@/hooks/useCreateStarterTask";
+
+/**
+ * Empty-state suggestion for the homepage tasks module: one click creates
+ * the "Weekly valuation + streams report, Mondays" task via the existing
+ * task-creation path (recoupable/chat#1850).
+ */
+const StarterTaskCard = () => {
+  const { selectedArtist } = useArtistProvider();
+  const { handleCreateStarterTask, isCreating, isScheduled } =
+    useCreateStarterTask();
+  const artistName = selectedArtist?.name || "your artist";
+
+  if (isScheduled) {
+    return (
+      <p className="text-sm text-muted-foreground" role="status">
+        Scheduled: weekly valuation + streams report for {artistName}, Mondays
+        at 9am.
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-start justify-between gap-3 sm:flex-row sm:items-center">
+      <div>
+        <p className="text-sm font-medium text-foreground">
+          Weekly valuation + streams report for {artistName}, Mondays
+        </p>
+        <p className="text-xs text-muted-foreground">
+          Valuation, ranges, and stream deltas in your inbox every Monday.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={() => handleCreateStarterTask()}
+        disabled={isCreating}
+        className="shrink-0 rounded-xl bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {isCreating ? "Scheduling..." : "Schedule it"}
+      </button>
+    </div>
+  );
+};
+
+export default StarterTaskCard;

--- a/components/Home/TasksModule.tsx
+++ b/components/Home/TasksModule.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import Link from "next/link";
+import { useArtistProvider } from "@/providers/ArtistProvider";
+import { useTaskRuns } from "@/hooks/useTaskRuns";
+import { getHomeTasksModuleState } from "@/lib/home/getHomeTasksModuleState";
+import HomeRunRow from "./HomeRunRow";
+import StarterTaskCard from "./StarterTaskCard";
+
+/**
+ * "Your label at work" homepage module: recent task runs (existing
+ * GET /api/tasks/runs) or the one-click starter suggestion for fresh
+ * accounts (recoupable/chat#1850). Renders nothing while loading or on
+ * failure so the homepage never blocks on it.
+ */
+const TasksModule = () => {
+  const { data: runs, isLoading, isError } = useTaskRuns();
+  const { selectedArtist } = useArtistProvider();
+
+  const state = getHomeTasksModuleState({
+    runs,
+    runsFailed: isError,
+    isLoading,
+    hasArtist: !!selectedArtist?.account_id,
+  });
+
+  if (state.view === "hidden") return null;
+
+  return (
+    <section
+      aria-label="Your label at work"
+      className="w-full rounded-xl bg-card p-6 shadow-[0px_0px_0px_1px_var(--border),0px_2px_4px_rgba(0,0,0,0.04)] dark:shadow-[0px_0px_0px_1px_var(--border),0px_2px_4px_rgba(0,0,0,0.2)]"
+    >
+      <div className="mb-3 flex items-center justify-between">
+        <h2 className="text-xs uppercase tracking-[0.05em] text-muted-foreground">
+          Your label at work
+        </h2>
+        <Link
+          href="/tasks"
+          className="text-xs font-medium text-foreground hover:underline"
+        >
+          View all
+        </Link>
+      </div>
+      {state.view === "runs" ? (
+        <div className="flex flex-col">
+          {state.runs.map((run) => (
+            <HomeRunRow key={run.id} run={run} />
+          ))}
+        </div>
+      ) : (
+        <StarterTaskCard />
+      )}
+    </section>
+  );
+};
+
+export default TasksModule;

--- a/hooks/useCreateStarterTask.ts
+++ b/hooks/useCreateStarterTask.ts
@@ -1,21 +1,35 @@
 "use client";
 
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { usePrivy } from "@privy-io/react-auth";
 import { toast } from "sonner";
 import { createStarterTask } from "@/lib/home/createStarterTask";
+import { findStarterTemplate } from "@/lib/home/findStarterTemplate";
+import fetchAgentTemplates from "@/lib/agent-templates/fetchAgentTemplates";
+import type { AgentTemplateRow } from "@/types/AgentTemplates";
 import { useArtistProvider } from "@/providers/ArtistProvider";
+import { useUserProvider } from "@/providers/UserProvder";
 
 /**
- * One-click creation of the homepage starter task ("Weekly valuation +
- * streams report, Mondays"). Mirrors `useCreateTask`: auth + artist come
- * from providers, the mutation goes through the existing `POST /api/tasks`
- * path which also mints the schedule.
+ * One-click creation of the homepage starter task. The task is sourced
+ * from an existing /agents template (DRY — findStarterTemplate picks it
+ * from the shared agent-templates query); auth + artist come from
+ * providers and the mutation goes through the existing `POST /api/tasks`
+ * path which also mints the schedule (recoupable/chat#1850).
  */
 export function useCreateStarterTask() {
   const { getAccessToken } = usePrivy();
   const { selectedArtist } = useArtistProvider();
+  const { userData } = useUserProvider();
   const queryClient = useQueryClient();
+
+  const { data: templates } = useQuery<AgentTemplateRow[]>({
+    queryKey: ["agent-templates"],
+    queryFn: () => fetchAgentTemplates(userData!),
+    retry: 1,
+    enabled: !!userData?.id,
+  });
+  const starterTemplate = findStarterTemplate(templates);
 
   const {
     mutate: handleCreateStarterTask,
@@ -28,11 +42,18 @@ export function useCreateStarterTask() {
       if (!artistAccountId || !artistName) {
         throw new Error("ARTIST_REQUIRED");
       }
+      if (!starterTemplate) {
+        throw new Error("TEMPLATE_REQUIRED");
+      }
       const accessToken = await getAccessToken();
       if (!accessToken) {
         throw new Error("AUTH_REQUIRED");
       }
-      return createStarterTask(accessToken, { artistName, artistAccountId });
+      return createStarterTask(accessToken, {
+        template: starterTemplate,
+        artistName,
+        artistAccountId,
+      });
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({
@@ -54,5 +75,5 @@ export function useCreateStarterTask() {
     },
   });
 
-  return { handleCreateStarterTask, isCreating, isScheduled };
+  return { handleCreateStarterTask, isCreating, isScheduled, starterTemplate };
 }

--- a/hooks/useCreateStarterTask.ts
+++ b/hooks/useCreateStarterTask.ts
@@ -1,0 +1,58 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { usePrivy } from "@privy-io/react-auth";
+import { toast } from "sonner";
+import { createStarterTask } from "@/lib/home/createStarterTask";
+import { useArtistProvider } from "@/providers/ArtistProvider";
+
+/**
+ * One-click creation of the homepage starter task ("Weekly valuation +
+ * streams report, Mondays"). Mirrors `useCreateTask`: auth + artist come
+ * from providers, the mutation goes through the existing `POST /api/tasks`
+ * path which also mints the schedule.
+ */
+export function useCreateStarterTask() {
+  const { getAccessToken } = usePrivy();
+  const { selectedArtist } = useArtistProvider();
+  const queryClient = useQueryClient();
+
+  const {
+    mutate: handleCreateStarterTask,
+    isPending: isCreating,
+    isSuccess: isScheduled,
+  } = useMutation({
+    mutationFn: async () => {
+      const artistAccountId = selectedArtist?.account_id;
+      const artistName = selectedArtist?.name;
+      if (!artistAccountId || !artistName) {
+        throw new Error("ARTIST_REQUIRED");
+      }
+      const accessToken = await getAccessToken();
+      if (!accessToken) {
+        throw new Error("AUTH_REQUIRED");
+      }
+      return createStarterTask(accessToken, { artistName, artistAccountId });
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ["scheduled-actions"],
+        exact: false,
+      });
+      toast.success("Task scheduled for Mondays at 9am");
+    },
+    onError: (error) => {
+      if (error instanceof Error && error.message === "ARTIST_REQUIRED") {
+        toast.error("Please select an artist first.");
+        return;
+      }
+      if (error instanceof Error && error.message === "AUTH_REQUIRED") {
+        toast.error("Please sign in to create a task.");
+        return;
+      }
+      toast.error("Failed to create the task. Please try again.");
+    },
+  });
+
+  return { handleCreateStarterTask, isCreating, isScheduled };
+}

--- a/lib/home/__tests__/buildStarterTaskParams.test.ts
+++ b/lib/home/__tests__/buildStarterTaskParams.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { buildStarterTaskParams } from "@/lib/home/buildStarterTaskParams";
+
+describe("buildStarterTaskParams", () => {
+  const params = buildStarterTaskParams({
+    artistName: "Del Water Gap",
+    artistAccountId: "artist-1",
+  });
+
+  it("titles the task after the artist", () => {
+    expect(params.title).toBe(
+      "Weekly valuation + streams report for Del Water Gap",
+    );
+  });
+
+  it("schedules Mondays", () => {
+    expect(params.schedule).toBe("0 9 * * 1");
+  });
+
+  it("targets the artist account", () => {
+    expect(params.artist_account_id).toBe("artist-1");
+  });
+
+  it("prompts for a valuation + streams report about the artist", () => {
+    expect(params.prompt).toContain("Del Water Gap");
+    expect(params.prompt.toLowerCase()).toContain("valuation");
+    expect(params.prompt.toLowerCase()).toContain("stream");
+  });
+});

--- a/lib/home/__tests__/buildStarterTaskParams.test.ts
+++ b/lib/home/__tests__/buildStarterTaskParams.test.ts
@@ -1,16 +1,34 @@
 import { describe, expect, it } from "vitest";
 import { buildStarterTaskParams } from "@/lib/home/buildStarterTaskParams";
+import type { AgentTemplateRow } from "@/types/AgentTemplates";
+
+const template = {
+  id: "9046c7e9-fd5a-4f08-a472-381d51bd6c90",
+  title: "Weekly Performance Dashboard",
+  description: "Weekly stats email",
+  prompt:
+    "Set up a weekly performance dashboard that emails me every Monday with my stats from all platforms.",
+  tags: ["Report"],
+  creator: null,
+  is_private: false,
+  created_at: null,
+  favorites_count: null,
+  updated_at: null,
+} as AgentTemplateRow;
 
 describe("buildStarterTaskParams", () => {
   const params = buildStarterTaskParams({
+    template,
     artistName: "Del Water Gap",
     artistAccountId: "artist-1",
   });
 
-  it("titles the task after the artist", () => {
-    expect(params.title).toBe(
-      "Weekly valuation + streams report for Del Water Gap",
-    );
+  it("titles the task after the template and the artist", () => {
+    expect(params.title).toBe("Weekly Performance Dashboard — Del Water Gap");
+  });
+
+  it("uses the agent template's prompt verbatim (DRY — no hand-written prompt)", () => {
+    expect(params.prompt).toBe(template.prompt);
   });
 
   it("schedules Mondays", () => {
@@ -19,11 +37,5 @@ describe("buildStarterTaskParams", () => {
 
   it("targets the artist account", () => {
     expect(params.artist_account_id).toBe("artist-1");
-  });
-
-  it("prompts for a valuation + streams report about the artist", () => {
-    expect(params.prompt).toContain("Del Water Gap");
-    expect(params.prompt.toLowerCase()).toContain("valuation");
-    expect(params.prompt.toLowerCase()).toContain("stream");
   });
 });

--- a/lib/home/__tests__/createStarterTask.test.ts
+++ b/lib/home/__tests__/createStarterTask.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createStarterTask } from "@/lib/home/createStarterTask";
+import { getClientApiBaseUrl } from "@/lib/api/getClientApiBaseUrl";
+import { DEFAULT_MODEL } from "@/lib/consts";
+
+vi.mock("@/lib/api/getClientApiBaseUrl", () => ({
+  getClientApiBaseUrl: vi.fn(),
+}));
+
+describe("createStarterTask", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getClientApiBaseUrl).mockReturnValue(
+      "https://api.recoupable.com",
+    );
+  });
+
+  it("POSTs the pre-wired weekly report task to /api/tasks", async () => {
+    const createdTask = { id: "task-1" };
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        status: "success",
+        tasks: [createdTask],
+      }),
+    }) as unknown as typeof fetch;
+
+    const result = await createStarterTask("test-token", {
+      artistName: "Del Water Gap",
+      artistAccountId: "artist-1",
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.recoupable.com/api/tasks",
+      expect.objectContaining({
+        method: "POST",
+        headers: {
+          Authorization: "Bearer test-token",
+          "Content-Type": "application/json",
+        },
+      }),
+    );
+    const init = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
+    const body = JSON.parse(String(init.body));
+    expect(body.title).toBe(
+      "Weekly valuation + streams report for Del Water Gap",
+    );
+    expect(body.schedule).toBe("0 9 * * 1");
+    expect(body.artist_account_id).toBe("artist-1");
+    expect(body.model).toBe(DEFAULT_MODEL);
+    expect(typeof body.prompt).toBe("string");
+    expect(result).toEqual(createdTask);
+  });
+
+  it("propagates API errors", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: vi.fn().mockResolvedValue("boom"),
+    }) as unknown as typeof fetch;
+
+    await expect(
+      createStarterTask("test-token", {
+        artistName: "Del Water Gap",
+        artistAccountId: "artist-1",
+      }),
+    ).rejects.toThrow("HTTP 500");
+  });
+});

--- a/lib/home/__tests__/createStarterTask.test.ts
+++ b/lib/home/__tests__/createStarterTask.test.ts
@@ -7,6 +7,20 @@ vi.mock("@/lib/api/getClientApiBaseUrl", () => ({
   getClientApiBaseUrl: vi.fn(),
 }));
 
+const starterTemplate = {
+  id: "9046c7e9-fd5a-4f08-a472-381d51bd6c90",
+  title: "Weekly Performance Dashboard",
+  description: "Weekly stats email",
+  prompt:
+    "Set up a weekly performance dashboard that emails me every Monday with my stats from all platforms.",
+  tags: ["Report"],
+  creator: null,
+  is_private: false,
+  created_at: null,
+  favorites_count: null,
+  updated_at: null,
+} as import("@/types/AgentTemplates").AgentTemplateRow;
+
 describe("createStarterTask", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -26,6 +40,7 @@ describe("createStarterTask", () => {
     }) as unknown as typeof fetch;
 
     const result = await createStarterTask("test-token", {
+      template: starterTemplate,
       artistName: "Del Water Gap",
       artistAccountId: "artist-1",
     });
@@ -42,13 +57,11 @@ describe("createStarterTask", () => {
     );
     const init = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
     const body = JSON.parse(String(init.body));
-    expect(body.title).toBe(
-      "Weekly valuation + streams report for Del Water Gap",
-    );
+    expect(body.title).toBe("Weekly Performance Dashboard — Del Water Gap");
     expect(body.schedule).toBe("0 9 * * 1");
     expect(body.artist_account_id).toBe("artist-1");
     expect(body.model).toBe(DEFAULT_MODEL);
-    expect(typeof body.prompt).toBe("string");
+    expect(body.prompt).toBe(starterTemplate.prompt);
     expect(result).toEqual(createdTask);
   });
 
@@ -61,6 +74,7 @@ describe("createStarterTask", () => {
 
     await expect(
       createStarterTask("test-token", {
+        template: starterTemplate,
         artistName: "Del Water Gap",
         artistAccountId: "artist-1",
       }),

--- a/lib/home/__tests__/findStarterTemplate.test.ts
+++ b/lib/home/__tests__/findStarterTemplate.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { findStarterTemplate } from "@/lib/home/findStarterTemplate";
+import type { AgentTemplateRow } from "@/types/AgentTemplates";
+
+const template = (over: Partial<AgentTemplateRow>): AgentTemplateRow =>
+  ({
+    id: "t-1",
+    title: "Some Agent",
+    description: "",
+    prompt: "do things",
+    tags: null,
+    creator: null,
+    is_private: false,
+    created_at: null,
+    favorites_count: null,
+    updated_at: null,
+    ...over,
+  }) as AgentTemplateRow;
+
+describe("findStarterTemplate", () => {
+  it("prefers the Weekly Performance Dashboard template", () => {
+    const templates = [
+      template({ id: "a", title: "Run Performance Report", tags: ["Report"] }),
+      template({
+        id: "b",
+        title: "Weekly Performance Dashboard",
+        tags: ["Report"],
+      }),
+    ];
+    expect(findStarterTemplate(templates)?.id).toBe("b");
+  });
+
+  it("falls back to the first Report-tagged template", () => {
+    const templates = [
+      template({ id: "a", title: "5 Viral Content Ideas", tags: ["Create"] }),
+      template({ id: "b", title: "YouTube Revenue Report", tags: ["Report"] }),
+    ];
+    expect(findStarterTemplate(templates)?.id).toBe("b");
+  });
+
+  it("returns undefined when no Report template exists", () => {
+    expect(
+      findStarterTemplate([template({ tags: ["Create"] })]),
+    ).toBeUndefined();
+    expect(findStarterTemplate([])).toBeUndefined();
+    expect(findStarterTemplate(undefined)).toBeUndefined();
+  });
+});

--- a/lib/home/__tests__/getHomeTasksModuleState.test.ts
+++ b/lib/home/__tests__/getHomeTasksModuleState.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { getHomeTasksModuleState } from "@/lib/home/getHomeTasksModuleState";
+import type { TaskRunItem } from "@/lib/tasks/getTaskRuns";
+
+const makeRun = (id: string): TaskRunItem => ({
+  id,
+  status: "COMPLETED",
+  taskIdentifier: "customer-prompt-task",
+  createdAt: "2026-07-06T09:00:00Z",
+  startedAt: "2026-07-06T09:00:01Z",
+  finishedAt: "2026-07-06T09:05:00Z",
+  durationMs: 299000,
+});
+
+describe("getHomeTasksModuleState", () => {
+  it("hides the module while runs are loading", () => {
+    expect(
+      getHomeTasksModuleState({
+        runs: undefined,
+        runsFailed: false,
+        isLoading: true,
+        hasArtist: true,
+      }),
+    ).toEqual({ view: "hidden" });
+  });
+
+  it("hides the module when the runs request failed", () => {
+    expect(
+      getHomeTasksModuleState({
+        runs: undefined,
+        runsFailed: true,
+        isLoading: false,
+        hasArtist: true,
+      }),
+    ).toEqual({ view: "hidden" });
+  });
+
+  it("shows recent runs when the account has task history", () => {
+    const runs = ["a", "b", "c"].map(makeRun);
+    expect(
+      getHomeTasksModuleState({
+        runs,
+        runsFailed: false,
+        isLoading: false,
+        hasArtist: true,
+      }),
+    ).toEqual({ view: "runs", runs });
+  });
+
+  it("caps the module at five runs", () => {
+    const runs = ["a", "b", "c", "d", "e", "f", "g"].map(makeRun);
+    const state = getHomeTasksModuleState({
+      runs,
+      runsFailed: false,
+      isLoading: false,
+      hasArtist: true,
+    });
+    expect(state).toEqual({ view: "runs", runs: runs.slice(0, 5) });
+  });
+
+  it("offers the starter task to a fresh account with an artist", () => {
+    expect(
+      getHomeTasksModuleState({
+        runs: [],
+        runsFailed: false,
+        isLoading: false,
+        hasArtist: true,
+      }),
+    ).toEqual({ view: "starter" });
+  });
+
+  it("hides the starter card when no artist is selected", () => {
+    expect(
+      getHomeTasksModuleState({
+        runs: [],
+        runsFailed: false,
+        isLoading: false,
+        hasArtist: false,
+      }),
+    ).toEqual({ view: "hidden" });
+  });
+});

--- a/lib/home/buildStarterTaskParams.ts
+++ b/lib/home/buildStarterTaskParams.ts
@@ -1,0 +1,28 @@
+import type { CreateTaskParams } from "@/lib/tasks/createTask";
+
+interface BuildStarterTaskParamsInput {
+  artistName: string;
+  artistAccountId: string;
+}
+
+/**
+ * The pre-wired one-click suggestion shown in the homepage tasks module's
+ * empty state: "Weekly valuation + streams report for {artist}, Mondays"
+ * (recoupable/chat#1850).
+ */
+export function buildStarterTaskParams({
+  artistName,
+  artistAccountId,
+}: BuildStarterTaskParamsInput): Omit<CreateTaskParams, "model"> {
+  return {
+    title: `Weekly valuation + streams report for ${artistName}`,
+    prompt:
+      `Write a weekly report email for ${artistName}. ` +
+      "Include the catalog's current estimated valuation with its range, " +
+      "how it changed since last week, and this week's streaming numbers " +
+      "for the top tracks with week-over-week deltas. Link every data " +
+      "source you cite and send the report by email.",
+    schedule: "0 9 * * 1",
+    artist_account_id: artistAccountId,
+  };
+}

--- a/lib/home/buildStarterTaskParams.ts
+++ b/lib/home/buildStarterTaskParams.ts
@@ -1,27 +1,26 @@
 import type { CreateTaskParams } from "@/lib/tasks/createTask";
+import type { AgentTemplateRow } from "@/types/AgentTemplates";
 
 interface BuildStarterTaskParamsInput {
+  template: AgentTemplateRow;
   artistName: string;
   artistAccountId: string;
 }
 
 /**
  * The pre-wired one-click suggestion shown in the homepage tasks module's
- * empty state: "Weekly valuation + streams report for {artist}, Mondays"
- * (recoupable/chat#1850).
+ * empty state (recoupable/chat#1850). The prompt is the chosen /agents
+ * template's prompt verbatim (DRY — see findStarterTemplate); only the
+ * title is personalized so the task list reads per-artist.
  */
 export function buildStarterTaskParams({
+  template,
   artistName,
   artistAccountId,
 }: BuildStarterTaskParamsInput): Omit<CreateTaskParams, "model"> {
   return {
-    title: `Weekly valuation + streams report for ${artistName}`,
-    prompt:
-      `Write a weekly report email for ${artistName}. ` +
-      "Include the catalog's current estimated valuation with its range, " +
-      "how it changed since last week, and this week's streaming numbers " +
-      "for the top tracks with week-over-week deltas. Link every data " +
-      "source you cite and send the report by email.",
+    title: `${template.title} — ${artistName}`,
+    prompt: template.prompt,
     schedule: "0 9 * * 1",
     artist_account_id: artistAccountId,
   };

--- a/lib/home/createStarterTask.ts
+++ b/lib/home/createStarterTask.ts
@@ -1,0 +1,23 @@
+import { createTask } from "@/lib/tasks/createTask";
+import type { Task } from "@/lib/tasks/getTasks";
+import { buildStarterTaskParams } from "@/lib/home/buildStarterTaskParams";
+import { DEFAULT_MODEL } from "@/lib/consts";
+
+interface CreateStarterTaskInput {
+  artistName: string;
+  artistAccountId: string;
+}
+
+/**
+ * Creates the homepage starter task through the existing task-creation
+ * path (`POST /api/tasks`, which also mints the schedule).
+ */
+export async function createStarterTask(
+  accessToken: string,
+  input: CreateStarterTaskInput,
+): Promise<Task> {
+  return createTask(accessToken, {
+    ...buildStarterTaskParams(input),
+    model: DEFAULT_MODEL,
+  });
+}

--- a/lib/home/createStarterTask.ts
+++ b/lib/home/createStarterTask.ts
@@ -1,16 +1,19 @@
 import { createTask } from "@/lib/tasks/createTask";
 import type { Task } from "@/lib/tasks/getTasks";
+import type { AgentTemplateRow } from "@/types/AgentTemplates";
 import { buildStarterTaskParams } from "@/lib/home/buildStarterTaskParams";
 import { DEFAULT_MODEL } from "@/lib/consts";
 
 interface CreateStarterTaskInput {
+  template: AgentTemplateRow;
   artistName: string;
   artistAccountId: string;
 }
 
 /**
  * Creates the homepage starter task through the existing task-creation
- * path (`POST /api/tasks`, which also mints the schedule).
+ * path (`POST /api/tasks`, which also mints the schedule). The task is
+ * built from an existing /agents template (DRY).
  */
 export async function createStarterTask(
   accessToken: string,

--- a/lib/home/findStarterTemplate.ts
+++ b/lib/home/findStarterTemplate.ts
@@ -1,0 +1,20 @@
+import type { AgentTemplateRow } from "@/types/AgentTemplates";
+
+const PREFERRED_TITLE = "Weekly Performance Dashboard";
+
+/**
+ * Picks the agent template behind the homepage starter task (DRY — the
+ * task's prompt comes from the existing /agents templates, never a
+ * hand-written string; recoupable/chat#1850 review). Prefers the weekly
+ * dashboard template, falls back to any Report-tagged agent, and returns
+ * undefined (card hidden) when none exist.
+ */
+export function findStarterTemplate(
+  templates: AgentTemplateRow[] | undefined,
+): AgentTemplateRow | undefined {
+  if (!templates?.length) return undefined;
+  return (
+    templates.find((t) => t.title === PREFERRED_TITLE) ??
+    templates.find((t) => (t.tags ?? []).includes("Report"))
+  );
+}

--- a/lib/home/getHomeTasksModuleState.ts
+++ b/lib/home/getHomeTasksModuleState.ts
@@ -1,0 +1,35 @@
+import type { TaskRunItem } from "@/lib/tasks/getTaskRuns";
+
+const MAX_HOME_RUNS = 5;
+
+interface GetHomeTasksModuleStateParams {
+  runs: TaskRunItem[] | undefined;
+  runsFailed: boolean;
+  isLoading: boolean;
+  hasArtist: boolean;
+}
+
+export type HomeTasksModuleState =
+  | { view: "hidden" }
+  | { view: "runs"; runs: TaskRunItem[] }
+  | { view: "starter" };
+
+/**
+ * Decides what the homepage tasks module renders: recent runs for accounts
+ * with task history, the one-click starter suggestion for fresh accounts
+ * with an artist, or nothing while loading / on failure so the homepage
+ * never blocks on this module (recoupable/chat#1850).
+ */
+export function getHomeTasksModuleState({
+  runs,
+  runsFailed,
+  isLoading,
+  hasArtist,
+}: GetHomeTasksModuleStateParams): HomeTasksModuleState {
+  if (isLoading || runsFailed || !runs) return { view: "hidden" };
+
+  if (runs.length > 0)
+    return { view: "runs", runs: runs.slice(0, MAX_HOME_RUNS) };
+
+  return hasArtist ? { view: "starter" } : { view: "hidden" };
+}


### PR DESCRIPTION
## What this does

Second PR of the Catalog HQ homepage stack (recoupable/chat#1850). Adds the **"Your label at work" tasks module** under the valuation hero:

- **Accounts with task history** see their most recent runs (capped at 5) from the existing `GET /api/tasks/runs` — run name, status pill, finished-at — each row linking to the existing `/tasks/{runId}` detail page.
- **Fresh accounts** (zero runs, artist selected) see one pre-wired suggestion card: *"Weekly valuation + streams report for {artist}, Mondays"*. One click creates the scheduled task via the existing `POST /api/tasks` path (which also mints the Trigger schedule), then the module shows it as scheduled.
- While loading or on any fetch failure the module renders nothing — home never blocks on it.

**Honest scope note on sent emails:** the issue asks for each run's sent email (subject + sent-at). No existing chat-consumable endpoint exposes per-run email subjects today — `GET /api/tasks/runs` returns `taskIdentifier/status/timestamps/metadata` only, and the email send log isn't surfaced through any `api.recoupable.dev` endpoint the chat app uses. Per the module's ONLY-existing-endpoints constraint, this PR shows what IS available (run name, status, finished-at). Surfacing email subjects needs an api-side addition (runs response or an email-log endpoint) — left open on #1850.

Uses only existing hooks/patterns: `useTaskRuns` (existing), new `useCreateStarterTask` mirroring `useCreateTask` (auth + artist from providers), pure `getHomeTasksModuleState` selector for the module's render decision.

## Tests (TDD — confirmed RED before implementing)

12 new unit tests, full suite 109 passed (31 files):
- `lib/home/__tests__/getHomeTasksModuleState.test.ts` — runs shown for accounts with history, capped at 5; starter card for fresh account with artist; hidden while loading / on failure / without artist (the Done-when).
- `lib/home/__tests__/createStarterTask.test.ts` — the one-click creation call fires `POST /api/tasks` with the exact payload (title, `0 9 * * 1` Monday schedule, artist_account_id, model); error propagation.
- `lib/home/__tests__/buildStarterTaskParams.test.ts` — starter task title/schedule/prompt contents.

`pnpm exec tsc --noEmit`: no new errors (same two pre-existing failures as on `main`). `eslint` + `prettier` clean on changed files.

## Screenshots

N/A (no preview screenshot in this PR; run/starter states verified via unit tests — see PR comment for preview verification).

## Stack

Part of a 3-PR stack for chat#1850 (merge in order, each PR only after its base):
1. #1852 `feat/home-valuation-hero` → base `main`
2. **this PR** `feat/home-tasks-module` → base `feat/home-valuation-hero`
3. `feat/home-command-bar` → base `feat/home-tasks-module`

When #1852 merges, this PR gets re-targeted to `main`.

Tracked in recoupable/chat#1850.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the "Your label at work" tasks module under the valuation hero to show recent task runs or let new users schedule a weekly report in one click. It now renders inside `ChatGreeting` and never blocks the page (chat#1850).

- **New Features**
  - Renders via `TasksModule` under `ValuationHero`/greeting in `ChatGreeting` (order: valuation → tasks → chat input); shows up to 5 recent runs (name, status, finished-at) from `GET /api/tasks/runs`; rows link to `/tasks/{runId}`, header to `/tasks`.
  - For fresh accounts with a selected artist, a starter card schedules a Monday 9am report in one click through `POST /api/tasks` and reflects the scheduled state.
  - Self-hides while loading, on fetch error, or when no artist is selected; email subjects are omitted until the API exposes them (chat#1850).

- **Refactors**
  - Starter task now pulls its prompt from `/agents` templates via the shared `agent-templates` query; `findStarterTemplate` prefers “Weekly Performance Dashboard,” falls back to any Report-tagged template, and hides the card when none exist. Only the title is personalized.

<sup>Written for commit 9e9095dadbc36d36ffdca0cb20e58e6724ce864f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a homepage tasks section showing recent task runs with status, time, and links to details.
  * Added an empty-state starter task card with a one-click schedule action when no runs are available.
* **Bug Fixes**
  * Improved homepage behavior so the tasks section hides when loading, unavailable, or empty.
  * Added clearer success and error feedback for starter task scheduling.
* **Style**
  * Adjusted homepage layout and spacing to fit the new tasks content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->