### PR TITLE
feat(onboarding): first-task step — pre-run weekly report + confirm schedule (chat#1867)

### DIFF
--- a/app/onboarding/first-task/page.tsx
+++ b/app/onboarding/first-task/page.tsx
@@ -1,0 +1,10 @@
+import FirstTaskStep from "@/components/Onboarding/FirstTaskStep";
+
+/**
+ * Standalone mount for the onboarding first-task step (chat#1867) so
+ * the step is user-testable before the OnboardingSequence container
+ * exists. The sequence PR will mount <FirstTaskStep /> directly.
+ */
+const FirstTaskOnboardingPage = () => <FirstTaskStep />;
+
+export default FirstTaskOnboardingPage;

--- a/components/Onboarding/FirstTaskConfirm.tsx
+++ b/components/Onboarding/FirstTaskConfirm.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import Link from "next/link";
+import { useConfirmFirstTask } from "@/hooks/useConfirmFirstTask";
+import { getFirstTaskSchedule } from "@/lib/onboarding/getFirstTaskSchedule";
+import { getCronHumanPreview } from "@/lib/tasks/getCronHumanPreview";
+import { formatScheduledActionDate } from "@/lib/utils/formatScheduledActionDate";
+
+interface FirstTaskConfirmProps {
+  catalogName?: string;
+}
+
+/**
+ * The one question after the pre-run report (chat#1867): "get this every
+ * Monday?" Confirm creates the enabled weekly task; decline creates
+ * nothing. Success shows the next-run time from the created row.
+ */
+const FirstTaskConfirm = ({ catalogName }: FirstTaskConfirmProps) => {
+  const { confirm, decline, phase, task } = useConfirmFirstTask({
+    catalogName,
+  });
+
+  if (phase === "declined") {
+    return (
+      <p className="text-sm text-muted-foreground" role="status">
+        No task created. You can set up a weekly report anytime from{" "}
+        <Link href="/tasks" className="underline hover:text-foreground">
+          Tasks
+        </Link>
+        .
+      </p>
+    );
+  }
+
+  if (phase === "scheduled") {
+    const nextRun = task?.next_run
+      ? formatScheduledActionDate(task.next_run)
+      : getCronHumanPreview(getFirstTaskSchedule());
+    return (
+      <div role="status">
+        <p className="text-sm font-medium text-foreground">
+          Weekly report scheduled.
+        </p>
+        <p className="text-sm text-muted-foreground">
+          Next run: {nextRun}.{" "}
+          <Link href="/tasks" className="underline hover:text-foreground">
+            View your tasks
+          </Link>
+        </p>
+      </div>
+    );
+  }
+
+  const isCreating = phase === "creating";
+  return (
+    <div className="flex flex-col items-start justify-between gap-3 sm:flex-row sm:items-center">
+      <div>
+        <p className="text-sm font-medium text-foreground">
+          Get this every Monday?
+        </p>
+        <p className="text-xs text-muted-foreground">
+          We&apos;ll run this report every Monday at 9am as a scheduled task.
+        </p>
+      </div>
+      <div className="flex shrink-0 gap-2">
+        <button
+          type="button"
+          onClick={decline}
+          disabled={isCreating}
+          className="rounded-xl px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          Not now
+        </button>
+        <button
+          type="button"
+          onClick={confirm}
+          disabled={isCreating}
+          className="rounded-xl bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {isCreating ? "Scheduling..." : "Yes, every Monday"}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default FirstTaskConfirm;

--- a/components/Onboarding/FirstTaskReportRun.tsx
+++ b/components/Onboarding/FirstTaskReportRun.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { Response } from "@/components/ai-elements/response";
+import { useFirstTaskReport } from "@/hooks/useFirstTaskReport";
+import FirstTaskConfirm from "./FirstTaskConfirm";
+
+interface FirstTaskReportRunProps {
+  sessionId: string;
+  chatId: string;
+  prompt: string;
+  catalogName?: string;
+}
+
+/**
+ * Streams the pre-run weekly report through the normal chat pipeline
+ * and, only once it has finished, asks the one confirm question
+ * (chat#1867 — show finished work before asking anything).
+ */
+const FirstTaskReportRun = ({
+  sessionId,
+  chatId,
+  prompt,
+  catalogName,
+}: FirstTaskReportRunProps) => {
+  const { reportText, phase } = useFirstTaskReport({
+    sessionId,
+    chatId,
+    prompt,
+  });
+
+  return (
+    <div className="flex w-full flex-col gap-4">
+      <section
+        aria-label="Your first weekly report"
+        className="w-full rounded-xl bg-card p-6 shadow-[0px_0px_0px_1px_var(--border),0px_2px_4px_rgba(0,0,0,0.04)] dark:shadow-[0px_0px_0px_1px_var(--border),0px_2px_4px_rgba(0,0,0,0.2)]"
+      >
+        {phase === "generating" && (
+          <p
+            className="mb-3 animate-pulse text-xs uppercase tracking-[0.05em] text-muted-foreground"
+            role="status"
+          >
+            Generating this week&apos;s report...
+          </p>
+        )}
+        {phase === "error" ? (
+          <p className="text-sm text-destructive" role="alert">
+            We couldn&apos;t generate the report. Refresh the page to try again.
+          </p>
+        ) : (
+          <Response>{reportText}</Response>
+        )}
+      </section>
+      {phase === "ready" && (
+        <section className="w-full rounded-xl bg-card p-6 shadow-[0px_0px_0px_1px_var(--border),0px_2px_4px_rgba(0,0,0,0.04)] dark:shadow-[0px_0px_0px_1px_var(--border),0px_2px_4px_rgba(0,0,0,0.2)]">
+          <FirstTaskConfirm catalogName={catalogName} />
+        </section>
+      )}
+    </div>
+  );
+};
+
+export default FirstTaskReportRun;

--- a/components/Onboarding/FirstTaskStep.tsx
+++ b/components/Onboarding/FirstTaskStep.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useArtistProvider } from "@/providers/ArtistProvider";
+import useCatalogs from "@/hooks/useCatalogs";
+import { useNewChatBootstrap } from "@/hooks/useNewChatBootstrap";
+import { buildFirstTaskPrompt } from "@/lib/onboarding/buildFirstTaskPrompt";
+import FirstTaskReportRun from "./FirstTaskReportRun";
+
+/**
+ * Onboarding sequence final step (chat#1867): pre-run the first weekly
+ * catalog report, show it finished, then ask "get this every Monday?".
+ * Self-contained — provisions its own chat session (same infrastructure
+ * a normal send uses) so it can slot into the OnboardingSequence
+ * container later without depending on it.
+ */
+const FirstTaskStep = () => {
+  const { selectedArtist, isLoading: isArtistsLoading } = useArtistProvider();
+  const catalogsQuery = useCatalogs();
+  const bootstrap = useNewChatBootstrap();
+  const artistName = selectedArtist?.name;
+
+  // Wait for catalogs so the pre-run prompt names the claimed catalog —
+  // and therefore matches the scheduled task's prompt byte-for-byte.
+  const isPreparing =
+    isArtistsLoading || catalogsQuery.isLoading || bootstrap.status !== "ready";
+  const catalogName = catalogsQuery.data?.catalogs?.[0]?.name;
+
+  return (
+    <div className="mx-auto flex w-full max-w-3xl flex-col gap-4 px-4 py-8">
+      <header>
+        <h1 className="text-xl font-semibold text-foreground">
+          Your first weekly report
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          {artistName
+            ? `This week's catalog report for ${artistName} — the kind of update Recoup can send you every Monday.`
+            : "The kind of update Recoup can send you every Monday."}
+        </p>
+      </header>
+      {!isArtistsLoading && !artistName ? (
+        <p className="text-sm text-muted-foreground" role="status">
+          Select an artist to generate your first report.
+        </p>
+      ) : bootstrap.status === "error" ? (
+        <p className="text-sm text-destructive" role="alert">
+          {bootstrap.message}
+        </p>
+      ) : isPreparing || bootstrap.status !== "ready" || !artistName ? (
+        <p
+          className="animate-pulse text-sm text-muted-foreground"
+          role="status"
+        >
+          Preparing your workspace...
+        </p>
+      ) : (
+        <FirstTaskReportRun
+          // Re-key per provisioned chat: an artist switch mints a fresh
+          // session, and the remount re-arms the one-shot auto-send.
+          key={bootstrap.chatId}
+          sessionId={bootstrap.sessionId}
+          chatId={bootstrap.chatId}
+          prompt={buildFirstTaskPrompt({ artistName, catalogName })}
+          catalogName={catalogName}
+        />
+      )}
+    </div>
+  );
+};
+
+export default FirstTaskStep;

--- a/hooks/useConfirmFirstTask.ts
+++ b/hooks/useConfirmFirstTask.ts
@@ -1,0 +1,78 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { usePrivy } from "@privy-io/react-auth";
+import { toast } from "sonner";
+import { createTask } from "@/lib/tasks/createTask";
+import type { Task } from "@/lib/tasks/getTasks";
+import { buildFirstTaskParams } from "@/lib/onboarding/buildFirstTaskParams";
+import {
+  getFirstTaskConfirmPhase,
+  type FirstTaskConfirmPhase,
+  type FirstTaskDecision,
+} from "@/lib/onboarding/getFirstTaskConfirmPhase";
+import { useArtistProvider } from "@/providers/ArtistProvider";
+import { DEFAULT_MODEL } from "@/lib/consts";
+
+interface UseConfirmFirstTaskInput {
+  catalogName?: string;
+}
+
+/**
+ * Confirm/decline for the onboarding first task (chat#1867). Confirm
+ * schedules the weekly report through the existing `POST /api/tasks`
+ * path (which also mints the schedule — same as useCreateStarterTask);
+ * decline creates nothing. Auth + artist come from providers.
+ */
+export function useConfirmFirstTask({ catalogName }: UseConfirmFirstTaskInput) {
+  const { getAccessToken } = usePrivy();
+  const { selectedArtist } = useArtistProvider();
+  const queryClient = useQueryClient();
+  const [decision, setDecision] = useState<FirstTaskDecision>("pending");
+
+  const {
+    mutate,
+    isPending,
+    data: task,
+  } = useMutation<Task>({
+    mutationFn: async () => {
+      const artistAccountId = selectedArtist?.account_id;
+      const artistName = selectedArtist?.name;
+      if (!artistAccountId || !artistName) {
+        throw new Error("ARTIST_REQUIRED");
+      }
+      const accessToken = await getAccessToken();
+      if (!accessToken) {
+        throw new Error("AUTH_REQUIRED");
+      }
+      return createTask(accessToken, {
+        ...buildFirstTaskParams({ artistName, artistAccountId, catalogName }),
+        model: DEFAULT_MODEL,
+      });
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ["scheduled-actions"],
+        exact: false,
+      });
+    },
+    onError: () => {
+      toast.error("Couldn't schedule the weekly report. Please try again.");
+    },
+  });
+
+  const confirm = () => {
+    setDecision("confirmed");
+    mutate();
+  };
+  const decline = () => setDecision("declined");
+
+  const phase: FirstTaskConfirmPhase = getFirstTaskConfirmPhase({
+    decision,
+    isCreating: isPending,
+    hasTask: Boolean(task),
+  });
+
+  return { confirm, decline, phase, task };
+}

--- a/hooks/useFirstTaskReport.ts
+++ b/hooks/useFirstTaskReport.ts
@@ -1,0 +1,73 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useChat } from "@ai-sdk/react";
+import { useChatTransport } from "@/hooks/useChatTransport";
+import { useArtistProvider } from "@/providers/ArtistProvider";
+import { generateUUID } from "@/lib/generateUUID";
+import { DEFAULT_MODEL } from "@/lib/consts";
+import { getReportTextFromMessages } from "@/lib/onboarding/getReportTextFromMessages";
+import {
+  getFirstTaskRunPhase,
+  type FirstTaskRunPhase,
+} from "@/lib/onboarding/getFirstTaskRunPhase";
+
+interface UseFirstTaskReportInput {
+  /** Api-minted ids from the provisioned session — callers mount only once these exist. */
+  sessionId: string;
+  chatId: string;
+  prompt: string;
+}
+
+interface UseFirstTaskReportResult {
+  reportText: string;
+  phase: FirstTaskRunPhase;
+}
+
+/**
+ * Pre-runs the onboarding first task (chat#1867) through the normal
+ * chat pipeline — the same `POST /api/chat` transport a scheduled run's
+ * prompt flows through — and exposes the streamed report. Auto-fires
+ * the prompt exactly once per mount; artist context comes from the
+ * provider (composed-hook pattern, chat#1847).
+ */
+export function useFirstTaskReport({
+  sessionId,
+  chatId,
+  prompt,
+}: UseFirstTaskReportInput): UseFirstTaskReportResult {
+  const { transport, getHeaders } = useChatTransport({ chatId, sessionId });
+  const { selectedArtist } = useArtistProvider();
+  const artistId = selectedArtist?.account_id;
+
+  const { messages, status, sendMessage } = useChat({
+    id: chatId,
+    transport,
+    experimental_throttle: 100,
+    generateId: generateUUID,
+  });
+
+  const didSendRef = useRef(false);
+  useEffect(() => {
+    if (didSendRef.current || !artistId) return;
+    didSendRef.current = true;
+    const fire = async () => {
+      const headers = await getHeaders();
+      sendMessage(
+        {
+          id: generateUUID(),
+          role: "user",
+          parts: [{ type: "text", text: prompt }],
+        },
+        { body: { roomId: chatId, artistId, model: DEFAULT_MODEL }, headers },
+      );
+    };
+    void fire();
+  }, [artistId, chatId, prompt, getHeaders, sendMessage]);
+
+  const reportText = getReportTextFromMessages(messages);
+  return {
+    reportText,
+    phase: getFirstTaskRunPhase({ status, hasReport: reportText.length > 0 }),
+  };
+}

--- a/lib/onboarding/__tests__/buildFirstTaskParams.test.ts
+++ b/lib/onboarding/__tests__/buildFirstTaskParams.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { buildFirstTaskParams } from "@/lib/onboarding/buildFirstTaskParams";
+import { buildFirstTaskPrompt } from "@/lib/onboarding/buildFirstTaskPrompt";
+import { getFirstTaskSchedule } from "@/lib/onboarding/getFirstTaskSchedule";
+
+const input = {
+  artistName: "Luh Tyler",
+  artistAccountId: "artist-123",
+  catalogName: "Debut",
+};
+
+describe("buildFirstTaskParams", () => {
+  it("builds POST /api/tasks params with a personalized title", () => {
+    const params = buildFirstTaskParams(input);
+    expect(params).toEqual({
+      title: "Weekly Catalog Report — Luh Tyler",
+      prompt: buildFirstTaskPrompt({
+        artistName: "Luh Tyler",
+        catalogName: "Debut",
+      }),
+      schedule: getFirstTaskSchedule(),
+      artist_account_id: "artist-123",
+    });
+  });
+
+  it("uses the exact prompt the pre-run showed, so the scheduled task matches the preview", () => {
+    const params = buildFirstTaskParams(input);
+    expect(params.prompt).toBe(buildFirstTaskPrompt(input));
+  });
+});

--- a/lib/onboarding/__tests__/buildFirstTaskPrompt.test.ts
+++ b/lib/onboarding/__tests__/buildFirstTaskPrompt.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { buildFirstTaskPrompt } from "@/lib/onboarding/buildFirstTaskPrompt";
+
+describe("buildFirstTaskPrompt", () => {
+  it("names the artist and reads as a weekly catalog report brief", () => {
+    const prompt = buildFirstTaskPrompt({ artistName: "Luh Tyler" });
+    expect(prompt).toContain("Luh Tyler");
+    expect(prompt.toLowerCase()).toContain("catalog report");
+    expect(prompt.toLowerCase()).toContain("week");
+  });
+
+  it("mentions the catalog by name when one is provided", () => {
+    const prompt = buildFirstTaskPrompt({
+      artistName: "Luh Tyler",
+      catalogName: "Tyler's Catalog",
+    });
+    expect(prompt).toContain('"Tyler\'s Catalog"');
+  });
+
+  it("omits the catalog clause when no catalog name is provided", () => {
+    const prompt = buildFirstTaskPrompt({ artistName: "Luh Tyler" });
+    expect(prompt).not.toContain('""');
+    expect(prompt).not.toContain("undefined");
+  });
+
+  it("is identical for the pre-run and the scheduled task (pure)", () => {
+    const input = { artistName: "Luh Tyler", catalogName: "Debut" };
+    expect(buildFirstTaskPrompt(input)).toBe(buildFirstTaskPrompt(input));
+  });
+});

--- a/lib/onboarding/__tests__/getFirstTaskConfirmPhase.test.ts
+++ b/lib/onboarding/__tests__/getFirstTaskConfirmPhase.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { getFirstTaskConfirmPhase } from "@/lib/onboarding/getFirstTaskConfirmPhase";
+
+describe("getFirstTaskConfirmPhase", () => {
+  it("asks the one question by default", () => {
+    expect(
+      getFirstTaskConfirmPhase({
+        decision: "pending",
+        isCreating: false,
+        hasTask: false,
+      }),
+    ).toBe("asking");
+  });
+
+  it("is creating while the POST /api/tasks mutation is in flight", () => {
+    expect(
+      getFirstTaskConfirmPhase({
+        decision: "confirmed",
+        isCreating: true,
+        hasTask: false,
+      }),
+    ).toBe("creating");
+  });
+
+  it("is scheduled once the task row exists", () => {
+    expect(
+      getFirstTaskConfirmPhase({
+        decision: "confirmed",
+        isCreating: false,
+        hasTask: true,
+      }),
+    ).toBe("scheduled");
+  });
+
+  it("is declined when the user says no — decline never creates a task", () => {
+    expect(
+      getFirstTaskConfirmPhase({
+        decision: "declined",
+        isCreating: false,
+        hasTask: false,
+      }),
+    ).toBe("declined");
+  });
+
+  it("returns to asking after a failed create (confirmed but no task, not in flight)", () => {
+    expect(
+      getFirstTaskConfirmPhase({
+        decision: "confirmed",
+        isCreating: false,
+        hasTask: false,
+      }),
+    ).toBe("asking");
+  });
+});

--- a/lib/onboarding/__tests__/getFirstTaskRunPhase.test.ts
+++ b/lib/onboarding/__tests__/getFirstTaskRunPhase.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { getFirstTaskRunPhase } from "@/lib/onboarding/getFirstTaskRunPhase";
+
+describe("getFirstTaskRunPhase", () => {
+  it("is generating before the auto-send fires (idle chat, no report)", () => {
+    expect(getFirstTaskRunPhase({ status: "ready", hasReport: false })).toBe(
+      "generating",
+    );
+  });
+
+  it("is generating while the send is submitted or streaming", () => {
+    expect(
+      getFirstTaskRunPhase({ status: "submitted", hasReport: false }),
+    ).toBe("generating");
+    expect(getFirstTaskRunPhase({ status: "streaming", hasReport: true })).toBe(
+      "generating",
+    );
+  });
+
+  it("is ready only when the stream finished with report text", () => {
+    expect(getFirstTaskRunPhase({ status: "ready", hasReport: true })).toBe(
+      "ready",
+    );
+  });
+
+  it("is error when the chat transport errored", () => {
+    expect(getFirstTaskRunPhase({ status: "error", hasReport: false })).toBe(
+      "error",
+    );
+  });
+});

--- a/lib/onboarding/__tests__/getFirstTaskSchedule.test.ts
+++ b/lib/onboarding/__tests__/getFirstTaskSchedule.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { getFirstTaskSchedule } from "@/lib/onboarding/getFirstTaskSchedule";
+import { getCronHumanPreview } from "@/lib/tasks/getCronHumanPreview";
+
+describe("getFirstTaskSchedule", () => {
+  it("returns the Monday 9am weekly cron", () => {
+    expect(getFirstTaskSchedule()).toBe("0 9 * * 1");
+  });
+
+  it("is a valid cron the existing human-preview helper can describe", () => {
+    const preview = getCronHumanPreview(getFirstTaskSchedule());
+    expect(preview).toContain("Monday");
+  });
+});

--- a/lib/onboarding/__tests__/getReportTextFromMessages.test.ts
+++ b/lib/onboarding/__tests__/getReportTextFromMessages.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import type { UIMessage } from "ai";
+import { getReportTextFromMessages } from "@/lib/onboarding/getReportTextFromMessages";
+
+const user = (text: string): UIMessage => ({
+  id: "u1",
+  role: "user",
+  parts: [{ type: "text", text }],
+});
+
+const assistant = (id: string, parts: UIMessage["parts"]): UIMessage => ({
+  id,
+  role: "assistant",
+  parts,
+});
+
+describe("getReportTextFromMessages", () => {
+  it("returns empty string when no assistant message exists yet", () => {
+    expect(getReportTextFromMessages([])).toBe("");
+    expect(getReportTextFromMessages([user("write my report")])).toBe("");
+  });
+
+  it("returns the last assistant message's text parts joined", () => {
+    const messages = [
+      user("write my report"),
+      assistant("a1", [
+        { type: "text", text: "# Weekly Report" },
+        { type: "text", text: "Streams are up." },
+      ]),
+    ];
+    expect(getReportTextFromMessages(messages)).toBe(
+      "# Weekly Report\n\nStreams are up.",
+    );
+  });
+
+  it("ignores non-text parts (reasoning, tool calls)", () => {
+    const messages = [
+      user("write my report"),
+      assistant("a1", [
+        { type: "reasoning", text: "thinking..." },
+        { type: "text", text: "Report body" },
+      ] as UIMessage["parts"]),
+    ];
+    expect(getReportTextFromMessages(messages)).toBe("Report body");
+  });
+
+  it("uses the latest assistant message when there are several", () => {
+    const messages = [
+      user("write my report"),
+      assistant("a1", [{ type: "text", text: "old" }]),
+      user("again"),
+      assistant("a2", [{ type: "text", text: "new" }]),
+    ];
+    expect(getReportTextFromMessages(messages)).toBe("new");
+  });
+});

--- a/lib/onboarding/buildFirstTaskParams.ts
+++ b/lib/onboarding/buildFirstTaskParams.ts
@@ -1,0 +1,27 @@
+import type { CreateTaskParams } from "@/lib/tasks/createTask";
+import { buildFirstTaskPrompt } from "@/lib/onboarding/buildFirstTaskPrompt";
+import { getFirstTaskSchedule } from "@/lib/onboarding/getFirstTaskSchedule";
+
+export interface BuildFirstTaskParamsInput {
+  artistName: string;
+  artistAccountId: string;
+  catalogName?: string;
+}
+
+/**
+ * `POST /api/tasks` params for the onboarding first task (chat#1867).
+ * The prompt is the same builder output the pre-run streamed, so
+ * confirming schedules exactly the report the user just read.
+ */
+export function buildFirstTaskParams({
+  artistName,
+  artistAccountId,
+  catalogName,
+}: BuildFirstTaskParamsInput): Omit<CreateTaskParams, "model"> {
+  return {
+    title: `Weekly Catalog Report — ${artistName}`,
+    prompt: buildFirstTaskPrompt({ artistName, catalogName }),
+    schedule: getFirstTaskSchedule(),
+    artist_account_id: artistAccountId,
+  };
+}

--- a/lib/onboarding/buildFirstTaskPrompt.ts
+++ b/lib/onboarding/buildFirstTaskPrompt.ts
@@ -1,0 +1,28 @@
+export interface BuildFirstTaskPromptInput {
+  artistName: string;
+  catalogName?: string;
+}
+
+/**
+ * The weekly catalog report brief used both for the onboarding pre-run
+ * (fired through the normal chat pipeline) and as the scheduled task's
+ * prompt — one string so the preview the user confirms is exactly what
+ * the Monday run will produce (chat#1867, first-task step).
+ */
+export function buildFirstTaskPrompt({
+  artistName,
+  catalogName,
+}: BuildFirstTaskPromptInput): string {
+  const catalogClause = catalogName
+    ? `the "${catalogName}" catalog`
+    : "the claimed catalog";
+  return [
+    `Write this week's catalog report for ${artistName}, covering ${catalogClause}.`,
+    "Structure it with clear markdown headings:",
+    "1. Headline — the one number or change that matters most this week.",
+    "2. Catalog performance — streams and listener trends across the catalog's releases, calling out top movers.",
+    "3. What changed — anything new since last week (releases, playlists, notable spikes or drops).",
+    "4. Recommended actions — 2-3 concrete next steps for the week ahead.",
+    "Keep it concise and skimmable. If a data point is unavailable, say so briefly instead of guessing.",
+  ].join("\n");
+}

--- a/lib/onboarding/getFirstTaskConfirmPhase.ts
+++ b/lib/onboarding/getFirstTaskConfirmPhase.ts
@@ -1,0 +1,29 @@
+export type FirstTaskDecision = "pending" | "confirmed" | "declined";
+
+export type FirstTaskConfirmPhase =
+  | "asking"
+  | "creating"
+  | "scheduled"
+  | "declined";
+
+export interface GetFirstTaskConfirmPhaseInput {
+  decision: FirstTaskDecision;
+  isCreating: boolean;
+  hasTask: boolean;
+}
+
+/**
+ * Confirm-step phase for the onboarding first task (chat#1867). Pure so
+ * the decline-never-creates and failed-create-returns-to-asking rules
+ * are unit-testable without mounting the mutation hook.
+ */
+export function getFirstTaskConfirmPhase({
+  decision,
+  isCreating,
+  hasTask,
+}: GetFirstTaskConfirmPhaseInput): FirstTaskConfirmPhase {
+  if (decision === "declined") return "declined";
+  if (hasTask) return "scheduled";
+  if (isCreating) return "creating";
+  return "asking";
+}

--- a/lib/onboarding/getFirstTaskRunPhase.ts
+++ b/lib/onboarding/getFirstTaskRunPhase.ts
@@ -1,0 +1,22 @@
+export type FirstTaskRunPhase = "generating" | "ready" | "error";
+
+export interface GetFirstTaskRunPhaseInput {
+  /** AI SDK useChat status: "ready" | "submitted" | "streaming" | "error". */
+  status: string;
+  hasReport: boolean;
+}
+
+/**
+ * Pre-run phase for the onboarding first task (chat#1867). "ready"
+ * requires a finished stream AND report text — an idle chat before the
+ * auto-send fires is still "generating", so the confirm question never
+ * shows before the report exists.
+ */
+export function getFirstTaskRunPhase({
+  status,
+  hasReport,
+}: GetFirstTaskRunPhaseInput): FirstTaskRunPhase {
+  if (status === "error") return "error";
+  if (status === "ready" && hasReport) return "ready";
+  return "generating";
+}

--- a/lib/onboarding/getFirstTaskSchedule.ts
+++ b/lib/onboarding/getFirstTaskSchedule.ts
@@ -1,0 +1,8 @@
+/**
+ * Cron for the onboarding first task: Mondays at 9am — the "get this
+ * every Monday?" promise in the confirm step. Matches the homepage
+ * starter task cadence (buildStarterTaskParams, chat#1850).
+ */
+export function getFirstTaskSchedule(): string {
+  return "0 9 * * 1";
+}

--- a/lib/onboarding/getReportTextFromMessages.ts
+++ b/lib/onboarding/getReportTextFromMessages.ts
@@ -1,0 +1,20 @@
+import type { UIMessage } from "ai";
+
+/**
+ * Markdown of the pre-run report: the latest assistant message's text
+ * parts joined. Non-text parts (reasoning, tool calls) are skipped —
+ * the onboarding step renders only the finished report body.
+ */
+export function getReportTextFromMessages(messages: UIMessage[]): string {
+  const lastAssistant = [...messages]
+    .reverse()
+    .find((message) => message.role === "assistant");
+  if (!lastAssistant) return "";
+  return lastAssistant.parts
+    .filter(
+      (part): part is Extract<UIMessage["parts"][number], { type: "text" }> =>
+        part.type === "text" && Boolean(part.text),
+    )
+    .map((part) => part.text)
+    .join("\n\n");
+}


### PR DESCRIPTION
Implements the **"First-task creation: pre-run + confirm (sequence final step)"** item from recoupable/chat#1867 (respec 2026-07-20: pre-run shape — finished work in hand before the one question, superseding the earlier one-click button shape).

## What this does

`/onboarding/first-task` (standalone mount so the step is user-testable before the OnboardingSequence container from the sibling PR exists — the container will mount `<FirstTaskStep />` directly, no dependency on that branch):

1. **Pre-run** — on landing, the step provisions a chat session (same `useNewChatBootstrap` infrastructure the homepage uses) and fires the weekly catalog report prompt through the normal chat pipeline (`POST /api/chat` via the existing `useChatTransport`). The report streams into the step and renders via the existing `Response` (Streamdown) component.
2. **One question** — only after the stream finishes with report text does the confirm card appear: "Get this every Monday?" with **Yes, every Monday** / **Not now**.
3. **Confirm** — creates the enabled weekly task via the existing `POST /api/tasks` path (which also mints the schedule; mirrors `useCreateStarterTask`/`createTask`), schedule `0 9 * * 1`, then shows the next-run time from the created `scheduled_actions` row (fallback: cron human preview). Invalidates the `scheduled-actions` query so /tasks reflects it.
4. **Decline** — creates nothing; shows a pointer to /tasks.

The pre-run prompt and the scheduled task's prompt come from one pure builder (`buildFirstTaskPrompt`), so the preview the user confirms is byte-for-byte the prompt Monday's run executes. The prompt names the claimed catalog (first `account_catalogs` catalog via the existing `useCatalogs`) when one exists.

## Scope discipline (chat-side only)

No api changes were needed — both halves ride existing endpoints (`POST /api/chat` for the pre-run, `POST /api/tasks` for creation).

**Noted follow-up (not hacked in):** the pre-run executes the report prompt through the interactive chat pipeline, while the Monday run executes the same prompt through the scheduled_actions worker path. Prompt parity is guaranteed by the shared builder; runtime parity (the task runner's exact tool/model context) is an api-side concern and stays out of scope here. If we later want the pre-run to literally invoke the task runner once, that's an api follow-up.

## Files

- `lib/onboarding/` — pure helpers, TDD red-first: `buildFirstTaskPrompt`, `getFirstTaskSchedule`, `buildFirstTaskParams`, `getFirstTaskConfirmPhase` (decline-never-creates + failed-create-returns-to-asking rules), `getFirstTaskRunPhase`, `getReportTextFromMessages` (+ 6 test files, 21 tests)
- `hooks/useFirstTaskReport.ts` — composed hook: transport + `useChat` + one-shot auto-send (mirrors the `useInitialMessageAutoSend` pattern; artist from provider)
- `hooks/useConfirmFirstTask.ts` — confirm/decline + `createTask` mutation (mirrors `useCreateStarterTask`)
- `components/Onboarding/FirstTaskStep.tsx` / `FirstTaskReportRun.tsx` / `FirstTaskConfirm.tsx`
- `app/onboarding/first-task/page.tsx`

All files one exported function, <100 LOC.

## Verification

- `pnpm exec vitest run` — 41 files / 151 tests pass (21 new).
- `pnpm exec tsc --noEmit` — the only errors are pre-existing on `main` in untouched files (`SpotifyDeepResearchResult.tsx` png module, `lib/emails/__tests__/extractSendEmailResults.test.ts` UIMessage `content`); zero errors in the new code.
- `pnpm build` — webpack compilation succeeds and the new route compiles (`.next/server/app/onboarding/first-task/page.js` emitted). The build then fails at the collect-page-data stage with `Missing required Supabase environment variables` in untouched routes (`/api/agent-templates/favorites`, `/api/agent-creator`, `/api/cron/recoupDailyStats`) — environmental: no local checkout has real env files (only `.env.example`); Vercel injects them at deploy. The Vercel PR build is the authoritative gate here.
- `pnpm lint` (`next lint`) is broken on Next 16 in this repo (`Invalid project directory provided ... /lint`) — pre-existing; CI gates on `pnpm test`. New files were run through `prettier --write` instead.
- Not verified here: live end-to-end on preview (needs an authenticated session). See "How to test" below.

## How to test on preview

1. Sign in on the preview deploy with an account that has a rostered artist (ideally a claimed catalog, e.g. a fresh valuation-path signup).
2. Open `/onboarding/first-task`. Expected: "Preparing your workspace..." then the report streams in under "Generating this week's report..." — the confirm question must NOT be visible while streaming.
3. When the report finishes, the "Get this every Monday?" card appears. Click **Yes, every Monday**. Expected: button shows "Scheduling...", then "Weekly report scheduled. Next run: <date>" with a working link to /tasks.
4. Verify one new enabled `scheduled_actions` row for the account + selected artist: title `Weekly Catalog Report — <artist>`, schedule `0 9 * * 1`, visible on /tasks.
5. Reload `/onboarding/first-task` and click **Not now** after the report renders. Expected: "No task created." and no new `scheduled_actions` row.

Note: previews hit the test api base (`test-recoup-api.vercel.app`) per `lib/consts.ts`; if that branch has drifted from `main`, use the `recoup_api_override` sessionStorage hatch.

Part of recoupable/chat#1867.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pre-runs this week’s catalog report in onboarding, then asks to schedule it. Confirm creates a Monday 9am weekly task; decline creates nothing. Part of chat#1867.

- **New Features**
  - New route `/onboarding/first-task` mounts the step so it’s testable standalone.
  - Pre-run streams the report via the normal chat pipeline (`POST /api/chat`), then shows “Get this every Monday?” only after the report finishes.
  - Confirm schedules the task (`0 9 * * 1`) via `POST /api/tasks`, shows the next run from `scheduled_actions`, and invalidates the `scheduled-actions` query; decline shows a link to /tasks.
  - Shared prompt builder ensures the preview matches the scheduled run byte-for-byte; includes catalog name when available.
  - No API changes; added small hooks and pure helpers with unit tests.

<sup>Written for commit b7ef55789543714e3566e6c4e238845c9cf8ef8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

