### PR TITLE
feat: prefer the Weekly valuation + streams report starter template

### DIFF
--- a/lib/home/__tests__/findStarterTemplate.test.ts
+++ b/lib/home/__tests__/findStarterTemplate.test.ts
@@ -18,7 +18,24 @@ const template = (over: Partial<AgentTemplateRow>): AgentTemplateRow =>
   }) as AgentTemplateRow;
 
 describe("findStarterTemplate", () => {
-  it("prefers the Weekly Performance Dashboard template", () => {
+  it("prefers the weekly valuation + streams template above all others", () => {
+    const templates = [
+      template({ id: "a", title: "Run Performance Report", tags: ["Report"] }),
+      template({
+        id: "b",
+        title: "Weekly Performance Dashboard",
+        tags: ["Report"],
+      }),
+      template({
+        id: "c",
+        title: "Weekly valuation + streams report",
+        tags: ["Report"],
+      }),
+    ];
+    expect(findStarterTemplate(templates)?.id).toBe("c");
+  });
+
+  it("falls back to the Weekly Performance Dashboard template", () => {
     const templates = [
       template({ id: "a", title: "Run Performance Report", tags: ["Report"] }),
       template({

--- a/lib/home/findStarterTemplate.ts
+++ b/lib/home/findStarterTemplate.ts
@@ -1,20 +1,25 @@
 import type { AgentTemplateRow } from "@/types/AgentTemplates";
 
-const PREFERRED_TITLE = "Weekly Performance Dashboard";
+/** Most-preferred first — the valuation report is the video's hero flow (chat#1850). */
+const PREFERRED_TITLES = [
+  "Weekly valuation + streams report",
+  "Weekly Performance Dashboard",
+];
 
 /**
  * Picks the agent template behind the homepage starter task (DRY — the
  * task's prompt comes from the existing /agents templates, never a
  * hand-written string; recoupable/chat#1850 review). Prefers the weekly
- * dashboard template, falls back to any Report-tagged agent, and returns
- * undefined (card hidden) when none exist.
+ * valuation report, then the weekly dashboard, falls back to any
+ * Report-tagged agent, and returns undefined (card hidden) when none exist.
  */
 export function findStarterTemplate(
   templates: AgentTemplateRow[] | undefined,
 ): AgentTemplateRow | undefined {
   if (!templates?.length) return undefined;
-  return (
-    templates.find((t) => t.title === PREFERRED_TITLE) ??
-    templates.find((t) => (t.tags ?? []).includes("Report"))
-  );
+  for (const title of PREFERRED_TITLES) {
+    const match = templates.find((t) => t.title === title);
+    if (match) return match;
+  }
+  return templates.find((t) => (t.tags ?? []).includes("Report"));
 }


### PR DESCRIPTION
Part of recoupable/chat#1850 (video/experience parity, item 3 — starter template includes valuation).

## What

- `lib/home/findStarterTemplate.ts`: the homepage starter task's preference chain is now **"Weekly valuation + streams report"** → **"Weekly Performance Dashboard"** → any `Report`-tagged template → hidden. The previously preferred dashboard template has no valuation in its prompt (platform stats only), so the starter task never matched the video's valuation-report flow.
- TDD: new preference test added RED first, then the implementation (4/4 tests in `lib/home/__tests__/findStarterTemplate.test.ts`).

## Template data (already live)

The new `/agents` template was created in production via `POST https://chat.recoupable.dev/api/agent-templates`:

- id `ad0a233b-5f6d-4b91-89a6-90a1a8ecfd94`, title "Weekly valuation + streams report", tags `["Report"]`, `is_private: false`
- Prompt asks for (a) current estimated catalog valuation with low–high range + week-over-week change, (b) top-track streaming numbers with week-over-week deltas, (c) every cited number linked to its source (house rule for task emails).
- Verified publicly listed via `GET /api/agent-templates`.

## Verification

- `pnpm vitest run` — 33 files / 127 tests pass
- `pnpm exec tsc --noEmit` — 8 errors, identical to the pre-existing main baseline (none in touched files)
- Pending: fresh-account live verification of the full starter flow is still blocked by the Privy test-app cap on preview deployments (known pending check from #1850).

## Siblings

Cross-repo valuation derivation guard (item 2 of #1850): recoupable/api#765 and recoupable/marketing#44 share a byte-identical golden fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the homepage starter task prefer the "Weekly valuation + streams report" template, with fallbacks to "Weekly Performance Dashboard" and then any "Report"-tagged template. Aligns the starter flow with the valuation report experience from recoupable/chat#1850 while keeping the card visible during rollout.

- **New Features**
  - Implemented new preference chain in `lib/home/findStarterTemplate.ts`.
  - Added tests for top preference and dashboard fallback in `lib/home/__tests__/findStarterTemplate.test.ts`.

<sup>Written for commit 33b29d69bd1dc2cb8ca28acfcb6657481ca9438f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1856?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


