### PR TITLE
fix: /catalogs/[catalogId] crash on null-metadata rows (null-safe artists + toggle default off)

### DIFF
--- a/components/VercelChat/tools/catalog/CatalogSongsResult.tsx
+++ b/components/VercelChat/tools/catalog/CatalogSongsResult.tsx
@@ -44,7 +44,9 @@ export default function CatalogSongsResult({
       ? (uploadProgress.current / uploadProgress.total) * 100
       : 0;
 
-  const [hideIncomplete, setHideIncomplete] = useState(true);
+  // Default OFF so fresh valuation-claimed catalogs (rows with null metadata)
+  // are visible instead of appearing empty (chat#1867)
+  const [hideIncomplete, setHideIncomplete] = useState(false);
 
   const filteredSongs = useMemo(() => {
     const songs = displayResult.songs || [];

--- a/lib/catalog/__tests__/formatArtists.test.ts
+++ b/lib/catalog/__tests__/formatArtists.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { formatArtists } from "@/lib/catalog/formatArtists";
+import { CatalogSongsResponse } from "@/lib/catalog/getCatalogSongs";
+
+type Artists = CatalogSongsResponse["songs"][0]["artists"];
+
+// The API's left join emits null entries for songs with no artist rows
+// (e.g. fresh valuation-claimed catalogs), so runtime data can contain
+// null elements and null names despite the declared type.
+const asArtists = (value: unknown): Artists => value as Artists;
+
+describe("formatArtists", () => {
+  it("returns em dash when artists is undefined", () => {
+    expect(formatArtists(asArtists(undefined))).toBe("—");
+  });
+
+  it("returns em dash when artists is empty", () => {
+    expect(formatArtists(asArtists([]))).toBe("—");
+  });
+
+  it("does not throw and returns em dash when artists contains only null", () => {
+    expect(() => formatArtists(asArtists([null]))).not.toThrow();
+    expect(formatArtists(asArtists([null]))).toBe("—");
+  });
+
+  it("returns em dash when every artist has a null or blank name", () => {
+    expect(
+      formatArtists(
+        asArtists([
+          { id: "1", name: null, timestamp: "2026-01-01" },
+          { id: "2", name: "  ", timestamp: "2026-01-01" },
+        ]),
+      ),
+    ).toBe("—");
+  });
+
+  it("skips null entries but keeps valid artist names", () => {
+    expect(
+      formatArtists(
+        asArtists([
+          null,
+          { id: "1", name: "Artist A", timestamp: "2026-01-01" },
+        ]),
+      ),
+    ).toBe("Artist A");
+  });
+
+  it("joins multiple valid artist names with a comma", () => {
+    expect(
+      formatArtists(
+        asArtists([
+          { id: "1", name: "Artist A", timestamp: "2026-01-01" },
+          { id: "2", name: "Artist B", timestamp: "2026-01-01" },
+        ]),
+      ),
+    ).toBe("Artist A, Artist B");
+  });
+});

--- a/lib/catalog/formatArtists.ts
+++ b/lib/catalog/formatArtists.ts
@@ -3,10 +3,16 @@ import { CatalogSongsResponse } from "./getCatalogSongs";
 /**
  * Formats an array of artists into a comma-separated string
  * Returns "—" if no artists exist
+ *
+ * The API's left join emits null entries for songs without artist rows
+ * (e.g. fresh valuation-claimed catalogs), so null elements and null
+ * names must be tolerated despite the declared type.
  */
 export const formatArtists = (
   artists: CatalogSongsResponse["songs"][0]["artists"],
 ): string => {
-  if (!artists || artists.length === 0) return "—";
-  return artists.map((artist) => artist.name).join(", ");
+  const names = (artists ?? [])
+    .map((artist) => artist?.name?.trim())
+    .filter((name): name is string => !!name);
+  return names.length > 0 ? names.join(", ") : "—";
 };


### PR DESCRIPTION
## What / Why

Fixes the `/catalogs/[catalogId]` crash on null-metadata rows tracked in #1867.

On chat.recoupable.dev/catalogs/{id}, toggling "Hide items with missing info" off crashed the page to the error boundary with `TypeError: Cannot read properties of null (reading 'name')`. The default-on toggle masked the crash and made fresh valuation-claimed catalogs (whose rows have null artist/album metadata) look empty.

## Root cause

`lib/catalog/formatArtists.ts:11` — `artists.map((artist) => artist.name)`. The API's left join emits null entries in the `artists` array for songs without artist rows, so `artist` can be `null` at runtime despite the declared type. `CatalogSongRow` renders every row through `formatArtists`, so a single null-metadata row crashed the whole list. Name/album/notes already had `|| "—"` fallbacks; the artists column was the only unsafe access in the render path.

## Changes

- `lib/catalog/formatArtists.ts` — skip null entries and blank names, fall back to an em dash placeholder ("—")
- `components/VercelChat/tools/catalog/CatalogSongsResult.tsx` — "Hide items with missing info" now defaults **OFF** so null-metadata rows render (safely) instead of the catalog appearing empty
- `lib/catalog/__tests__/formatArtists.test.ts` — new unit tests covering null elements, null/blank names, and the happy path

## Test evidence (TDD, RED → GREEN)

Test written first, run against unmodified `formatArtists`:

```
FAIL lib/catalog/__tests__/formatArtists.test.ts > formatArtists > skips null entries but keeps valid artist names
TypeError: Cannot read properties of null (reading 'name')
 ❯ lib/catalog/formatArtists.ts:11:41
Tests  3 failed | 3 passed (6)
```

This reproduces the exact production TypeError. After the fix:

```
lib/catalog: Test Files 3 passed (3), Tests 16 passed (16)
Full suite:  Test Files 34 passed (34), Tests 132 passed (132)
```

## Verification

- [x] `pnpm exec vitest run` — 34 files / 132 tests, all pass
- [x] `pnpm exec tsc --noEmit` — 8 pre-existing errors on `main` (in `lib/emails/__tests__/extractSendEmailResults.test.ts` and `SpotifyDeepResearchResult.tsx`), identical count with and without this change; no new errors introduced
- [x] `pnpm exec eslint` on touched files — clean; `pnpm exec prettier --check` on touched files — clean (repo `pnpm lint` / `next lint` is broken on this Next 16 setup independent of this change)
- [ ] Preview verification pending — not yet exercised on a Vercel preview deployment

## How to test on preview

1. Open the preview URL at `/catalogs/{catalogId}` for a catalog with null-metadata song rows (e.g. a fresh valuation-claimed catalog).
2. The page should load with all rows visible by default (toggle now defaults to "Showing all items"); rows with missing artist/album show "—" instead of crashing.
3. Toggle "Hide items with missing info" on and off — no error boundary; on hides incomplete rows, off shows them again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the /catalogs/[catalogId] crash when song rows have null artist metadata. Artists are now rendered safely, and the list shows all rows by default so fresh catalogs don’t look empty.

- **Bug Fixes**
  - Null-safe artist formatting: skip null entries and blank names; fallback to "—".
  - "Hide items with missing info" now defaults OFF to display rows with missing metadata.
  - Added unit tests for null elements, blank names, and normal cases.

<sup>Written for commit ab52d704003941c525a27422c3a3bd0cf3c18bd2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1868?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Incomplete songs now appear by default in newly claimed catalogs, including when metadata is unavailable.
  * Artist names are displayed more reliably when entries are missing, blank, or contain extra whitespace.
  * Catalogs with no usable artist names now show a placeholder instead of an empty value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->