### PR TITLE
feat(home): catalog awareness on the authenticated home — reframe toward catalog-is-home (chat#1867/#1881 item 1869-r)

### DIFF
--- a/components/Chat/ChatGreeting.tsx
+++ b/components/Chat/ChatGreeting.tsx
@@ -1,17 +1,18 @@
 import { useArtistProvider } from "@/providers/ArtistProvider";
 import ImageWithFallback from "@/components/ImageWithFallback";
 import ValuationHero from "@/components/Home/ValuationHero";
+import HomeCatalogCta from "@/components/Home/HomeCatalogCta";
 import useHomeValuation from "@/hooks/useHomeValuation";
 import TasksModule from "@/components/Home/TasksModule";
 import HomeSuggestedPrompts from "@/components/Home/HomeSuggestedPrompts";
-import { VALUATION_URL } from "@/lib/consts";
 
 /**
  * The empty chat's home header (recoupable/chat#1850), valuation first —
  * it's the headline number customers arrive with from the marketing
  * funnel: the artist-scoped catalog valuation hero when the account has
  * measured data for the current scope, otherwise the "Ask me about"
- * greeting plus a CTA into the valuation funnel; the "label at work"
+ * greeting plus either the claimed-catalog card (recoupable/chat#1867) or,
+ * with nothing claimed, a CTA into the valuation funnel; the "label at work"
  * tasks module and the suggested prompt chips render beneath it (each
  * self-hiding when it has nothing to show). All context arrives via provider-backed hooks — no props beyond
  * the fade flag the chat empty state already owned, so the chat component
@@ -67,16 +68,7 @@ export function ChatGreeting({ isVisible }: { isVisible: boolean }) {
         )}
         {isArtistSelected ? artistName : "your roster"}
       </span>
-      <div className="mb-4 mt-4">
-        <a
-          href={VALUATION_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="rounded-full bg-card px-4 py-2 text-sm font-normal text-muted-foreground shadow-[0px_0px_0px_1px_var(--border)] transition-colors hover:text-foreground"
-        >
-          Get a free catalog valuation &rarr;
-        </a>
-      </div>
+      <HomeCatalogCta />
       <div className="text-left text-sm font-normal tracking-normal">
         <TasksModule />
       </div>

--- a/components/Home/CatalogCard.tsx
+++ b/components/Home/CatalogCard.tsx
@@ -1,0 +1,59 @@
+import Link from "next/link";
+import { formatValuationAmount } from "@/lib/catalog/formatValuationAmount";
+import type { CatalogValuationBand } from "@/lib/catalog/getCatalogMeasurements";
+
+interface CatalogCardProps {
+  catalogId: string;
+  catalogName: string;
+  valuation: CatalogValuationBand | null;
+  measuredTrackCount: number | null;
+}
+
+/**
+ * Chat-home card for the account's claimed catalog (recoupable/chat#1867):
+ * replaces the circular marketing valuation link once a catalog exists,
+ * linking into the in-app catalog instead. Dollar figures render only when
+ * the measurements read was trustworthy; otherwise the card stays honest
+ * with name + link. Styling per DESIGN.md: shadow-as-border, achromatic
+ * chrome.
+ */
+const CatalogCard = ({
+  catalogId,
+  catalogName,
+  valuation,
+  measuredTrackCount,
+}: CatalogCardProps) => (
+  <Link
+    href={`/catalogs/${catalogId}`}
+    aria-label={`View your claimed catalog ${catalogName}`}
+    className="block w-full rounded-xl bg-card p-5 text-left shadow-[0px_0px_0px_1px_var(--border),0px_2px_4px_rgba(0,0,0,0.04)] transition-colors hover:bg-muted dark:shadow-[0px_0px_0px_1px_var(--border),0px_2px_4px_rgba(0,0,0,0.2)]"
+  >
+    <span className="text-xs uppercase tracking-[0.05em] text-muted-foreground">
+      Your claimed catalog
+    </span>
+    <p className="mt-1 font-heading text-lg font-semibold text-foreground">
+      {catalogName}
+    </p>
+    {valuation ? (
+      <>
+        <p className="mt-3 font-heading text-3xl font-semibold tracking-tight text-foreground tabular-nums">
+          {formatValuationAmount(valuation.mid)}
+        </p>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Range {formatValuationAmount(valuation.low)} to{" "}
+          {formatValuationAmount(valuation.high)}
+          {measuredTrackCount
+            ? ` · ${measuredTrackCount} ${
+                measuredTrackCount === 1 ? "track" : "tracks"
+              } measured`
+            : ""}
+        </p>
+      </>
+    ) : null}
+    <span className="mt-3 inline-block text-sm font-medium text-foreground">
+      View your catalog &rarr;
+    </span>
+  </Link>
+);
+
+export default CatalogCard;

--- a/components/Home/HomeCatalogCta.tsx
+++ b/components/Home/HomeCatalogCta.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import CatalogCard from "@/components/Home/CatalogCard";
+import useHomeCatalogCard from "@/hooks/useHomeCatalogCard";
+import { VALUATION_URL } from "@/lib/consts";
+
+/**
+ * The greeting's CTA slot (recoupable/chat#1867): a claimed catalog
+ * replaces the marketing valuation link — sending a signup back to the
+ * funnel they just completed is circular — otherwise the link into the
+ * valuation funnel stays as-is. Self-contained via provider-backed hooks
+ * so the greeting needs no knowledge of which variant renders.
+ */
+const HomeCatalogCta = () => {
+  const catalogCard = useHomeCatalogCard();
+
+  if (catalogCard.show) {
+    return (
+      <div className="mb-4 mt-4 text-left text-sm font-normal tracking-normal">
+        <CatalogCard
+          catalogId={catalogCard.catalogId}
+          catalogName={catalogCard.catalogName}
+          valuation={catalogCard.valuation}
+          measuredTrackCount={catalogCard.measuredTrackCount}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="mb-4 mt-4">
+      <a
+        href={VALUATION_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="rounded-full bg-card px-4 py-2 text-sm font-normal text-muted-foreground shadow-[0px_0px_0px_1px_var(--border)] transition-colors hover:text-foreground"
+      >
+        Get a free catalog valuation &rarr;
+      </a>
+    </div>
+  );
+};
+
+export default HomeCatalogCta;

--- a/components/Home/HomeSuggestedPrompts.tsx
+++ b/components/Home/HomeSuggestedPrompts.tsx
@@ -4,6 +4,7 @@ import { useVercelChatContext } from "@/providers/VercelChatProvider";
 import { useArtistProvider } from "@/providers/ArtistProvider";
 import useHomeValuation from "@/hooks/useHomeValuation";
 import useHomeTasksModuleState from "@/hooks/useHomeTasksModuleState";
+import useCatalogs from "@/hooks/useCatalogs";
 import { getHomeSuggestedPrompts } from "@/lib/home/getHomeSuggestedPrompts";
 
 /**
@@ -19,11 +20,13 @@ const HomeSuggestedPrompts = () => {
   const { selectedArtist } = useArtistProvider();
   const valuation = useHomeValuation();
   const tasksState = useHomeTasksModuleState();
+  const { data: catalogsData } = useCatalogs();
 
   const prompts = getHomeSuggestedPrompts({
     hasValuation: valuation.show,
     hasRuns: tasksState.view === "runs",
     artistName: selectedArtist?.name || "",
+    catalogName: catalogsData?.catalogs?.[0]?.name || "",
   });
 
   if (prompts.length === 0) return null;

--- a/hooks/useHomeCatalogCard.ts
+++ b/hooks/useHomeCatalogCard.ts
@@ -1,0 +1,31 @@
+import useCatalogs from "@/hooks/useCatalogs";
+import useCatalogMeasurements from "@/hooks/useCatalogMeasurements";
+import {
+  getHomeCatalogCardState,
+  type HomeCatalogCardState,
+} from "@/lib/home/getHomeCatalogCardState";
+
+/**
+ * Composed hook behind the chat-home claimed-catalog card
+ * (recoupable/chat#1867). Reads the account's first claimed catalog and
+ * its whole-catalog measurement aggregates through the same provider-backed
+ * hooks the valuation hero uses (react-query dedupes by key), always
+ * unscoped: the card labels its numbers by catalog name, so no artist
+ * scope echo is involved. limit 1 keeps the read to the aggregates.
+ */
+const useHomeCatalogCard = (): HomeCatalogCardState => {
+  const { data: catalogsData, isError: catalogsFailed } = useCatalogs();
+  const catalog = catalogsData?.catalogs?.[0];
+
+  const { data: measurements, isError: measurementsFailed } =
+    useCatalogMeasurements(catalog?.id, undefined, 1);
+
+  return getHomeCatalogCardState({
+    catalog,
+    catalogsFailed,
+    measurements,
+    measurementsFailed,
+  });
+};
+
+export default useHomeCatalogCard;

--- a/lib/home/__tests__/getHomeCatalogCardState.test.ts
+++ b/lib/home/__tests__/getHomeCatalogCardState.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { getHomeCatalogCardState } from "@/lib/home/getHomeCatalogCardState";
+import type { Catalog } from "@/types/Catalog";
+import type { CatalogMeasurementsResponse } from "@/lib/catalog/getCatalogMeasurements";
+
+const catalog: Catalog = {
+  id: "cat-1",
+  name: "Del Water Gap Catalog",
+  created_at: "2026-07-20T00:00:00Z",
+  updated_at: "2026-07-20T00:00:00Z",
+};
+
+const measurements: CatalogMeasurementsResponse = {
+  status: "success",
+  measurements: [{ isrc: "USABC1234567", playcount: 1200000 }],
+  measured_song_count: 7,
+  valuation: { low: 7000, mid: 10000, high: 14000 },
+  artist_account_id: null,
+};
+
+describe("getHomeCatalogCardState", () => {
+  it("hides the card when the account has no claimed catalog", () => {
+    expect(
+      getHomeCatalogCardState({
+        catalog: undefined,
+        catalogsFailed: false,
+        measurements: undefined,
+        measurementsFailed: false,
+      }),
+    ).toEqual({ show: false });
+  });
+
+  it("hides the card when the catalogs read failed", () => {
+    expect(
+      getHomeCatalogCardState({
+        catalog,
+        catalogsFailed: true,
+        measurements,
+        measurementsFailed: false,
+      }),
+    ).toEqual({ show: false });
+  });
+
+  it("shows the claimed catalog with valuation when measurements are trustworthy", () => {
+    expect(
+      getHomeCatalogCardState({
+        catalog,
+        catalogsFailed: false,
+        measurements,
+        measurementsFailed: false,
+      }),
+    ).toEqual({
+      show: true,
+      catalogId: "cat-1",
+      catalogName: "Del Water Gap Catalog",
+      valuation: { low: 7000, mid: 10000, high: 14000 },
+      measuredTrackCount: 7,
+    });
+  });
+
+  it("shows the card without numbers when measurements failed", () => {
+    expect(
+      getHomeCatalogCardState({
+        catalog,
+        catalogsFailed: false,
+        measurements: undefined,
+        measurementsFailed: true,
+      }),
+    ).toEqual({
+      show: true,
+      catalogId: "cat-1",
+      catalogName: "Del Water Gap Catalog",
+      valuation: null,
+      measuredTrackCount: null,
+    });
+  });
+
+  it("omits numbers from a pre-v2 response missing the whole-scope aggregate", () => {
+    expect(
+      getHomeCatalogCardState({
+        catalog,
+        catalogsFailed: false,
+        measurements: {
+          ...measurements,
+          measured_song_count: undefined,
+          artist_account_id: undefined,
+        },
+        measurementsFailed: false,
+      }),
+    ).toEqual({
+      show: true,
+      catalogId: "cat-1",
+      catalogName: "Del Water Gap Catalog",
+      valuation: null,
+      measuredTrackCount: null,
+    });
+  });
+
+  it("omits numbers when nothing is measured yet", () => {
+    expect(
+      getHomeCatalogCardState({
+        catalog,
+        catalogsFailed: false,
+        measurements: { ...measurements, measured_song_count: 0 },
+        measurementsFailed: false,
+      }),
+    ).toEqual({
+      show: true,
+      catalogId: "cat-1",
+      catalogName: "Del Water Gap Catalog",
+      valuation: null,
+      measuredTrackCount: null,
+    });
+  });
+});

--- a/lib/home/__tests__/getHomeSuggestedPrompts.test.ts
+++ b/lib/home/__tests__/getHomeSuggestedPrompts.test.ts
@@ -7,6 +7,7 @@ describe("getHomeSuggestedPrompts", () => {
       hasValuation: true,
       hasRuns: true,
       artistName: "Del Water Gap",
+      catalogName: "",
     });
 
     expect(prompts.map((p) => p.label)).toEqual([
@@ -21,6 +22,7 @@ describe("getHomeSuggestedPrompts", () => {
       hasValuation: true,
       hasRuns: true,
       artistName: "Del Water Gap",
+      catalogName: "",
     });
     expect(prompts.length).toBeLessThanOrEqual(3);
   });
@@ -30,6 +32,7 @@ describe("getHomeSuggestedPrompts", () => {
       hasValuation: false,
       hasRuns: false,
       artistName: "Del Water Gap",
+      catalogName: "",
     });
 
     expect(prompts.map((p) => p.label)).toEqual([
@@ -38,11 +41,39 @@ describe("getHomeSuggestedPrompts", () => {
     ]);
   });
 
+  it("anchors the catalog-value prompt to the claimed catalog when one exists", () => {
+    const prompts = getHomeSuggestedPrompts({
+      hasValuation: false,
+      hasRuns: false,
+      artistName: "Del Water Gap",
+      catalogName: "Del Water Gap Catalog",
+    });
+
+    const chip = prompts.find((p) => p.label === "What's my catalog worth?");
+    expect(chip).toBeDefined();
+    expect(chip?.prompt).toContain('"Del Water Gap Catalog"');
+    expect(chip?.prompt).toMatch(/songs already in my Recoup catalog/i);
+  });
+
+  it("keeps the generic estimate prompt when no catalog is claimed", () => {
+    const prompts = getHomeSuggestedPrompts({
+      hasValuation: false,
+      hasRuns: false,
+      artistName: "Del Water Gap",
+      catalogName: "",
+    });
+
+    const chip = prompts.find((p) => p.label === "What's my catalog worth?");
+    expect(chip?.prompt).toContain("Del Water Gap");
+    expect(chip?.prompt).toContain("public streaming data");
+  });
+
   it("omits the artist chip when no artist is selected", () => {
     const prompts = getHomeSuggestedPrompts({
       hasValuation: true,
       hasRuns: false,
       artistName: "",
+      catalogName: "",
     });
 
     expect(prompts.map((p) => p.label)).toEqual([
@@ -55,6 +86,7 @@ describe("getHomeSuggestedPrompts", () => {
       hasValuation: true,
       hasRuns: true,
       artistName: "Del Water Gap",
+      catalogName: "",
     });
     for (const p of prompts) {
       expect(p.prompt.length).toBeGreaterThan(10);

--- a/lib/home/getHomeCatalogCardState.ts
+++ b/lib/home/getHomeCatalogCardState.ts
@@ -1,0 +1,57 @@
+import type {
+  CatalogMeasurementsResponse,
+  CatalogValuationBand,
+} from "@/lib/catalog/getCatalogMeasurements";
+import type { Catalog } from "@/types/Catalog";
+
+interface GetHomeCatalogCardStateParams {
+  catalog: Catalog | undefined;
+  catalogsFailed: boolean;
+  measurements: CatalogMeasurementsResponse | undefined;
+  measurementsFailed: boolean;
+}
+
+export type HomeCatalogCardState =
+  | { show: false }
+  | {
+      show: true;
+      catalogId: string;
+      catalogName: string;
+      valuation: CatalogValuationBand | null;
+      measuredTrackCount: number | null;
+    };
+
+/**
+ * Decides whether the chat-home fallback (no valuation hero) shows the
+ * account's claimed catalog instead of the circular marketing valuation
+ * link (recoupable/chat#1867). A claimed catalog always earns the card —
+ * it links into /catalogs/{id} — but the dollar figures only ride along
+ * when the whole-catalog measurements read is trustworthy: a present
+ * valuation band plus a nonzero whole-scope measured_song_count aggregate
+ * (absent on pre-v2 deployments, whose numbers come from a capped read and
+ * must not be shown). A failed or empty measurements read degrades to a
+ * name-only card, never back to the marketing link.
+ */
+export function getHomeCatalogCardState({
+  catalog,
+  catalogsFailed,
+  measurements,
+  measurementsFailed,
+}: GetHomeCatalogCardStateParams): HomeCatalogCardState {
+  if (catalogsFailed || !catalog) return { show: false };
+
+  const trustworthy =
+    !measurementsFailed &&
+    !!measurements?.valuation &&
+    !!measurements.measured_song_count;
+
+  return {
+    show: true,
+    catalogId: catalog.id,
+    catalogName: catalog.name,
+    valuation: trustworthy ? measurements.valuation : null,
+    measuredTrackCount: trustworthy
+      ? (measurements.measured_song_count ?? null)
+      : null,
+  };
+}

--- a/lib/home/getHomeSuggestedPrompts.ts
+++ b/lib/home/getHomeSuggestedPrompts.ts
@@ -7,6 +7,7 @@ interface GetHomeSuggestedPromptsParams {
   hasValuation: boolean;
   hasRuns: boolean;
   artistName: string;
+  catalogName: string;
 }
 
 const MAX_PROMPTS = 3;
@@ -20,6 +21,7 @@ export function getHomeSuggestedPrompts({
   hasValuation,
   hasRuns,
   artistName,
+  catalogName,
 }: GetHomeSuggestedPromptsParams): HomeSuggestedPrompt[] {
   const prompts: HomeSuggestedPrompt[] = [];
 
@@ -29,6 +31,18 @@ export function getHomeSuggestedPrompts({
       prompt:
         "Why did my catalog valuation change? Walk through the latest " +
         "measurements and explain what moved the estimate.",
+    });
+  } else if (catalogName) {
+    // The account already claimed a catalog: anchor the ask to that
+    // catalog's data so the model reaches for the catalog toolset instead
+    // of dead-ending on a generic estimate (recoupable/chat#1867).
+    prompts.push({
+      label: "What's my catalog worth?",
+      prompt:
+        `Estimate what my claimed catalog "${catalogName}" is worth. ` +
+        "Start from the songs already in my Recoup catalog, then use " +
+        "public streaming data, and tell me what's missing to tighten " +
+        "the estimate.",
     });
   } else {
     prompts.push({


### PR DESCRIPTION
> **Reframe + rebase (2026-07-22).** Base retargeted `test` → **`main`** (`test` was promoted in #1880 then retired) and the branch rebased onto latest `main` — the PR is no longer stuck on the dead `test` branch. Direction updated per the **2026-07-21 decision in #1867**: the catalog view should **be** the authenticated home (with persistent nav), not a card on the chat-first home. Scope + TODO below. Tracked as **item 1869-r** in #1881.

Part of #1867 ("Chat home catalog awareness + in-chat valuation handoff") and #1881 (onboarding v2).

## The 2026-07-21 reframe

Original direction (as-built here): add a claimed-catalog **card** into the chat-first home's greeting CTA slot. The 2026-07-21 decision in #1867 supersedes that framing — the **catalog view should be the primary authenticated landing surface**, with the persistent nav, rather than a card bolted onto a chat-first home.

The building blocks for that already exist on `main`:
- **Persistent nav** — `components/Sidebar` wraps every authenticated route via `app/layout.tsx`.
- **Catalog view** — `app/catalogs` (`CatalogsPage` → `CatalogsPageContent`) already renders a catalog-first surface inside that nav.

So "catalog-is-home" is mostly a **landing-surface routing decision** (what the authenticated `/` renders/redirects to), not net-new UI.

## What this PR currently contains (transitional foundation, kept non-regressive)

Rather than regress the home back to the circular marketing link while the landing redesign is specced, the rebased commit keeps the **catalog-awareness foundation** that's correct under either framing:

- `lib/home/getHomeCatalogCardState.ts` — pure selector (TDD): claimed catalog → name + trustworthy value band / measured tracks, degrading to name-only, never back to the marketing link.
- `hooks/useHomeCatalogCard.ts` — composed from the same provider-backed `useCatalogs` / `useCatalogMeasurements` hooks the valuation hero uses (react-query dedupes).
- `components/Home/CatalogCard.tsx`, `components/Home/HomeCatalogCta.tsx` — the card + CTA slot (DESIGN.md: shadow-as-border, achromatic chrome).
- `lib/home/getHomeSuggestedPrompts.ts` — the "What's my catalog worth?" chip anchors to the claimed catalog by name, routing the ask into the existing catalog toolset.

This kills the circular `recoupable.dev/valuation` CTA today; the selector/hook are reused by the catalog-is-home landing.

## TODO — catalog-is-home landing (the reframe's remaining scope)

Deferred out of this PR because it changes the core authenticated product surface and needs design sign-off + roster-gated browser verification:

- [ ] Decide the authenticated `/` behavior for accounts with a claimed catalog: render the catalog view at `/` (reusing `CatalogsPageContent`) vs. redirect to `/catalogs`, keeping the chat reachable. Interacts with `HomePage`'s onboarding-sequence routing and the `?q=` initial-message path.
- [ ] Demote the chat-home **card** framing once the catalog view is the landing surface (the card's selector/hook stay; the greeting-slot placement goes).
- [ ] DESIGN.md pass on the catalog-first landing (nav emphasis, valuation hero placement).
- [ ] Browser verification on a preview.

## Verification gate

Full end-to-end verification needs a **populated roster/catalog**, **gated on api item 1b** ([api#777](https://github.com/recoupable/api/pull/777) — link the searched Spotify artist). The landing-surface change also needs a preview + design review before it merges.

## Gates (this rebased revision)

- `pnpm vitest run lib/home` — 41 passing (incl. `getHomeCatalogCardState`, `getHomeSuggestedPrompts`).
- Rebased cleanly onto latest `main`; base retargeted to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)