### PR TITLE
feat(onboarding): state-derived onboarding router with resume-on-landing + skip-for-now

### DIFF
--- a/components/Home/HomePage.tsx
+++ b/components/Home/HomePage.tsx
@@ -19,8 +19,9 @@ const HomePage = ({ initialMessages }: { initialMessages?: UIMessage[] }) => {
   }, [setFrameReady, isFrameReady]);
 
   // Incomplete accounts resume the sequence at their derived step on every
-  // landing; skip drops to the app with the checklist pinned; activated
-  // accounts only ever see the normal home (recoupable/chat#1867).
+  // landing; skip drops to the app with the checklist pinned as a persistent
+  // reminder; activated accounts only ever see the normal home
+  // (recoupable/chat#1867).
   if (onboarding.view === "sequence" && onboarding.step !== "complete") {
     return (
       <div className="flex flex-col size-full items-center">
@@ -40,7 +41,6 @@ const HomePage = ({ initialMessages }: { initialMessages?: UIMessage[] }) => {
         <OnboardingChecklist
           checkpoints={onboarding.checkpoints}
           onResume={onboarding.resume}
-          onDismiss={onboarding.dismissChecklist}
         />
       )}
     </div>

--- a/components/Home/HomePage.tsx
+++ b/components/Home/HomePage.tsx
@@ -34,7 +34,7 @@ const HomePage = ({ initialMessages }: { initialMessages?: UIMessage[] }) => {
   }
 
   return (
-    <div className="flex flex-col size-full items-center">
+    <div className="relative flex flex-col size-full items-center">
       <NewChatBootstrap initialMessages={initialMessages} />
       {onboarding.view === "checklist" && (
         <OnboardingChecklist

--- a/components/Home/HomePage.tsx
+++ b/components/Home/HomePage.tsx
@@ -2,11 +2,15 @@
 
 import { useMiniKit } from "@coinbase/onchainkit/minikit";
 import NewChatBootstrap from "../VercelChat/NewChatBootstrap";
+import OnboardingChecklist from "@/components/Onboarding/OnboardingChecklist";
+import OnboardingSequence from "@/components/Onboarding/OnboardingSequence";
+import { useOnboardingGate } from "@/hooks/useOnboardingGate";
 import { useEffect } from "react";
 import { UIMessage } from "ai";
 
 const HomePage = ({ initialMessages }: { initialMessages?: UIMessage[] }) => {
   const { setFrameReady, isFrameReady } = useMiniKit();
+  const onboarding = useOnboardingGate();
 
   useEffect(() => {
     if (!isFrameReady) {
@@ -14,9 +18,31 @@ const HomePage = ({ initialMessages }: { initialMessages?: UIMessage[] }) => {
     }
   }, [setFrameReady, isFrameReady]);
 
+  // Incomplete accounts resume the sequence at their derived step on every
+  // landing; skip drops to the app with the checklist pinned; activated
+  // accounts only ever see the normal home (recoupable/chat#1867).
+  if (onboarding.view === "sequence" && onboarding.step !== "complete") {
+    return (
+      <div className="flex flex-col size-full items-center">
+        <OnboardingSequence
+          step={onboarding.step}
+          checkpoints={onboarding.checkpoints}
+          onSkip={onboarding.skip}
+        />
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-col size-full items-center">
       <NewChatBootstrap initialMessages={initialMessages} />
+      {onboarding.view === "checklist" && (
+        <OnboardingChecklist
+          checkpoints={onboarding.checkpoints}
+          onResume={onboarding.resume}
+          onDismiss={onboarding.dismissChecklist}
+        />
+      )}
     </div>
   );
 };

--- a/components/Home/__tests__/HomePage.onboarding.test.tsx
+++ b/components/Home/__tests__/HomePage.onboarding.test.tsx
@@ -76,28 +76,22 @@ describe("HomePage onboarding gate (single source of truth)", () => {
       name: /onboarding checklist/i,
     });
     // Regression guard: `fixed` pinned the card to the viewport edge, where
-    // the z-[65] ArtistsSidebar rail clipped the Dismiss button off-screen.
+    // the z-[65] ArtistsSidebar rail clipped it off-screen.
     expect(checklist.className).not.toContain("fixed");
     expect(checklist.className).toContain("absolute");
     expect(checklist.parentElement?.className).toContain("relative");
   });
 
-  it("dismiss from the checklist hides it at the HomePage level", () => {
+  it("has no dismiss control — the checklist is a persistent reminder", () => {
     render(<HomePage />);
     fireEvent.click(screen.getByRole("button", { name: /skip for now/i }));
-    fireEvent.click(
-      screen.getByRole("button", { name: /dismiss onboarding checklist/i }),
-    );
-    expect(
-      screen.queryByRole("complementary", { name: /onboarding checklist/i }),
-    ).toBeNull();
-    expect(screen.getByTestId("chat-bootstrap")).toBeDefined();
+    expect(screen.queryByRole("button", { name: /dismiss/i })).toBeNull();
   });
 
-  it("resume from the checklist re-opens the sequence", () => {
+  it("clicking Finish setting up re-opens the sequence", () => {
     render(<HomePage />);
     fireEvent.click(screen.getByRole("button", { name: /skip for now/i }));
-    fireEvent.click(screen.getByRole("button", { name: /resume setup/i }));
+    fireEvent.click(screen.getByRole("button", { name: /finish setting up/i }));
     expect(
       screen.getByRole("heading", { level: 3, name: /confirm your artists/i }),
     ).toBeDefined();

--- a/components/Home/__tests__/HomePage.onboarding.test.tsx
+++ b/components/Home/__tests__/HomePage.onboarding.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import HomePage from "@/components/Home/HomePage";
+
+vi.mock("@coinbase/onchainkit/minikit", () => ({
+  useMiniKit: () => ({ setFrameReady: vi.fn(), isFrameReady: true }),
+}));
+
+vi.mock("@/components/VercelChat/NewChatBootstrap", () => ({
+  default: () => <div data-testid="chat-bootstrap" />,
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: React.ComponentProps<"a"> & { href: string }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/providers/UserProvder", () => ({
+  useUserProvider: () => ({ userData: { account_id: "acct-test" } }),
+}));
+
+vi.mock("@/hooks/useOnboardingState", () => ({
+  useOnboardingState: () => ({
+    isReady: true,
+    step: "artists",
+    checkpoints: [
+      { id: "artists", complete: false },
+      { id: "socials", complete: false },
+      { id: "catalog", complete: false },
+      { id: "task", complete: false },
+    ],
+  }),
+}));
+
+describe("HomePage onboarding gate (single source of truth)", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it("renders the sequence with the step card as an h3 under the container h2", () => {
+    render(<HomePage />);
+    expect(
+      screen.getByRole("heading", {
+        level: 2,
+        name: /finish setting up your account/i,
+      }),
+    ).toBeDefined();
+    expect(
+      screen.getByRole("heading", { level: 3, name: /confirm your artists/i }),
+    ).toBeDefined();
+    expect(screen.queryAllByRole("heading", { level: 1 })).toHaveLength(0);
+  });
+
+  it("skip drops to the app with the pinned checklist", () => {
+    render(<HomePage />);
+    fireEvent.click(screen.getByRole("button", { name: /skip for now/i }));
+    expect(screen.getByTestId("chat-bootstrap")).toBeDefined();
+    expect(
+      screen.getByRole("complementary", { name: /onboarding checklist/i }),
+    ).toBeDefined();
+  });
+
+  it("positions the checklist inside the content area, not fixed to the viewport under the right rail", () => {
+    render(<HomePage />);
+    fireEvent.click(screen.getByRole("button", { name: /skip for now/i }));
+    const checklist = screen.getByRole("complementary", {
+      name: /onboarding checklist/i,
+    });
+    // Regression guard: `fixed` pinned the card to the viewport edge, where
+    // the z-[65] ArtistsSidebar rail clipped the Dismiss button off-screen.
+    expect(checklist.className).not.toContain("fixed");
+    expect(checklist.className).toContain("absolute");
+    expect(checklist.parentElement?.className).toContain("relative");
+  });
+
+  it("dismiss from the checklist hides it at the HomePage level", () => {
+    render(<HomePage />);
+    fireEvent.click(screen.getByRole("button", { name: /skip for now/i }));
+    fireEvent.click(
+      screen.getByRole("button", { name: /dismiss onboarding checklist/i }),
+    );
+    expect(
+      screen.queryByRole("complementary", { name: /onboarding checklist/i }),
+    ).toBeNull();
+    expect(screen.getByTestId("chat-bootstrap")).toBeDefined();
+  });
+
+  it("resume from the checklist re-opens the sequence", () => {
+    render(<HomePage />);
+    fireEvent.click(screen.getByRole("button", { name: /skip for now/i }));
+    fireEvent.click(screen.getByRole("button", { name: /resume setup/i }));
+    expect(
+      screen.getByRole("heading", { level: 3, name: /confirm your artists/i }),
+    ).toBeDefined();
+  });
+});

--- a/components/Home/__tests__/HomePage.onboarding.test.tsx
+++ b/components/Home/__tests__/HomePage.onboarding.test.tsx
@@ -88,10 +88,10 @@ describe("HomePage onboarding gate (single source of truth)", () => {
     expect(screen.queryByRole("button", { name: /dismiss/i })).toBeNull();
   });
 
-  it("clicking Finish setting up re-opens the sequence", () => {
+  it("the Continue button re-opens the sequence", () => {
     render(<HomePage />);
     fireEvent.click(screen.getByRole("button", { name: /skip for now/i }));
-    fireEvent.click(screen.getByRole("button", { name: /finish setting up/i }));
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }));
     expect(
       screen.getByRole("heading", { level: 3, name: /confirm your artists/i }),
     ).toBeDefined();

--- a/components/Onboarding/OnboardingChecklist.tsx
+++ b/components/Onboarding/OnboardingChecklist.tsx
@@ -1,51 +1,36 @@
 "use client";
 
-import { X } from "lucide-react";
 import OnboardingCheckpointList from "@/components/Onboarding/OnboardingCheckpointList";
 import type { OnboardingCheckpoint } from "@/lib/onboarding/types";
 
 interface OnboardingChecklistProps {
   checkpoints: OnboardingCheckpoint[];
   onResume: () => void;
-  onDismiss: () => void;
 }
 
 /**
- * Pinned, dismissible checklist shown after "skip for now"
- * (recoupable/chat#1867): keeps the remaining activation checkpoints
- * visible in the app and re-opens the sequence on resume. Positioned
- * `absolute` within the (relative) home content area — never `fixed` to
- * the viewport, where the z-[65] ArtistsSidebar rail overlaps the right
- * edge and clips the dismiss button off-screen.
+ * Pinned checklist shown after "skip for now" (recoupable/chat#1867): a
+ * persistent reminder of the remaining activation checkpoints with no
+ * dismiss — clicking "Finish setting up" re-opens the sequence. Positioned
+ * `absolute` within the (relative) home content area, never `fixed` to the
+ * viewport where the z-[65] ArtistsSidebar rail overlaps and clips it.
  */
 const OnboardingChecklist = ({
   checkpoints,
   onResume,
-  onDismiss,
 }: OnboardingChecklistProps) => (
   <aside
     aria-label="Onboarding checklist"
     className="absolute bottom-4 right-4 z-40 w-64 rounded-xl border bg-card p-4 text-card-foreground shadow-lg"
   >
-    <div className="mb-3 flex items-start justify-between gap-2">
-      <p className="text-sm font-semibold text-foreground">Finish setting up</p>
-      <button
-        type="button"
-        onClick={onDismiss}
-        aria-label="Dismiss onboarding checklist"
-        className="rounded p-0.5 text-muted-foreground transition-colors hover:text-foreground"
-      >
-        <X className="size-4" />
-      </button>
-    </div>
-    <OnboardingCheckpointList checkpoints={checkpoints} />
     <button
       type="button"
       onClick={onResume}
-      className="mt-3 w-full rounded-xl bg-primary px-3 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:opacity-90"
+      className="mb-3 w-full text-left text-sm font-semibold text-foreground transition-colors hover:text-primary"
     >
-      Resume setup
+      Finish setting up
     </button>
+    <OnboardingCheckpointList checkpoints={checkpoints} />
   </aside>
 );
 

--- a/components/Onboarding/OnboardingChecklist.tsx
+++ b/components/Onboarding/OnboardingChecklist.tsx
@@ -13,7 +13,10 @@ interface OnboardingChecklistProps {
 /**
  * Pinned, dismissible checklist shown after "skip for now"
  * (recoupable/chat#1867): keeps the remaining activation checkpoints
- * visible in the app and re-opens the sequence on resume.
+ * visible in the app and re-opens the sequence on resume. Positioned
+ * `absolute` within the (relative) home content area — never `fixed` to
+ * the viewport, where the z-[65] ArtistsSidebar rail overlaps the right
+ * edge and clips the dismiss button off-screen.
  */
 const OnboardingChecklist = ({
   checkpoints,
@@ -22,7 +25,7 @@ const OnboardingChecklist = ({
 }: OnboardingChecklistProps) => (
   <aside
     aria-label="Onboarding checklist"
-    className="fixed bottom-4 right-4 z-40 w-64 rounded-xl border bg-card p-4 text-card-foreground shadow-lg"
+    className="absolute bottom-4 right-4 z-40 w-64 rounded-xl border bg-card p-4 text-card-foreground shadow-lg"
   >
     <div className="mb-3 flex items-start justify-between gap-2">
       <p className="text-sm font-semibold text-foreground">Finish setting up</p>

--- a/components/Onboarding/OnboardingChecklist.tsx
+++ b/components/Onboarding/OnboardingChecklist.tsx
@@ -11,7 +11,7 @@ interface OnboardingChecklistProps {
 /**
  * Pinned checklist shown after "skip for now" (recoupable/chat#1867): a
  * persistent reminder of the remaining activation checkpoints with no
- * dismiss — clicking "Finish setting up" re-opens the sequence. Positioned
+ * dismiss — the "Continue" button re-opens the sequence. Positioned
  * `absolute` within the (relative) home content area, never `fixed` to the
  * viewport where the z-[65] ArtistsSidebar rail overlaps and clips it.
  */
@@ -23,14 +23,17 @@ const OnboardingChecklist = ({
     aria-label="Onboarding checklist"
     className="absolute bottom-4 right-4 z-40 w-64 rounded-xl border bg-card p-4 text-card-foreground shadow-lg"
   >
+    <p className="mb-3 text-sm font-semibold text-foreground">
+      Finish setting up
+    </p>
+    <OnboardingCheckpointList checkpoints={checkpoints} />
     <button
       type="button"
       onClick={onResume}
-      className="mb-3 w-full text-left text-sm font-semibold text-foreground transition-colors hover:text-primary"
+      className="mt-3 w-full rounded-xl bg-primary px-3 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:opacity-90"
     >
-      Finish setting up
+      Continue
     </button>
-    <OnboardingCheckpointList checkpoints={checkpoints} />
   </aside>
 );
 

--- a/components/Onboarding/OnboardingChecklist.tsx
+++ b/components/Onboarding/OnboardingChecklist.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { X } from "lucide-react";
+import OnboardingCheckpointList from "@/components/Onboarding/OnboardingCheckpointList";
+import type { OnboardingCheckpoint } from "@/lib/onboarding/types";
+
+interface OnboardingChecklistProps {
+  checkpoints: OnboardingCheckpoint[];
+  onResume: () => void;
+  onDismiss: () => void;
+}
+
+/**
+ * Pinned, dismissible checklist shown after "skip for now"
+ * (recoupable/chat#1867): keeps the remaining activation checkpoints
+ * visible in the app and re-opens the sequence on resume.
+ */
+const OnboardingChecklist = ({
+  checkpoints,
+  onResume,
+  onDismiss,
+}: OnboardingChecklistProps) => (
+  <aside
+    aria-label="Onboarding checklist"
+    className="fixed bottom-4 right-4 z-40 w-64 rounded-xl border bg-card p-4 text-card-foreground shadow-lg"
+  >
+    <div className="mb-3 flex items-start justify-between gap-2">
+      <p className="text-sm font-semibold text-foreground">Finish setting up</p>
+      <button
+        type="button"
+        onClick={onDismiss}
+        aria-label="Dismiss onboarding checklist"
+        className="rounded p-0.5 text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <X className="size-4" />
+      </button>
+    </div>
+    <OnboardingCheckpointList checkpoints={checkpoints} />
+    <button
+      type="button"
+      onClick={onResume}
+      className="mt-3 w-full rounded-xl bg-primary px-3 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:opacity-90"
+    >
+      Resume setup
+    </button>
+  </aside>
+);
+
+export default OnboardingChecklist;

--- a/components/Onboarding/OnboardingCheckpointList.tsx
+++ b/components/Onboarding/OnboardingCheckpointList.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { Check } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { getOnboardingStepContent } from "@/lib/onboarding/getOnboardingStepContent";
+import type { OnboardingCheckpoint } from "@/lib/onboarding/types";
+
+/**
+ * Read-only list of activation checkpoints with completion state. Shared
+ * by the onboarding sequence (progress) and the pinned checklist.
+ */
+const OnboardingCheckpointList = ({
+  checkpoints,
+}: {
+  checkpoints: OnboardingCheckpoint[];
+}) => (
+  <ul className="flex flex-col gap-2">
+    {checkpoints.map((checkpoint) => (
+      <li key={checkpoint.id} className="flex items-center gap-2 text-sm">
+        <span
+          aria-hidden="true"
+          className={cn(
+            "flex size-4 shrink-0 items-center justify-center rounded-full",
+            checkpoint.complete
+              ? "bg-primary text-primary-foreground"
+              : "border border-muted-foreground/40",
+          )}
+        >
+          {checkpoint.complete && <Check className="size-3" />}
+        </span>
+        <span
+          className={cn(
+            checkpoint.complete
+              ? "text-muted-foreground line-through"
+              : "text-foreground",
+          )}
+        >
+          {getOnboardingStepContent(checkpoint.id).title}
+        </span>
+        <span className="sr-only">
+          {checkpoint.complete ? "(complete)" : "(incomplete)"}
+        </span>
+      </li>
+    ))}
+  </ul>
+);
+
+export default OnboardingCheckpointList;

--- a/components/Onboarding/OnboardingSequence.tsx
+++ b/components/Onboarding/OnboardingSequence.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import OnboardingCheckpointList from "@/components/Onboarding/OnboardingCheckpointList";
+import OnboardingStepCard from "@/components/Onboarding/OnboardingStepCard";
+import type {
+  OnboardingCheckpoint,
+  OnboardingStepId,
+} from "@/lib/onboarding/types";
+
+interface OnboardingSequenceProps {
+  step: OnboardingStepId;
+  checkpoints: OnboardingCheckpoint[];
+  onSkip: () => void;
+}
+
+/**
+ * The onboarding sequence container (recoupable/chat#1867): renders the
+ * derived current step with overall progress and an always-visible
+ * "skip for now" escape hatch — a soft gate, never a wall.
+ */
+const OnboardingSequence = ({
+  step,
+  checkpoints,
+  onSkip,
+}: OnboardingSequenceProps) => {
+  const stepNumber = checkpoints.findIndex((c) => c.id === step) + 1;
+
+  return (
+    <div className="flex w-full max-w-md flex-1 flex-col justify-center gap-6 px-4 py-8">
+      <div>
+        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          Set up Recoup · step {stepNumber} of {checkpoints.length}
+        </p>
+        <h2 className="mt-1 text-xl font-semibold text-foreground">
+          Finish setting up your account
+        </h2>
+      </div>
+      <OnboardingStepCard step={step} />
+      <OnboardingCheckpointList checkpoints={checkpoints} />
+      <button
+        type="button"
+        onClick={onSkip}
+        className="self-start text-sm text-muted-foreground underline-offset-4 transition-colors hover:text-foreground hover:underline"
+      >
+        Skip for now
+      </button>
+    </div>
+  );
+};
+
+export default OnboardingSequence;

--- a/components/Onboarding/OnboardingStepCard.tsx
+++ b/components/Onboarding/OnboardingStepCard.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import Link from "next/link";
+import { getOnboardingStepContent } from "@/lib/onboarding/getOnboardingStepContent";
+import type { OnboardingStepId } from "@/lib/onboarding/types";
+
+/**
+ * Placeholder card for a single onboarding step (recoupable/chat#1867).
+ * Each step's full in-sequence experience ships in sibling PRs; until then
+ * the card states the step's purpose and links to the existing page where
+ * it can be completed today.
+ */
+const OnboardingStepCard = ({ step }: { step: OnboardingStepId }) => {
+  const { title, description, href, linkLabel } =
+    getOnboardingStepContent(step);
+
+  return (
+    <section
+      aria-labelledby="onboarding-step-title"
+      className="w-full rounded-xl border bg-card p-6 text-card-foreground shadow"
+    >
+      <h1
+        id="onboarding-step-title"
+        className="text-lg font-semibold text-foreground"
+      >
+        {title}
+      </h1>
+      <p className="mt-2 text-sm text-muted-foreground">{description}</p>
+      <Link
+        href={href}
+        className="mt-4 inline-block rounded-xl bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:opacity-90"
+      >
+        {linkLabel}
+      </Link>
+    </section>
+  );
+};
+
+export default OnboardingStepCard;

--- a/components/Onboarding/OnboardingStepCard.tsx
+++ b/components/Onboarding/OnboardingStepCard.tsx
@@ -19,12 +19,12 @@ const OnboardingStepCard = ({ step }: { step: OnboardingStepId }) => {
       aria-labelledby="onboarding-step-title"
       className="w-full rounded-xl border bg-card p-6 text-card-foreground shadow"
     >
-      <h1
+      <h3
         id="onboarding-step-title"
         className="text-lg font-semibold text-foreground"
       >
         {title}
-      </h1>
+      </h3>
       <p className="mt-2 text-sm text-muted-foreground">{description}</p>
       <Link
         href={href}

--- a/hooks/__tests__/useOnboardingSessionFlags.test.tsx
+++ b/hooks/__tests__/useOnboardingSessionFlags.test.tsx
@@ -8,44 +8,31 @@ describe("useOnboardingSessionFlags", () => {
     window.sessionStorage.clear();
   });
 
-  it("starts unskipped and undismissed", () => {
+  it("starts unskipped", () => {
     const { result } = renderHook(() => useOnboardingSessionFlags("acct-a"));
     expect(result.current.skipped).toBe(false);
-    expect(result.current.checklistDismissed).toBe(false);
   });
 
-  it("skip and dismissChecklist set session-scoped flags", () => {
+  it("skip sets the account-scoped flag; resume clears it", () => {
     const { result } = renderHook(() => useOnboardingSessionFlags("acct-a"));
     act(() => result.current.skip());
-    act(() => result.current.dismissChecklist());
     expect(result.current.skipped).toBe(true);
-    expect(result.current.checklistDismissed).toBe(true);
-  });
-
-  it("resume clears both flags", () => {
-    const { result } = renderHook(() => useOnboardingSessionFlags("acct-a"));
-    act(() => result.current.skip());
-    act(() => result.current.dismissChecklist());
     act(() => result.current.resume());
     expect(result.current.skipped).toBe(false);
-    expect(result.current.checklistDismissed).toBe(false);
   });
 
-  it("does not leak one account's choices to another in the same tab", () => {
+  it("does not leak one account's choice to another in the same tab", () => {
     const { result, rerender } = renderHook(
       ({ accountId }: { accountId: string }) =>
         useOnboardingSessionFlags(accountId),
       { initialProps: { accountId: "acct-a" } },
     );
     act(() => result.current.skip());
-    act(() => result.current.dismissChecklist());
 
     rerender({ accountId: "acct-b" });
     expect(result.current.skipped).toBe(false);
-    expect(result.current.checklistDismissed).toBe(false);
 
     rerender({ accountId: "acct-a" });
     expect(result.current.skipped).toBe(true);
-    expect(result.current.checklistDismissed).toBe(true);
   });
 });

--- a/hooks/__tests__/useOnboardingSessionFlags.test.tsx
+++ b/hooks/__tests__/useOnboardingSessionFlags.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useOnboardingSessionFlags } from "@/hooks/useOnboardingSessionFlags";
+
+describe("useOnboardingSessionFlags", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it("starts unskipped and undismissed", () => {
+    const { result } = renderHook(() => useOnboardingSessionFlags("acct-a"));
+    expect(result.current.skipped).toBe(false);
+    expect(result.current.checklistDismissed).toBe(false);
+  });
+
+  it("skip and dismissChecklist set session-scoped flags", () => {
+    const { result } = renderHook(() => useOnboardingSessionFlags("acct-a"));
+    act(() => result.current.skip());
+    act(() => result.current.dismissChecklist());
+    expect(result.current.skipped).toBe(true);
+    expect(result.current.checklistDismissed).toBe(true);
+  });
+
+  it("resume clears both flags", () => {
+    const { result } = renderHook(() => useOnboardingSessionFlags("acct-a"));
+    act(() => result.current.skip());
+    act(() => result.current.dismissChecklist());
+    act(() => result.current.resume());
+    expect(result.current.skipped).toBe(false);
+    expect(result.current.checklistDismissed).toBe(false);
+  });
+
+  it("does not leak one account's choices to another in the same tab", () => {
+    const { result, rerender } = renderHook(
+      ({ accountId }: { accountId: string }) =>
+        useOnboardingSessionFlags(accountId),
+      { initialProps: { accountId: "acct-a" } },
+    );
+    act(() => result.current.skip());
+    act(() => result.current.dismissChecklist());
+
+    rerender({ accountId: "acct-b" });
+    expect(result.current.skipped).toBe(false);
+    expect(result.current.checklistDismissed).toBe(false);
+
+    rerender({ accountId: "acct-a" });
+    expect(result.current.skipped).toBe(true);
+    expect(result.current.checklistDismissed).toBe(true);
+  });
+});

--- a/hooks/__tests__/useRefreshCatalogsOnLanding.test.tsx
+++ b/hooks/__tests__/useRefreshCatalogsOnLanding.test.tsx
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+import React from "react";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it } from "vitest";
+import { useRefreshCatalogsOnLanding } from "@/hooks/useRefreshCatalogsOnLanding";
+
+describe("useRefreshCatalogsOnLanding", () => {
+  it("invalidates cached catalogs on mount so each landing re-derives fresh", async () => {
+    const queryClient = new QueryClient();
+    // Simulate a fresh-but-stale-in-reality cache entry from useCatalogs
+    // (staleTime 5min): an out-of-band claim would otherwise be missed.
+    queryClient.setQueryData(["catalogs", "acct-a"], { catalogs: [] });
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    renderHook(() => useRefreshCatalogsOnLanding(), { wrapper });
+
+    await waitFor(() => {
+      expect(
+        queryClient.getQueryState(["catalogs", "acct-a"])?.isInvalidated,
+      ).toBe(true);
+    });
+  });
+
+  it("leaves unrelated query caches untouched", async () => {
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(["artists", "user-1", null], []);
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    renderHook(() => useRefreshCatalogsOnLanding(), { wrapper });
+
+    expect(
+      queryClient.getQueryState(["artists", "user-1", null])?.isInvalidated,
+    ).toBe(false);
+  });
+});

--- a/hooks/artists/useArtistsRoster.ts
+++ b/hooks/artists/useArtistsRoster.ts
@@ -17,6 +17,12 @@ interface UseArtistsRosterResult {
   artists: ArtistRecord[];
   isLoading: boolean;
   /**
+   * True when the roster fetch failed. Consumers that derive state from
+   * the roster (e.g. the onboarding gate) must treat an errored roster
+   * as unresolved rather than an empty roster.
+   */
+  isError: boolean;
+  /**
    * Direct cache mutation. Mirrors React's `setState` signature so both
    * `setArtists(newList)` and `setArtists(prev => mutate(prev))` work.
    * Used by `useArtistPinToggle` and `useDeleteArtist` for optimistic
@@ -63,7 +69,11 @@ export function useArtistsRoster({
   // v5's `isLoading` flips false while `enabled` is false, which would
   // let `useNewChatBootstrap` fire with `artistId: undefined` during
   // the user-data-loading window.
-  const { data: artists = [], isPending } = useQuery({
+  const {
+    data: artists = [],
+    isPending,
+    isError,
+  } = useQuery({
     queryKey,
     queryFn,
     enabled: !!userId && authenticated,
@@ -83,5 +93,5 @@ export function useArtistsRoster({
     [queryClient, queryKey, queryFn],
   );
 
-  return { artists, isLoading: isPending, setArtists, refetchArtists };
+  return { artists, isLoading: isPending, isError, setArtists, refetchArtists };
 }

--- a/hooks/useArtists.tsx
+++ b/hooks/useArtists.tsx
@@ -28,10 +28,11 @@ const useArtists = () => {
 
   const orgKey = selectedOrgId || "personal";
 
-  const { artists, isLoading, setArtists, refetchArtists } = useArtistsRoster({
-    userId: userData?.id,
-    orgId: selectedOrgId,
-  });
+  const { artists, isLoading, isError, setArtists, refetchArtists } =
+    useArtistsRoster({
+      userId: userData?.id,
+      orgId: selectedOrgId,
+    });
 
   const { selectedArtist, setSelectedArtist } = useArtistSelection(
     orgKey,
@@ -124,6 +125,7 @@ const useArtists = () => {
     setMenuVisibleArtistId,
     menuVisibleArtistId,
     isLoading,
+    isError,
     isCreatingArtist,
     setIsCreatingArtist,
     updateChatState,

--- a/hooks/useOnboardingGate.ts
+++ b/hooks/useOnboardingGate.ts
@@ -16,28 +16,26 @@ export interface OnboardingGate {
   checkpoints: OnboardingCheckpoint[];
   skip: () => void;
   resume: () => void;
-  dismissChecklist: () => void;
 }
 
 /**
- * Soft gate for the chat home: derived onboarding state + session-scoped
- * skip controls. Single source of truth for the gate — mount it once (in
- * `HomePage`) and pass the callbacks down; skip/dismiss are account-scoped
- * session escape hatches, never persisted server-side
- * (recoupable/chat#1867).
+ * Soft gate for the chat home: derived onboarding state + the session-scoped
+ * skip control. Single source of truth for the gate — mount it once (in
+ * `HomePage`) and pass the callbacks down; skip is an account-scoped session
+ * escape hatch, never persisted server-side (recoupable/chat#1867).
  */
 export function useOnboardingGate(): OnboardingGate {
   const { userData } = useUserProvider();
   const { isReady, step, checkpoints } = useOnboardingState();
-  const { skipped, checklistDismissed, skip, resume, dismissChecklist } =
-    useOnboardingSessionFlags(userData?.account_id ?? "");
+  const { skipped, skip, resume } = useOnboardingSessionFlags(
+    userData?.account_id ?? "",
+  );
 
   return {
-    view: getOnboardingView({ isReady, step, skipped, checklistDismissed }),
+    view: getOnboardingView({ isReady, step, skipped }),
     step,
     checkpoints,
     skip,
     resume,
-    dismissChecklist,
   };
 }

--- a/hooks/useOnboardingGate.ts
+++ b/hooks/useOnboardingGate.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useOnboardingSessionFlags } from "@/hooks/useOnboardingSessionFlags";
 import { useOnboardingState } from "@/hooks/useOnboardingState";
 import { getOnboardingView } from "@/lib/onboarding/getOnboardingView";
 import type { OnboardingView } from "@/lib/onboarding/getOnboardingView";
@@ -8,16 +8,7 @@ import type {
   OnboardingCheckpoint,
   OnboardingStep,
 } from "@/lib/onboarding/types";
-
-// Session-scoped on purpose (recoupable/chat#1867): skip and dismiss are
-// escape hatches for the current visit only — the next landing derives
-// state fresh and resumes the sequence by default. Never persisted
-// server-side (no wizard cursor).
-const SKIP_KEY = "recoup-onboarding-skipped";
-const DISMISS_KEY = "recoup-onboarding-checklist-dismissed";
-
-const readSessionFlag = (key: string): boolean =>
-  typeof window !== "undefined" && window.sessionStorage.getItem(key) === "1";
+import { useUserProvider } from "@/providers/UserProvder";
 
 export interface OnboardingGate {
   view: OnboardingView;
@@ -28,30 +19,18 @@ export interface OnboardingGate {
   dismissChecklist: () => void;
 }
 
-/** Soft gate for the chat home: derived onboarding state + skip controls. */
+/**
+ * Soft gate for the chat home: derived onboarding state + session-scoped
+ * skip controls. Single source of truth for the gate — mount it once (in
+ * `HomePage`) and pass the callbacks down; skip/dismiss are account-scoped
+ * session escape hatches, never persisted server-side
+ * (recoupable/chat#1867).
+ */
 export function useOnboardingGate(): OnboardingGate {
+  const { userData } = useUserProvider();
   const { isReady, step, checkpoints } = useOnboardingState();
-  const [skipped, setSkipped] = useState(() => readSessionFlag(SKIP_KEY));
-  const [checklistDismissed, setChecklistDismissed] = useState(() =>
-    readSessionFlag(DISMISS_KEY),
-  );
-
-  const skip = useCallback(() => {
-    window.sessionStorage.setItem(SKIP_KEY, "1");
-    setSkipped(true);
-  }, []);
-
-  const resume = useCallback(() => {
-    window.sessionStorage.removeItem(SKIP_KEY);
-    window.sessionStorage.removeItem(DISMISS_KEY);
-    setSkipped(false);
-    setChecklistDismissed(false);
-  }, []);
-
-  const dismissChecklist = useCallback(() => {
-    window.sessionStorage.setItem(DISMISS_KEY, "1");
-    setChecklistDismissed(true);
-  }, []);
+  const { skipped, checklistDismissed, skip, resume, dismissChecklist } =
+    useOnboardingSessionFlags(userData?.account_id ?? "");
 
   return {
     view: getOnboardingView({ isReady, step, skipped, checklistDismissed }),

--- a/hooks/useOnboardingGate.ts
+++ b/hooks/useOnboardingGate.ts
@@ -1,0 +1,64 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { useOnboardingState } from "@/hooks/useOnboardingState";
+import { getOnboardingView } from "@/lib/onboarding/getOnboardingView";
+import type { OnboardingView } from "@/lib/onboarding/getOnboardingView";
+import type {
+  OnboardingCheckpoint,
+  OnboardingStep,
+} from "@/lib/onboarding/types";
+
+// Session-scoped on purpose (recoupable/chat#1867): skip and dismiss are
+// escape hatches for the current visit only — the next landing derives
+// state fresh and resumes the sequence by default. Never persisted
+// server-side (no wizard cursor).
+const SKIP_KEY = "recoup-onboarding-skipped";
+const DISMISS_KEY = "recoup-onboarding-checklist-dismissed";
+
+const readSessionFlag = (key: string): boolean =>
+  typeof window !== "undefined" && window.sessionStorage.getItem(key) === "1";
+
+export interface OnboardingGate {
+  view: OnboardingView;
+  step: OnboardingStep;
+  checkpoints: OnboardingCheckpoint[];
+  skip: () => void;
+  resume: () => void;
+  dismissChecklist: () => void;
+}
+
+/** Soft gate for the chat home: derived onboarding state + skip controls. */
+export function useOnboardingGate(): OnboardingGate {
+  const { isReady, step, checkpoints } = useOnboardingState();
+  const [skipped, setSkipped] = useState(() => readSessionFlag(SKIP_KEY));
+  const [checklistDismissed, setChecklistDismissed] = useState(() =>
+    readSessionFlag(DISMISS_KEY),
+  );
+
+  const skip = useCallback(() => {
+    window.sessionStorage.setItem(SKIP_KEY, "1");
+    setSkipped(true);
+  }, []);
+
+  const resume = useCallback(() => {
+    window.sessionStorage.removeItem(SKIP_KEY);
+    window.sessionStorage.removeItem(DISMISS_KEY);
+    setSkipped(false);
+    setChecklistDismissed(false);
+  }, []);
+
+  const dismissChecklist = useCallback(() => {
+    window.sessionStorage.setItem(DISMISS_KEY, "1");
+    setChecklistDismissed(true);
+  }, []);
+
+  return {
+    view: getOnboardingView({ isReady, step, skipped, checklistDismissed }),
+    step,
+    checkpoints,
+    skip,
+    resume,
+    dismissChecklist,
+  };
+}

--- a/hooks/useOnboardingSessionFlags.ts
+++ b/hooks/useOnboardingSessionFlags.ts
@@ -6,16 +6,14 @@ import { writeOnboardingFlag } from "@/lib/onboarding/writeOnboardingFlag";
 
 export interface OnboardingSessionFlags {
   skipped: boolean;
-  checklistDismissed: boolean;
   skip: () => void;
   resume: () => void;
-  dismissChecklist: () => void;
 }
 
 /**
- * Session-scoped skip/dismiss escape hatches for the onboarding gate
+ * Session-scoped skip escape hatch for the onboarding gate
  * (recoupable/chat#1867), keyed by account id so an account switch in the
- * same tab re-derives from that account's own flags instead of inheriting
+ * same tab re-derives from that account's own flag instead of inheriting
  * the previous account's choice. Never persisted server-side.
  */
 export function useOnboardingSessionFlags(
@@ -24,13 +22,9 @@ export function useOnboardingSessionFlags(
   const [skipped, setSkipped] = useState(() =>
     readOnboardingFlag("skipped", accountId),
   );
-  const [checklistDismissed, setChecklistDismissed] = useState(() =>
-    readOnboardingFlag("checklist-dismissed", accountId),
-  );
 
   useEffect(() => {
     setSkipped(readOnboardingFlag("skipped", accountId));
-    setChecklistDismissed(readOnboardingFlag("checklist-dismissed", accountId));
   }, [accountId]);
 
   const skip = useCallback(() => {
@@ -40,15 +34,8 @@ export function useOnboardingSessionFlags(
 
   const resume = useCallback(() => {
     writeOnboardingFlag("skipped", accountId, false);
-    writeOnboardingFlag("checklist-dismissed", accountId, false);
     setSkipped(false);
-    setChecklistDismissed(false);
   }, [accountId]);
 
-  const dismissChecklist = useCallback(() => {
-    writeOnboardingFlag("checklist-dismissed", accountId, true);
-    setChecklistDismissed(true);
-  }, [accountId]);
-
-  return { skipped, checklistDismissed, skip, resume, dismissChecklist };
+  return { skipped, skip, resume };
 }

--- a/hooks/useOnboardingSessionFlags.ts
+++ b/hooks/useOnboardingSessionFlags.ts
@@ -1,0 +1,54 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { readOnboardingFlag } from "@/lib/onboarding/readOnboardingFlag";
+import { writeOnboardingFlag } from "@/lib/onboarding/writeOnboardingFlag";
+
+export interface OnboardingSessionFlags {
+  skipped: boolean;
+  checklistDismissed: boolean;
+  skip: () => void;
+  resume: () => void;
+  dismissChecklist: () => void;
+}
+
+/**
+ * Session-scoped skip/dismiss escape hatches for the onboarding gate
+ * (recoupable/chat#1867), keyed by account id so an account switch in the
+ * same tab re-derives from that account's own flags instead of inheriting
+ * the previous account's choice. Never persisted server-side.
+ */
+export function useOnboardingSessionFlags(
+  accountId: string,
+): OnboardingSessionFlags {
+  const [skipped, setSkipped] = useState(() =>
+    readOnboardingFlag("skipped", accountId),
+  );
+  const [checklistDismissed, setChecklistDismissed] = useState(() =>
+    readOnboardingFlag("checklist-dismissed", accountId),
+  );
+
+  useEffect(() => {
+    setSkipped(readOnboardingFlag("skipped", accountId));
+    setChecklistDismissed(readOnboardingFlag("checklist-dismissed", accountId));
+  }, [accountId]);
+
+  const skip = useCallback(() => {
+    writeOnboardingFlag("skipped", accountId, true);
+    setSkipped(true);
+  }, [accountId]);
+
+  const resume = useCallback(() => {
+    writeOnboardingFlag("skipped", accountId, false);
+    writeOnboardingFlag("checklist-dismissed", accountId, false);
+    setSkipped(false);
+    setChecklistDismissed(false);
+  }, [accountId]);
+
+  const dismissChecklist = useCallback(() => {
+    writeOnboardingFlag("checklist-dismissed", accountId, true);
+    setChecklistDismissed(true);
+  }, [accountId]);
+
+  return { skipped, checklistDismissed, skip, resume, dismissChecklist };
+}

--- a/hooks/useOnboardingState.ts
+++ b/hooks/useOnboardingState.ts
@@ -1,0 +1,60 @@
+"use client";
+
+import { useMemo } from "react";
+import { usePrivy } from "@privy-io/react-auth";
+import useCatalogs from "@/hooks/useCatalogs";
+import { useScheduledActions } from "@/hooks/useScheduledActions";
+import { useArtistProvider } from "@/providers/ArtistProvider";
+import { getOnboardingCheckpoints } from "@/lib/onboarding/getOnboardingCheckpoints";
+import { getOnboardingStep } from "@/lib/onboarding/getOnboardingStep";
+import type {
+  OnboardingCheckpoint,
+  OnboardingStep,
+} from "@/lib/onboarding/types";
+
+export interface OnboardingState {
+  /** True once every checkpoint source resolved for an authenticated user. */
+  isReady: boolean;
+  step: OnboardingStep;
+  checkpoints: OnboardingCheckpoint[];
+}
+
+/**
+ * Derives onboarding state on every landing from the existing checkpoint
+ * sources: the artist roster (with socials), claimed catalogs, and
+ * scheduled tasks. No stored cursor (recoupable/chat#1867), so steps
+ * completed out-of-band (valuation auto-claim, chat, API) advance the
+ * derived step automatically. Composes existing data hooks; auth and the
+ * roster come from providers per the hooks convention.
+ */
+export function useOnboardingState(): OnboardingState {
+  const { authenticated } = usePrivy();
+  const { artists, isLoading: artistsLoading } = useArtistProvider();
+  const catalogsQuery = useCatalogs();
+  const tasksQuery = useScheduledActions({});
+
+  const catalogs = catalogsQuery.data?.catalogs;
+  const tasks = tasksQuery.data;
+
+  // Failed fetches keep isReady false: the gate fails open to the normal
+  // app instead of mis-deriving a step from partial state.
+  const isReady =
+    authenticated &&
+    !artistsLoading &&
+    catalogsQuery.isSuccess &&
+    tasksQuery.isSuccess;
+
+  return useMemo(() => {
+    const state = {
+      artists: artists ?? [],
+      catalogs: catalogs ?? [],
+      tasks: tasks ?? [],
+    };
+
+    return {
+      isReady,
+      step: getOnboardingStep(state),
+      checkpoints: getOnboardingCheckpoints(state),
+    };
+  }, [artists, catalogs, tasks, isReady]);
+}

--- a/hooks/useOnboardingState.ts
+++ b/hooks/useOnboardingState.ts
@@ -3,21 +3,13 @@
 import { useMemo } from "react";
 import { usePrivy } from "@privy-io/react-auth";
 import useCatalogs from "@/hooks/useCatalogs";
+import { useRefreshCatalogsOnLanding } from "@/hooks/useRefreshCatalogsOnLanding";
 import { useScheduledActions } from "@/hooks/useScheduledActions";
 import { useArtistProvider } from "@/providers/ArtistProvider";
-import { getOnboardingCheckpoints } from "@/lib/onboarding/getOnboardingCheckpoints";
-import { getOnboardingStep } from "@/lib/onboarding/getOnboardingStep";
-import type {
-  OnboardingCheckpoint,
-  OnboardingStep,
-} from "@/lib/onboarding/types";
+import { deriveOnboardingState } from "@/lib/onboarding/deriveOnboardingState";
+import type { DerivedOnboardingState } from "@/lib/onboarding/deriveOnboardingState";
 
-export interface OnboardingState {
-  /** True once every checkpoint source resolved for an authenticated user. */
-  isReady: boolean;
-  step: OnboardingStep;
-  checkpoints: OnboardingCheckpoint[];
-}
+export type OnboardingState = DerivedOnboardingState;
 
 /**
  * Derives onboarding state on every landing from the existing checkpoint
@@ -25,36 +17,46 @@ export interface OnboardingState {
  * scheduled tasks. No stored cursor (recoupable/chat#1867), so steps
  * completed out-of-band (valuation auto-claim, chat, API) advance the
  * derived step automatically. Composes existing data hooks; auth and the
- * roster come from providers per the hooks convention.
+ * roster come from providers per the hooks convention; the projection
+ * itself lives in `deriveOnboardingState` (pure).
  */
 export function useOnboardingState(): OnboardingState {
   const { authenticated } = usePrivy();
-  const { artists, isLoading: artistsLoading } = useArtistProvider();
+  const {
+    artists,
+    isLoading: artistsLoading,
+    isError: artistsError,
+  } = useArtistProvider();
   const catalogsQuery = useCatalogs();
   const tasksQuery = useScheduledActions({});
+  useRefreshCatalogsOnLanding();
 
   const catalogs = catalogsQuery.data?.catalogs;
+  const catalogsReady = catalogsQuery.isSuccess;
   const tasks = tasksQuery.data;
+  const tasksReady = tasksQuery.isSuccess;
 
-  // Failed fetches keep isReady false: the gate fails open to the normal
-  // app instead of mis-deriving a step from partial state.
-  const isReady =
-    authenticated &&
-    !artistsLoading &&
-    catalogsQuery.isSuccess &&
-    tasksQuery.isSuccess;
-
-  return useMemo(() => {
-    const state = {
-      artists: artists ?? [],
-      catalogs: catalogs ?? [],
-      tasks: tasks ?? [],
-    };
-
-    return {
-      isReady,
-      step: getOnboardingStep(state),
-      checkpoints: getOnboardingCheckpoints(state),
-    };
-  }, [artists, catalogs, tasks, isReady]);
+  return useMemo(
+    () =>
+      deriveOnboardingState({
+        authenticated,
+        artists,
+        artistsLoading,
+        artistsError,
+        catalogs,
+        catalogsReady,
+        tasks,
+        tasksReady,
+      }),
+    [
+      authenticated,
+      artists,
+      artistsLoading,
+      artistsError,
+      catalogs,
+      catalogsReady,
+      tasks,
+      tasksReady,
+    ],
+  );
 }

--- a/hooks/useRefreshCatalogsOnLanding.ts
+++ b/hooks/useRefreshCatalogsOnLanding.ts
@@ -1,0 +1,19 @@
+"use client";
+
+import { useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+
+/**
+ * One fresh catalogs read per landing for the onboarding state path only:
+ * `useCatalogs` keeps its 5-minute staleTime for every other consumer, but
+ * the derived onboarding step must see out-of-band claims (valuation
+ * auto-claim, chat, API) immediately, so mounting the onboarding consumer
+ * invalidates the cached entry and lets the active query refetch.
+ */
+export function useRefreshCatalogsOnLanding(): void {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    queryClient.invalidateQueries({ queryKey: ["catalogs"] });
+  }, [queryClient]);
+}

--- a/lib/onboarding/__tests__/deriveOnboardingState.test.ts
+++ b/lib/onboarding/__tests__/deriveOnboardingState.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { deriveOnboardingState } from "@/lib/onboarding/deriveOnboardingState";
+
+const readyInput = {
+  authenticated: true,
+  artists: [{ account_socials: [{}] }],
+  artistsLoading: false,
+  artistsError: false,
+  catalogs: [{}],
+  catalogsReady: true,
+  tasks: [{ enabled: true }],
+  tasksReady: true,
+};
+
+describe("deriveOnboardingState", () => {
+  it("is ready with a derived step once every source resolved", () => {
+    const state = deriveOnboardingState(readyInput);
+    expect(state.isReady).toBe(true);
+    expect(state.step).toBe("complete");
+    expect(state.checkpoints).toHaveLength(4);
+  });
+
+  it("is not ready while the roster is loading", () => {
+    expect(
+      deriveOnboardingState({ ...readyInput, artistsLoading: true }).isReady,
+    ).toBe(false);
+  });
+
+  it("fails open when the roster fetch errored (isReady false -> view none)", () => {
+    expect(
+      deriveOnboardingState({ ...readyInput, artistsError: true }).isReady,
+    ).toBe(false);
+  });
+
+  it("is not ready when catalogs or tasks have not resolved", () => {
+    expect(
+      deriveOnboardingState({ ...readyInput, catalogsReady: false }).isReady,
+    ).toBe(false);
+    expect(
+      deriveOnboardingState({ ...readyInput, tasksReady: false }).isReady,
+    ).toBe(false);
+  });
+
+  it("is not ready while unauthenticated", () => {
+    expect(
+      deriveOnboardingState({ ...readyInput, authenticated: false }).isReady,
+    ).toBe(false);
+  });
+
+  it("treats missing source data as empty state", () => {
+    const state = deriveOnboardingState({
+      ...readyInput,
+      artists: undefined,
+      catalogs: undefined,
+      tasks: undefined,
+    });
+    expect(state.step).toBe("artists");
+    expect(state.checkpoints.every((c) => !c.complete)).toBe(true);
+  });
+});

--- a/lib/onboarding/__tests__/getOnboardingCheckpoints.test.ts
+++ b/lib/onboarding/__tests__/getOnboardingCheckpoints.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { getOnboardingCheckpoints } from "@/lib/onboarding/getOnboardingCheckpoints";
+
+describe("getOnboardingCheckpoints", () => {
+  it("returns all four checkpoints in sequence order", () => {
+    const checkpoints = getOnboardingCheckpoints({
+      artists: [],
+      catalogs: [],
+      tasks: [],
+    });
+    expect(checkpoints.map((c) => c.id)).toEqual([
+      "artists",
+      "socials",
+      "catalog",
+      "task",
+    ]);
+    expect(checkpoints.every((c) => !c.complete)).toBe(true);
+  });
+
+  it("marks each checkpoint complete from account state, independently", () => {
+    const checkpoints = getOnboardingCheckpoints({
+      artists: [{ account_socials: [{ id: "s1" }] }],
+      catalogs: [],
+      tasks: [{ enabled: true }],
+    });
+    expect(checkpoints).toEqual([
+      { id: "artists", complete: true },
+      { id: "socials", complete: true },
+      { id: "catalog", complete: false },
+      { id: "task", complete: true },
+    ]);
+  });
+
+  it("keeps socials incomplete while the roster is empty", () => {
+    const checkpoints = getOnboardingCheckpoints({
+      artists: [],
+      catalogs: [{ id: "c1" }],
+      tasks: [],
+    });
+    expect(checkpoints.find((c) => c.id === "socials")?.complete).toBe(false);
+  });
+});

--- a/lib/onboarding/__tests__/getOnboardingFlagKey.test.ts
+++ b/lib/onboarding/__tests__/getOnboardingFlagKey.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { getOnboardingFlagKey } from "@/lib/onboarding/getOnboardingFlagKey";
+
+describe("getOnboardingFlagKey", () => {
+  it("scopes the skipped flag by account id", () => {
+    expect(getOnboardingFlagKey("skipped", "acct-a")).toBe(
+      "recoup-onboarding-skipped:acct-a",
+    );
+  });
+
+  it("scopes the checklist-dismissed flag by account id", () => {
+    expect(getOnboardingFlagKey("checklist-dismissed", "acct-a")).toBe(
+      "recoup-onboarding-checklist-dismissed:acct-a",
+    );
+  });
+
+  it("produces distinct keys for distinct accounts (no cross-account leak)", () => {
+    expect(getOnboardingFlagKey("skipped", "acct-a")).not.toBe(
+      getOnboardingFlagKey("skipped", "acct-b"),
+    );
+  });
+});

--- a/lib/onboarding/__tests__/getOnboardingFlagKey.test.ts
+++ b/lib/onboarding/__tests__/getOnboardingFlagKey.test.ts
@@ -8,12 +8,6 @@ describe("getOnboardingFlagKey", () => {
     );
   });
 
-  it("scopes the checklist-dismissed flag by account id", () => {
-    expect(getOnboardingFlagKey("checklist-dismissed", "acct-a")).toBe(
-      "recoup-onboarding-checklist-dismissed:acct-a",
-    );
-  });
-
   it("produces distinct keys for distinct accounts (no cross-account leak)", () => {
     expect(getOnboardingFlagKey("skipped", "acct-a")).not.toBe(
       getOnboardingFlagKey("skipped", "acct-b"),

--- a/lib/onboarding/__tests__/getOnboardingStep.edge.test.ts
+++ b/lib/onboarding/__tests__/getOnboardingStep.edge.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { getOnboardingStep } from "@/lib/onboarding/getOnboardingStep";
+
+describe("getOnboardingStep edge cases", () => {
+  it("treats null, undefined and empty account_socials as no socials", () => {
+    for (const account_socials of [null, undefined, []]) {
+      expect(
+        getOnboardingStep({
+          artists: [{ account_socials }],
+          catalogs: [{ id: "c1" }],
+          tasks: [{ enabled: true }],
+        }),
+      ).toBe("socials");
+    }
+  });
+
+  it("requires every rostered artist to have at least one social", () => {
+    expect(
+      getOnboardingStep({
+        artists: [{ account_socials: [{ id: "s1" }] }, { account_socials: [] }],
+        catalogs: [{ id: "c1" }],
+        tasks: [{ enabled: true }],
+      }),
+    ).toBe("socials");
+  });
+
+  it("ignores disabled and paused (null-enabled) tasks", () => {
+    expect(
+      getOnboardingStep({
+        artists: [{ account_socials: [{ id: "s1" }] }],
+        catalogs: [{ id: "c1" }],
+        tasks: [{ enabled: false }, { enabled: null }],
+      }),
+    ).toBe("task");
+  });
+});

--- a/lib/onboarding/__tests__/getOnboardingStep.test.ts
+++ b/lib/onboarding/__tests__/getOnboardingStep.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { getOnboardingStep } from "@/lib/onboarding/getOnboardingStep";
+import type {
+  OnboardingAccountState,
+  OnboardingStep,
+} from "@/lib/onboarding/types";
+
+interface StateFlags {
+  hasArtists: boolean;
+  allArtistsHaveSocials: boolean;
+  hasCatalog: boolean;
+  hasEnabledTask: boolean;
+}
+
+const makeState = ({
+  hasArtists,
+  allArtistsHaveSocials,
+  hasCatalog,
+  hasEnabledTask,
+}: StateFlags): OnboardingAccountState => ({
+  artists: hasArtists
+    ? [{ account_socials: allArtistsHaveSocials ? [{ id: "s1" }] : [] }]
+    : [],
+  catalogs: hasCatalog ? [{ id: "c1" }] : [],
+  tasks: hasEnabledTask ? [{ enabled: true }] : [],
+});
+
+/** Mirrors the spec's predicate priority: first unmet checkpoint wins. */
+const expectedStep = (flags: StateFlags): OnboardingStep => {
+  if (!flags.hasArtists) return "artists";
+  if (!flags.allArtistsHaveSocials) return "socials";
+  if (!flags.hasCatalog) return "catalog";
+  if (!flags.hasEnabledTask) return "task";
+  return "complete";
+};
+
+describe("getOnboardingStep", () => {
+  it("derives the first unmet step for every predicate combination", () => {
+    const bools = [false, true];
+    for (const hasArtists of bools) {
+      for (const allArtistsHaveSocials of bools) {
+        for (const hasCatalog of bools) {
+          for (const hasEnabledTask of bools) {
+            const flags = {
+              hasArtists,
+              allArtistsHaveSocials,
+              hasCatalog,
+              hasEnabledTask,
+            };
+            expect(
+              getOnboardingStep(makeState(flags)),
+              JSON.stringify(flags),
+            ).toBe(expectedStep(flags));
+          }
+        }
+      }
+    }
+  });
+
+  it("returns artists for a brand-new empty account", () => {
+    expect(getOnboardingStep({ artists: [], catalogs: [], tasks: [] })).toBe(
+      "artists",
+    );
+  });
+
+  it("auto-advances past steps completed out-of-band (valuation auto-claim)", () => {
+    // The marketing valuation auto-creates artist + catalog with socials
+    // before the user ever lands on chat: derived step must skip to task.
+    expect(
+      getOnboardingStep({
+        artists: [{ account_socials: [{ id: "s1" }] }],
+        catalogs: [{ id: "c1" }],
+        tasks: [],
+      }),
+    ).toBe("task");
+  });
+
+  it("returns complete for a fully activated account", () => {
+    expect(
+      getOnboardingStep({
+        artists: [{ account_socials: [{ id: "s1" }] }],
+        catalogs: [{ id: "c1" }],
+        tasks: [{ enabled: false }, { enabled: true }],
+      }),
+    ).toBe("complete");
+  });
+
+  it("never depends on stored cursor state: same inputs, same step", () => {
+    const state: OnboardingAccountState = {
+      artists: [{ account_socials: [] }],
+      catalogs: [],
+      tasks: [],
+    };
+    expect(getOnboardingStep(state)).toBe(getOnboardingStep(state));
+  });
+});

--- a/lib/onboarding/__tests__/getOnboardingStepContent.test.ts
+++ b/lib/onboarding/__tests__/getOnboardingStepContent.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { getOnboardingStepContent } from "@/lib/onboarding/getOnboardingStepContent";
+import { ONBOARDING_STEP_IDS } from "@/lib/onboarding/types";
+
+describe("getOnboardingStepContent", () => {
+  it("provides a titled card with an in-app link for every step", () => {
+    for (const id of ONBOARDING_STEP_IDS) {
+      const content = getOnboardingStepContent(id);
+      expect(content.title.length, id).toBeGreaterThan(0);
+      expect(content.description.length, id).toBeGreaterThan(0);
+      expect(content.linkLabel.length, id).toBeGreaterThan(0);
+      expect(content.href.startsWith("/"), id).toBe(true);
+    }
+  });
+
+  it("links each step to the relevant existing page", () => {
+    expect(getOnboardingStepContent("artists").href).toBe("/artists");
+    expect(getOnboardingStepContent("socials").href).toBe("/artists");
+    expect(getOnboardingStepContent("catalog").href).toBe("/catalogs");
+    expect(getOnboardingStepContent("task").href).toBe("/tasks");
+  });
+});

--- a/lib/onboarding/__tests__/getOnboardingView.test.ts
+++ b/lib/onboarding/__tests__/getOnboardingView.test.ts
@@ -4,58 +4,27 @@ import { getOnboardingView } from "@/lib/onboarding/getOnboardingView";
 describe("getOnboardingView", () => {
   it("shows nothing until account state has resolved", () => {
     expect(
-      getOnboardingView({
-        isReady: false,
-        step: "artists",
-        skipped: false,
-        checklistDismissed: false,
-      }),
+      getOnboardingView({ isReady: false, step: "artists", skipped: false }),
     ).toBe("none");
   });
 
   it("never surfaces onboarding for a fully activated account", () => {
     for (const skipped of [false, true]) {
       expect(
-        getOnboardingView({
-          isReady: true,
-          step: "complete",
-          skipped,
-          checklistDismissed: false,
-        }),
+        getOnboardingView({ isReady: true, step: "complete", skipped }),
       ).toBe("none");
     }
   });
 
   it("resumes the sequence by default for incomplete accounts", () => {
     expect(
-      getOnboardingView({
-        isReady: true,
-        step: "task",
-        skipped: false,
-        checklistDismissed: false,
-      }),
+      getOnboardingView({ isReady: true, step: "task", skipped: false }),
     ).toBe("sequence");
   });
 
-  it("drops to the app with the checklist pinned after skip", () => {
+  it("keeps the checklist pinned after skip — it is never dismissible", () => {
     expect(
-      getOnboardingView({
-        isReady: true,
-        step: "socials",
-        skipped: true,
-        checklistDismissed: false,
-      }),
+      getOnboardingView({ isReady: true, step: "socials", skipped: true }),
     ).toBe("checklist");
-  });
-
-  it("hides the checklist once dismissed", () => {
-    expect(
-      getOnboardingView({
-        isReady: true,
-        step: "socials",
-        skipped: true,
-        checklistDismissed: true,
-      }),
-    ).toBe("none");
   });
 });

--- a/lib/onboarding/__tests__/getOnboardingView.test.ts
+++ b/lib/onboarding/__tests__/getOnboardingView.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { getOnboardingView } from "@/lib/onboarding/getOnboardingView";
+
+describe("getOnboardingView", () => {
+  it("shows nothing until account state has resolved", () => {
+    expect(
+      getOnboardingView({
+        isReady: false,
+        step: "artists",
+        skipped: false,
+        checklistDismissed: false,
+      }),
+    ).toBe("none");
+  });
+
+  it("never surfaces onboarding for a fully activated account", () => {
+    for (const skipped of [false, true]) {
+      expect(
+        getOnboardingView({
+          isReady: true,
+          step: "complete",
+          skipped,
+          checklistDismissed: false,
+        }),
+      ).toBe("none");
+    }
+  });
+
+  it("resumes the sequence by default for incomplete accounts", () => {
+    expect(
+      getOnboardingView({
+        isReady: true,
+        step: "task",
+        skipped: false,
+        checklistDismissed: false,
+      }),
+    ).toBe("sequence");
+  });
+
+  it("drops to the app with the checklist pinned after skip", () => {
+    expect(
+      getOnboardingView({
+        isReady: true,
+        step: "socials",
+        skipped: true,
+        checklistDismissed: false,
+      }),
+    ).toBe("checklist");
+  });
+
+  it("hides the checklist once dismissed", () => {
+    expect(
+      getOnboardingView({
+        isReady: true,
+        step: "socials",
+        skipped: true,
+        checklistDismissed: true,
+      }),
+    ).toBe("none");
+  });
+});

--- a/lib/onboarding/__tests__/readOnboardingFlag.test.ts
+++ b/lib/onboarding/__tests__/readOnboardingFlag.test.ts
@@ -1,0 +1,33 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { readOnboardingFlag } from "@/lib/onboarding/readOnboardingFlag";
+import { getOnboardingFlagKey } from "@/lib/onboarding/getOnboardingFlagKey";
+
+describe("readOnboardingFlag", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it("returns false when the flag was never set", () => {
+    expect(readOnboardingFlag("skipped", "acct-a")).toBe(false);
+  });
+
+  it("returns true only for the account that set the flag", () => {
+    window.sessionStorage.setItem(
+      getOnboardingFlagKey("skipped", "acct-a"),
+      "1",
+    );
+    expect(readOnboardingFlag("skipped", "acct-a")).toBe(true);
+    expect(readOnboardingFlag("skipped", "acct-b")).toBe(false);
+  });
+
+  it("fails open (false) when sessionStorage access throws", () => {
+    const getItem = vi
+      .spyOn(Storage.prototype, "getItem")
+      .mockImplementation(() => {
+        throw new Error("denied");
+      });
+    expect(readOnboardingFlag("skipped", "acct-a")).toBe(false);
+    getItem.mockRestore();
+  });
+});

--- a/lib/onboarding/__tests__/writeOnboardingFlag.test.ts
+++ b/lib/onboarding/__tests__/writeOnboardingFlag.test.ts
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { writeOnboardingFlag } from "@/lib/onboarding/writeOnboardingFlag";
+import { readOnboardingFlag } from "@/lib/onboarding/readOnboardingFlag";
+
+describe("writeOnboardingFlag", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it("sets a flag readable for the same account only", () => {
+    writeOnboardingFlag("checklist-dismissed", "acct-a", true);
+    expect(readOnboardingFlag("checklist-dismissed", "acct-a")).toBe(true);
+    expect(readOnboardingFlag("checklist-dismissed", "acct-b")).toBe(false);
+  });
+
+  it("clears a flag when written false", () => {
+    writeOnboardingFlag("skipped", "acct-a", true);
+    writeOnboardingFlag("skipped", "acct-a", false);
+    expect(readOnboardingFlag("skipped", "acct-a")).toBe(false);
+  });
+
+  it("no-ops instead of throwing when sessionStorage access throws", () => {
+    const setItem = vi
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {
+        throw new Error("denied");
+      });
+    expect(() => writeOnboardingFlag("skipped", "acct-a", true)).not.toThrow();
+    setItem.mockRestore();
+  });
+});

--- a/lib/onboarding/__tests__/writeOnboardingFlag.test.ts
+++ b/lib/onboarding/__tests__/writeOnboardingFlag.test.ts
@@ -9,9 +9,9 @@ describe("writeOnboardingFlag", () => {
   });
 
   it("sets a flag readable for the same account only", () => {
-    writeOnboardingFlag("checklist-dismissed", "acct-a", true);
-    expect(readOnboardingFlag("checklist-dismissed", "acct-a")).toBe(true);
-    expect(readOnboardingFlag("checklist-dismissed", "acct-b")).toBe(false);
+    writeOnboardingFlag("skipped", "acct-a", true);
+    expect(readOnboardingFlag("skipped", "acct-a")).toBe(true);
+    expect(readOnboardingFlag("skipped", "acct-b")).toBe(false);
   });
 
   it("clears a flag when written false", () => {

--- a/lib/onboarding/deriveOnboardingState.ts
+++ b/lib/onboarding/deriveOnboardingState.ts
@@ -1,0 +1,60 @@
+import { getOnboardingCheckpoints } from "@/lib/onboarding/getOnboardingCheckpoints";
+import { getOnboardingStep } from "@/lib/onboarding/getOnboardingStep";
+import type {
+  OnboardingArtistState,
+  OnboardingCheckpoint,
+  OnboardingStep,
+  OnboardingTaskState,
+} from "@/lib/onboarding/types";
+
+export interface DeriveOnboardingStateInput {
+  authenticated: boolean;
+  artists: ReadonlyArray<OnboardingArtistState> | undefined;
+  artistsLoading: boolean;
+  artistsError: boolean;
+  catalogs: ReadonlyArray<unknown> | undefined;
+  catalogsReady: boolean;
+  tasks: ReadonlyArray<OnboardingTaskState> | undefined;
+  tasksReady: boolean;
+}
+
+export interface DerivedOnboardingState {
+  /** True once every checkpoint source resolved for an authenticated user. */
+  isReady: boolean;
+  step: OnboardingStep;
+  checkpoints: OnboardingCheckpoint[];
+}
+
+/**
+ * Pure projection of the checkpoint sources into onboarding state.
+ * A loading or errored source keeps `isReady` false, so the gate fails
+ * open to the normal app instead of mis-deriving a step from partial
+ * state (recoupable/chat#1867).
+ */
+export function deriveOnboardingState({
+  authenticated,
+  artists,
+  artistsLoading,
+  artistsError,
+  catalogs,
+  catalogsReady,
+  tasks,
+  tasksReady,
+}: DeriveOnboardingStateInput): DerivedOnboardingState {
+  const state = {
+    artists: artists ?? [],
+    catalogs: catalogs ?? [],
+    tasks: tasks ?? [],
+  };
+
+  return {
+    isReady:
+      authenticated &&
+      !artistsLoading &&
+      !artistsError &&
+      catalogsReady &&
+      tasksReady,
+    step: getOnboardingStep(state),
+    checkpoints: getOnboardingCheckpoints(state),
+  };
+}

--- a/lib/onboarding/getOnboardingCheckpoints.ts
+++ b/lib/onboarding/getOnboardingCheckpoints.ts
@@ -1,0 +1,37 @@
+import type {
+  OnboardingAccountState,
+  OnboardingCheckpoint,
+} from "@/lib/onboarding/types";
+
+/**
+ * Evaluates every activation checkpoint predicate against account state
+ * (recoupable/chat#1867). Each flag is independent so a checkpoint completed
+ * out-of-band (e.g. an artist added via API) reads complete immediately:
+ *
+ * - artists:  the account has at least one rostered artist
+ * - socials:  every rostered artist has at least one linked social
+ * - catalog:  the account has claimed at least one catalog
+ * - task:     the account has at least one enabled scheduled task
+ */
+export function getOnboardingCheckpoints(
+  state: OnboardingAccountState,
+): OnboardingCheckpoint[] {
+  const hasArtists = state.artists.length > 0;
+
+  return [
+    { id: "artists", complete: hasArtists },
+    {
+      id: "socials",
+      complete:
+        hasArtists &&
+        state.artists.every(
+          (artist) => (artist.account_socials?.length ?? 0) > 0,
+        ),
+    },
+    { id: "catalog", complete: state.catalogs.length > 0 },
+    {
+      id: "task",
+      complete: state.tasks.some((task) => task.enabled === true),
+    },
+  ];
+}

--- a/lib/onboarding/getOnboardingFlagKey.ts
+++ b/lib/onboarding/getOnboardingFlagKey.ts
@@ -3,7 +3,7 @@ import type { OnboardingFlag } from "@/lib/onboarding/types";
 /**
  * sessionStorage key for a session-scoped onboarding flag, scoped by
  * account id so accounts sharing a tab never inherit each other's
- * skip/dismiss choices.
+ * skip choice.
  */
 export function getOnboardingFlagKey(
   flag: OnboardingFlag,

--- a/lib/onboarding/getOnboardingFlagKey.ts
+++ b/lib/onboarding/getOnboardingFlagKey.ts
@@ -1,0 +1,13 @@
+import type { OnboardingFlag } from "@/lib/onboarding/types";
+
+/**
+ * sessionStorage key for a session-scoped onboarding flag, scoped by
+ * account id so accounts sharing a tab never inherit each other's
+ * skip/dismiss choices.
+ */
+export function getOnboardingFlagKey(
+  flag: OnboardingFlag,
+  accountId: string,
+): string {
+  return `recoup-onboarding-${flag}:${accountId}`;
+}

--- a/lib/onboarding/getOnboardingStep.ts
+++ b/lib/onboarding/getOnboardingStep.ts
@@ -1,0 +1,22 @@
+import { getOnboardingCheckpoints } from "@/lib/onboarding/getOnboardingCheckpoints";
+import type {
+  OnboardingAccountState,
+  OnboardingStep,
+} from "@/lib/onboarding/types";
+
+/**
+ * Derives the current onboarding step from account state: the first unmet
+ * activation checkpoint, or "complete" once all are met. Pure and
+ * deterministic by design (recoupable/chat#1867): recomputed on every
+ * landing so resume, multi-device, and out-of-band completion are correct
+ * for free, with no stored wizard cursor to drift from reality.
+ */
+export function getOnboardingStep(
+  state: OnboardingAccountState,
+): OnboardingStep {
+  const firstUnmet = getOnboardingCheckpoints(state).find(
+    (checkpoint) => !checkpoint.complete,
+  );
+
+  return firstUnmet?.id ?? "complete";
+}

--- a/lib/onboarding/getOnboardingStepContent.ts
+++ b/lib/onboarding/getOnboardingStepContent.ts
@@ -1,0 +1,50 @@
+import type { OnboardingStepId } from "@/lib/onboarding/types";
+
+export interface OnboardingStepContent {
+  title: string;
+  description: string;
+  href: string;
+  linkLabel: string;
+}
+
+const STEP_CONTENT: Record<OnboardingStepId, OnboardingStepContent> = {
+  artists: {
+    title: "Confirm your artists",
+    description:
+      "Confirm the artists you manage and add the rest of your roster so Recoup works for all of them.",
+    href: "/artists",
+    linkLabel: "Open your roster",
+  },
+  socials: {
+    title: "Verify socials",
+    description:
+      "Check the social profiles matched to each artist so the data behind your reports is right.",
+    href: "/artists",
+    linkLabel: "Review artist profiles",
+  },
+  catalog: {
+    title: "Claim your catalog",
+    description:
+      "Connect the catalog behind your valuation so Recoup can measure and track it over time.",
+    href: "/catalogs",
+    linkLabel: "Open catalogs",
+  },
+  task: {
+    title: "Schedule your first report",
+    description:
+      "Set up a recurring task and Recoup will keep working your catalog every week.",
+    href: "/tasks",
+    linkLabel: "Open tasks",
+  },
+};
+
+/**
+ * Placeholder card copy for each onboarding step. Each step's full
+ * experience ships in sibling PRs on recoupable/chat#1867; until then the
+ * card links to the existing page where the step can be completed today.
+ */
+export function getOnboardingStepContent(
+  step: OnboardingStepId,
+): OnboardingStepContent {
+  return STEP_CONTENT[step];
+}

--- a/lib/onboarding/getOnboardingView.ts
+++ b/lib/onboarding/getOnboardingView.ts
@@ -8,23 +8,19 @@ interface GetOnboardingViewParams {
   step: OnboardingStep;
   /** User pressed "skip for now" this session. */
   skipped: boolean;
-  /** User dismissed the pinned checklist this session. */
-  checklistDismissed: boolean;
 }
 
 /**
  * Soft-gate decision for the chat home (recoupable/chat#1867): incomplete
  * accounts resume the sequence by default; skip drops to the app with the
- * checklist pinned; activated accounts (and unresolved state, so the
- * sequence never flashes) see the normal app.
+ * checklist pinned as a persistent reminder (no dismiss); activated accounts
+ * (and unresolved state, so the sequence never flashes) see the normal app.
  */
 export function getOnboardingView({
   isReady,
   step,
   skipped,
-  checklistDismissed,
 }: GetOnboardingViewParams): OnboardingView {
   if (!isReady || step === "complete") return "none";
-  if (!skipped) return "sequence";
-  return checklistDismissed ? "none" : "checklist";
+  return skipped ? "checklist" : "sequence";
 }

--- a/lib/onboarding/getOnboardingView.ts
+++ b/lib/onboarding/getOnboardingView.ts
@@ -1,0 +1,30 @@
+import type { OnboardingStep } from "@/lib/onboarding/types";
+
+export type OnboardingView = "none" | "sequence" | "checklist";
+
+interface GetOnboardingViewParams {
+  /** True once artists, catalogs and tasks have all resolved. */
+  isReady: boolean;
+  step: OnboardingStep;
+  /** User pressed "skip for now" this session. */
+  skipped: boolean;
+  /** User dismissed the pinned checklist this session. */
+  checklistDismissed: boolean;
+}
+
+/**
+ * Soft-gate decision for the chat home (recoupable/chat#1867): incomplete
+ * accounts resume the sequence by default; skip drops to the app with the
+ * checklist pinned; activated accounts (and unresolved state, so the
+ * sequence never flashes) see the normal app.
+ */
+export function getOnboardingView({
+  isReady,
+  step,
+  skipped,
+  checklistDismissed,
+}: GetOnboardingViewParams): OnboardingView {
+  if (!isReady || step === "complete") return "none";
+  if (!skipped) return "sequence";
+  return checklistDismissed ? "none" : "checklist";
+}

--- a/lib/onboarding/readOnboardingFlag.ts
+++ b/lib/onboarding/readOnboardingFlag.ts
@@ -1,0 +1,22 @@
+import { getOnboardingFlagKey } from "@/lib/onboarding/getOnboardingFlagKey";
+import type { OnboardingFlag } from "@/lib/onboarding/types";
+
+/**
+ * Safe sessionStorage read for a session-scoped onboarding flag. Storage
+ * access can throw (SSR, denied/partitioned storage); the gate must fail
+ * open, so any failure reads as "not set".
+ */
+export function readOnboardingFlag(
+  flag: OnboardingFlag,
+  accountId: string,
+): boolean {
+  try {
+    return (
+      typeof window !== "undefined" &&
+      window.sessionStorage.getItem(getOnboardingFlagKey(flag, accountId)) ===
+        "1"
+    );
+  } catch {
+    return false;
+  }
+}

--- a/lib/onboarding/types.ts
+++ b/lib/onboarding/types.ts
@@ -1,0 +1,38 @@
+/**
+ * Onboarding activation checkpoints, in sequence order. The current step is
+ * always DERIVED from account state with these predicates on every landing,
+ * never stored as a wizard cursor (recoupable/chat#1867): out-of-band
+ * completion (valuation auto-claim, chat, API) can never desync the flow.
+ */
+export const ONBOARDING_STEP_IDS = [
+  "artists",
+  "socials",
+  "catalog",
+  "task",
+] as const;
+
+export type OnboardingStepId = (typeof ONBOARDING_STEP_IDS)[number];
+
+export type OnboardingStep = OnboardingStepId | "complete";
+
+/** Minimal structural slice of an `account_artist_ids` roster entry. */
+export interface OnboardingArtistState {
+  account_socials?: ReadonlyArray<unknown> | null;
+}
+
+/** Minimal structural slice of a `scheduled_actions` row. */
+export interface OnboardingTaskState {
+  enabled?: boolean | null;
+}
+
+/** Everything the step derivation needs, sourced from existing tables. */
+export interface OnboardingAccountState {
+  artists: ReadonlyArray<OnboardingArtistState>;
+  catalogs: ReadonlyArray<unknown>;
+  tasks: ReadonlyArray<OnboardingTaskState>;
+}
+
+export interface OnboardingCheckpoint {
+  id: OnboardingStepId;
+  complete: boolean;
+}

--- a/lib/onboarding/types.ts
+++ b/lib/onboarding/types.ts
@@ -36,3 +36,10 @@ export interface OnboardingCheckpoint {
   id: OnboardingStepId;
   complete: boolean;
 }
+
+/**
+ * Session-scoped escape hatches (skip / checklist dismissed). Stored in
+ * sessionStorage keyed by account id so one account's choice never leaks
+ * to another signed in from the same tab.
+ */
+export type OnboardingFlag = "skipped" | "checklist-dismissed";

--- a/lib/onboarding/types.ts
+++ b/lib/onboarding/types.ts
@@ -38,8 +38,9 @@ export interface OnboardingCheckpoint {
 }
 
 /**
- * Session-scoped escape hatches (skip / checklist dismissed). Stored in
- * sessionStorage keyed by account id so one account's choice never leaks
- * to another signed in from the same tab.
+ * Session-scoped skip escape hatch. Stored in sessionStorage keyed by
+ * account id so one account's choice never leaks to another signed in from
+ * the same tab. Skip is the only hatch — the pinned checklist that follows
+ * is a persistent reminder with no dismiss (recoupable/chat#1867).
  */
-export type OnboardingFlag = "skipped" | "checklist-dismissed";
+export type OnboardingFlag = "skipped";

--- a/lib/onboarding/writeOnboardingFlag.ts
+++ b/lib/onboarding/writeOnboardingFlag.ts
@@ -1,0 +1,25 @@
+import { getOnboardingFlagKey } from "@/lib/onboarding/getOnboardingFlagKey";
+import type { OnboardingFlag } from "@/lib/onboarding/types";
+
+/**
+ * Safe sessionStorage write for a session-scoped onboarding flag. Flags
+ * are best-effort: when storage access throws (denied/partitioned
+ * storage) this no-ops and the in-memory gate state still applies for
+ * the current view.
+ */
+export function writeOnboardingFlag(
+  flag: OnboardingFlag,
+  accountId: string,
+  value: boolean,
+): void {
+  try {
+    const key = getOnboardingFlagKey(flag, accountId);
+    if (value) {
+      window.sessionStorage.setItem(key, "1");
+    } else {
+      window.sessionStorage.removeItem(key);
+    }
+  } catch {
+    // Fail open: never crash the home flow over storage access.
+  }
+}

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.17",
     "@tailwindcss/typography": "0.5.0-alpha.3",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^20",
     "@types/papaparse": "^5.3.16",
     "@types/react": "^18",
@@ -126,6 +127,7 @@
     "eslint": "^8",
     "eslint-config-next": "14.2.13",
     "eslint-plugin-storybook": "^10.0.7",
+    "jsdom": "^29.1.1",
     "postcss": "^8",
     "prettier": "3.3.3",
     "tailwindcss": "^4.1.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,16 +31,16 @@ importers:
         version: 2.5.4(bufferutil@4.0.9)(deepmerge@4.3.1)(dotenv@16.6.1)(encoding@0.1.13)(react@19.2.1)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@coinbase/cdp-sdk':
         specifier: ^1.4.0
-        version: 1.39.0(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+        version: 1.39.0(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@coinbase/onchainkit':
         specifier: ^0.38.8
-        version: 0.38.19(@farcaster/miniapp-sdk@0.2.1(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(@tanstack/query-core@5.90.12)(@types/react@18.3.27)(@vercel/blob@2.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.1))(utf-8-validate@5.0.10)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
+        version: 0.38.19(@farcaster/miniapp-sdk@0.2.1(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(@tanstack/query-core@5.90.12)(@types/react@18.3.27)(@vercel/blob@2.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.1))(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
       '@composio/core':
         specifier: ^0.2.4
-        version: 0.2.6(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
+        version: 0.2.6(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
       '@composio/vercel':
         specifier: ^0.2.16
-        version: 0.2.18(@composio/core@0.2.6(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ai@6.0.165(zod@3.25.76))
+        version: 0.2.18(@composio/core@0.2.6(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ai@6.0.165(zod@3.25.76))
       '@farcaster/frame-sdk':
         specifier: ^0.0.44
         version: 0.0.44(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
@@ -61,7 +61,7 @@ importers:
         version: 1.24.3(zod@3.25.76)
       '@privy-io/react-auth':
         specifier: ^3.31.0
-        version: 3.31.0(@solana-program/system@0.8.1(@solana/kit@5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana-program/token@0.9.0(@solana/kit@5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/kit@5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@vercel/blob@2.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.1))(utf-8-validate@5.0.10)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
+        version: 3.31.0(@solana-program/system@0.8.1(@solana/kit@5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana-program/token@0.9.0(@solana/kit@5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/kit@5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@vercel/blob@2.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.1))(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
       '@radix-ui/react-alert-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -211,7 +211,7 @@ importers:
         version: 0.66.0(request@2.88.2)
       openai:
         specifier: ^4.67.3
-        version: 4.104.0(encoding@0.1.13)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
+        version: 4.104.0(encoding@0.1.13)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
       papaparse:
         specifier: ^5.5.3
         version: 5.5.3
@@ -295,10 +295,10 @@ importers:
         version: 2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       wagmi:
         specifier: ^2.15.4
-        version: 2.19.5(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@vercel/blob@2.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
+        version: 2.19.5(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@vercel/blob@2.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
       x402-mcp:
         specifier: ^0.1.1
-        version: 0.1.1(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@vercel/blob@2.3.2)(ai@6.0.165(zod@3.25.76))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(next@16.0.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+        version: 0.1.1(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@vercel/blob@2.3.2)(ai@6.0.165(zod@3.25.76))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(next@16.0.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       zod:
         specifier: ^3.25.0
         version: 3.25.76
@@ -309,6 +309,9 @@ importers:
       '@tailwindcss/typography':
         specifier: 0.5.0-alpha.3
         version: 0.5.0-alpha.3(tailwindcss@4.1.17)
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@types/node':
         specifier: ^20
         version: 20.19.25
@@ -342,6 +345,9 @@ importers:
       eslint-plugin-storybook:
         specifier: ^10.0.7
         version: 10.1.4(eslint@8.57.1)(storybook@10.1.4(@testing-library/dom@10.4.1)(bufferutil@4.0.9)(prettier@3.3.3)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(utf-8-validate@5.0.10))(typescript@5.9.3)
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1(@noble/hashes@1.8.0)
       postcss:
         specifier: ^8
         version: 8.5.6
@@ -356,7 +362,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.15(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.15)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+        version: 4.0.15(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.15)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
 
 packages:
 
@@ -560,6 +566,21 @@ packages:
 
   '@apify/utilities@2.24.0':
     resolution: {integrity: sha512-tc1lH0T4C0KOrCFKy4+pP/bj0VkAKUOqG1Unyyz0ddKv2b8R1PKxboEx2sGDZSHxCLA+nbk/kC2jgIvGqen2KA==}
+
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -1072,6 +1093,10 @@ packages:
   '@braintree/sanitize-url@7.1.1':
     resolution: {integrity: sha512-i1L7noDNxtFyL5DmZafWy1wRVhGehQmzZaz1HiN5e7iylJMSZR7ekOV7NsIqa5qBldlLrsKv4HbgFUVlQrz8Mw==}
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
   '@browserbasehq/sdk@2.6.0':
     resolution: {integrity: sha512-83iXP5D7xMm8Wyn66TUaUrgoByCmAJuoMoZQI3sGg3JAiMlTfnCIMqyVBoNSaItaPIkaCnrsj6LiusmXV2X9YA==}
 
@@ -1138,6 +1163,42 @@ packages:
   '@crawlee/types@3.15.3':
     resolution: {integrity: sha512-RvgVPXrsQw4GQIUXrC1z1aNOedUPJnZ/U/8n+jZ0fu1Iw9moJVMuiuIxSI8q1P6BA84aWZdalyfDWBZ3FMjsiw==}
     engines: {node: '>=16.0.0'}
+
+  '@csstools/color-helpers@6.1.0':
+    resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.1':
+    resolution: {integrity: sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.9':
+    resolution: {integrity: sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.6':
+    resolution: {integrity: sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@cypress/request-promise@5.0.0':
     resolution: {integrity: sha512-eKdYVpa9cBEw2kTBlHeu1PP16Blwtum6QHg/u9s/MoHkZfuo1pRGka1VlUHXF5kdew82BvOJVVGk0x8X0nbp+w==}
@@ -1518,6 +1579,15 @@ packages:
   '@ethereumjs/util@8.1.0':
     resolution: {integrity: sha512-zQ0IqbdX8FZ9aw11vP+dZkKDkS+kgIvQPHnSAXzP9pLu+Rfu3D3XEeLbicvoXJTYnhZiPmsZUxgdzXwNKxRPbA==}
     engines: {node: '>=14'}
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@farcaster/frame-core@0.0.39':
     resolution: {integrity: sha512-No+5rA97B1EzfkdpVbGRxJz3Ju8/jpY2GgJU/a2LiGFIS9ZV6a0wZznoFlB26puBzRMb+2R+M0zF0NFw8p4UJg==}
@@ -3780,6 +3850,21 @@ packages:
     resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
     engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
 
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@testing-library/user-event@14.6.1':
     resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
     engines: {node: '>=12', npm: '>=6'}
@@ -4879,6 +4964,9 @@ packages:
   bcrypt-pbkdf@1.0.2:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   big.js@5.2.2:
     resolution: {integrity: sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==}
 
@@ -5227,6 +5315,10 @@ packages:
   css-to-react-native@3.2.0:
     resolution: {integrity: sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
 
@@ -5403,6 +5495,10 @@ packages:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
 
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
     engines: {node: '>= 0.4'}
@@ -5460,6 +5556,9 @@ packages:
   decamelize@1.2.0:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
     engines: {node: '>=0.10.0'}
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-named-character-reference@1.2.0:
     resolution: {integrity: sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==}
@@ -5656,6 +5755,10 @@ packages:
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   es-abstract@1.24.0:
     resolution: {integrity: sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==}
@@ -6438,6 +6541,10 @@ packages:
     resolution: {integrity: sha512-icXIITfw/07Q88nLSkB9aiUrd8rYzSweK681Kjo/TSggaGbOX4RRyxxm71v+3PC8C/j+4rlxGeoTRxQDkaJkUw==}
     engines: {node: '>=16.9.0'}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -6695,6 +6802,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
@@ -6857,6 +6967,15 @@ packages:
 
   jsbn@0.1.1:
     resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
+
+  jsdom@29.1.1:
+    resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -7146,6 +7265,10 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -7260,6 +7383,9 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
@@ -7822,6 +7948,9 @@ packages:
 
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
@@ -8528,6 +8657,10 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
@@ -8917,6 +9050,9 @@ packages:
     peerDependencies:
       react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tabbable@6.3.0:
     resolution: {integrity: sha512-EIHvdY5bPLuWForiR/AN2Bxngzpuwn1is4asboytXtpTgsArc+WmSJKVLlhdh71u7jFcryDqB2A8lQvj78MkyQ==}
 
@@ -9018,8 +9154,15 @@ packages:
   tldts-core@6.1.86:
     resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
 
+  tldts-core@7.4.9:
+    resolution: {integrity: sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==}
+
   tldts@6.1.86:
     resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
+  tldts@7.4.9:
+    resolution: {integrity: sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==}
     hasBin: true
 
   to-buffer@1.2.2:
@@ -9050,11 +9193,19 @@ packages:
     resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
     engines: {node: '>=16'}
 
+  tough-cookie@6.0.2:
+    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
+    engines: {node: '>=16'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   tr46@1.0.1:
     resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -9173,6 +9324,10 @@ packages:
   undici@6.24.1:
     resolution: {integrity: sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==}
     engines: {node: '>=18.17'}
+
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    engines: {node: '>=20.18.1'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
@@ -9575,6 +9730,10 @@ packages:
   vscode-uri@3.0.8:
     resolution: {integrity: sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==}
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   wagmi@2.19.5:
     resolution: {integrity: sha512-RQUfKMv6U+EcSNNGiPbdkDtJwtuFxZWLmvDiQmjjBgkuPulUwDJsKhi7gjynzJdsx2yDqhHCXkKsbbfbIsHfcQ==}
     peerDependencies:
@@ -9610,6 +9769,10 @@ packages:
   webidl-conversions@4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
 
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
   webpack-sources@1.4.3:
     resolution: {integrity: sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==}
 
@@ -9626,6 +9789,14 @@ packages:
     peerDependenciesMeta:
       webpack-cli:
         optional: true
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -9822,9 +9993,16 @@ packages:
   x402@0.7.3:
     resolution: {integrity: sha512-8CIZsdMTOn52PjMH/ErVke9ebeZ7ErwiZ5FL3tN3Wny7Ynxs3LkuB/0q7IoccRLdVXA7f2lueYBJ2iDrElhXnA==}
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
   xmlbuilder@13.0.2:
     resolution: {integrity: sha512-Eux0i2QdDYKbdbA6AM6xE4m6ZTZr4G4xF9kahI2ukSEMCzwce2eX9WlTI5J3s+NU7hpasFsr8hWIONae7LluAQ==}
     engines: {node: '>=6.0'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   xmlhttprequest-ssl@2.1.2:
     resolution: {integrity: sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==}
@@ -10173,6 +10351,26 @@ snapshots:
     dependencies:
       '@apify/consts': 2.48.0
       '@apify/log': 2.5.28
+
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -10852,9 +11050,9 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@base-org/account@2.4.0(@types/react@18.3.27)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.1))(utf-8-validate@5.0.10)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)':
+  '@base-org/account@2.4.0(@types/react@18.3.27)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.1))(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)':
     dependencies:
-      '@coinbase/cdp-sdk': 1.39.0(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@coinbase/cdp-sdk': 1.39.0(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@noble/hashes': 1.4.0
       clsx: 1.2.1
       eventemitter3: 5.0.1
@@ -10880,6 +11078,10 @@ snapshots:
   '@bcoe/v8-coverage@1.0.2': {}
 
   '@braintree/sanitize-url@7.1.1': {}
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
 
   '@browserbasehq/sdk@2.6.0(encoding@0.1.13)':
     dependencies:
@@ -10949,11 +11151,11 @@ snapshots:
 
   '@chevrotain/utils@11.0.3': {}
 
-  '@coinbase/cdp-sdk@1.39.0(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+  '@coinbase/cdp-sdk@1.39.0(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
-      '@solana-program/system': 0.8.1(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
-      '@solana-program/token': 0.6.0(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
-      '@solana/kit': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana-program/system': 0.8.1(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
+      '@solana-program/token': 0.6.0(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
+      '@solana/kit': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)
       abitype: 1.0.6(typescript@5.9.3)(zod@3.25.76)
       axios: 1.13.2
@@ -10972,7 +11174,7 @@ snapshots:
       - utf-8-validate
       - ws
 
-  '@coinbase/onchainkit@0.38.19(@farcaster/miniapp-sdk@0.2.1(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(@tanstack/query-core@5.90.12)(@types/react@18.3.27)(@vercel/blob@2.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.1))(utf-8-validate@5.0.10)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)':
+  '@coinbase/onchainkit@0.38.19(@farcaster/miniapp-sdk@0.2.1(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(@tanstack/query-core@5.90.12)(@types/react@18.3.27)(@vercel/blob@2.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.1))(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)':
     dependencies:
       '@farcaster/frame-sdk': 0.1.12(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@farcaster/miniapp-wagmi-connector': 1.1.0(@farcaster/miniapp-sdk@0.2.1(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(@wagmi/core@2.22.1(@tanstack/query-core@5.90.12)(@types/react@18.3.27)(react@19.2.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.1))(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
@@ -10986,7 +11188,7 @@ snapshots:
       react-dom: 19.2.1(react@19.2.1)
       tailwind-merge: 2.6.0
       viem: 2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      wagmi: 2.19.5(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@vercel/blob@2.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
+      wagmi: 2.19.5(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@vercel/blob@2.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -11069,13 +11271,13 @@ snapshots:
 
   '@composio/client@0.1.0-alpha.40': {}
 
-  '@composio/core@0.2.6(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)':
+  '@composio/core@0.2.6(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)':
     dependencies:
       '@composio/client': 0.1.0-alpha.40
       '@composio/json-schema-to-zod': 0.1.19(zod@3.25.76)
       '@types/json-schema': 7.0.15
       chalk: 4.1.2
-      openai: 5.23.2(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
+      openai: 5.23.2(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
       pusher-js: 8.4.0
       semver: 7.7.3
       uuid: 13.0.0
@@ -11088,14 +11290,38 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
-  '@composio/vercel@0.2.18(@composio/core@0.2.6(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ai@6.0.165(zod@3.25.76))':
+  '@composio/vercel@0.2.18(@composio/core@0.2.6(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ai@6.0.165(zod@3.25.76))':
     dependencies:
-      '@composio/core': 0.2.6(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
+      '@composio/core': 0.2.6(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
       ai: 6.0.165(zod@3.25.76)
 
   '@crawlee/types@3.15.3':
     dependencies:
       tslib: 2.8.1
+
+  '@csstools/color-helpers@6.1.0': {}
+
+  '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.0
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.6(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@cypress/request-promise@5.0.0(@cypress/request@3.0.9)(request@2.88.2)':
     dependencies:
@@ -11354,6 +11580,10 @@ snapshots:
       '@ethereumjs/rlp': 4.0.1
       ethereum-cryptography: 2.2.1
       micro-ftch: 0.3.1
+
+  '@exodus/bytes@1.15.1(@noble/hashes@1.8.0)':
+    optionalDependencies:
+      '@noble/hashes': 1.8.0
 
   '@farcaster/frame-core@0.0.39(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
@@ -12057,7 +12287,7 @@ snapshots:
 
   '@privy-io/popup@0.0.4': {}
 
-  '@privy-io/react-auth@3.31.0(@solana-program/system@0.8.1(@solana/kit@5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana-program/token@0.9.0(@solana/kit@5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/kit@5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@vercel/blob@2.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.1))(utf-8-validate@5.0.10)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)':
+  '@privy-io/react-auth@3.31.0(@solana-program/system@0.8.1(@solana/kit@5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana-program/token@0.9.0(@solana/kit@5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/kit@5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@vercel/blob@2.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.1))(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)':
     dependencies:
       '@base-org/account': 1.1.1(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.1))(utf-8-validate@5.0.10)(zod@3.25.76)
       '@coinbase/wallet-sdk': 4.3.2
@@ -12099,7 +12329,7 @@ snapshots:
       stylis: 4.3.6
       tinycolor2: 1.6.0
       viem: 2.52.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      x402: 0.7.3(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@vercel/blob@2.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      x402: 0.7.3(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@vercel/blob@2.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       zustand: 5.0.9(@types/react@18.3.27)(react@19.2.1)(use-sync-external-store@1.4.0(react@19.2.1))
     optionalDependencies:
       '@solana-program/system': 0.8.1(@solana/kit@5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))
@@ -13440,9 +13670,9 @@ snapshots:
     dependencies:
       '@solana/kit': 5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
 
-  '@solana-program/system@0.8.1(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
+  '@solana-program/system@0.8.1(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
     dependencies:
-      '@solana/kit': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/kit': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
 
   '@solana-program/system@0.8.1(@solana/kit@5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))':
     dependencies:
@@ -13454,9 +13684,9 @@ snapshots:
       '@solana/kit': 5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/sysvars': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
 
-  '@solana-program/token@0.6.0(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
+  '@solana-program/token@0.6.0(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
     dependencies:
-      '@solana/kit': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/kit': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
 
   '@solana-program/token@0.9.0(@solana/kit@5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))':
     dependencies:
@@ -13710,7 +13940,7 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+  '@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/accounts': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/addresses': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -13724,11 +13954,11 @@ snapshots:
       '@solana/rpc': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/rpc-parsed-types': 3.0.3(typescript@5.9.3)
       '@solana/rpc-spec-types': 3.0.3(typescript@5.9.3)
-      '@solana/rpc-subscriptions': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/rpc-subscriptions': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@solana/rpc-types': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/signers': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/sysvars': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/transaction-confirmation': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/transaction-confirmation': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@solana/transaction-messages': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/transactions': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       typescript: 5.9.3
@@ -13933,14 +14163,14 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-subscriptions-channel-websocket@3.0.3(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+  '@solana/rpc-subscriptions-channel-websocket@3.0.3(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/errors': 3.0.3(typescript@5.9.3)
       '@solana/functional': 3.0.3(typescript@5.9.3)
       '@solana/rpc-subscriptions-spec': 3.0.3(typescript@5.9.3)
       '@solana/subscribable': 3.0.3(typescript@5.9.3)
       typescript: 5.9.3
-      ws: 8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
 
   '@solana/rpc-subscriptions-channel-websocket@5.5.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
@@ -13972,7 +14202,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/rpc-subscriptions@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+  '@solana/rpc-subscriptions@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/errors': 3.0.3(typescript@5.9.3)
       '@solana/fast-stable-stringify': 3.0.3(typescript@5.9.3)
@@ -13980,7 +14210,7 @@ snapshots:
       '@solana/promises': 3.0.3(typescript@5.9.3)
       '@solana/rpc-spec-types': 3.0.3(typescript@5.9.3)
       '@solana/rpc-subscriptions-api': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/rpc-subscriptions-channel-websocket': 3.0.3(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/rpc-subscriptions-channel-websocket': 3.0.3(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@solana/rpc-subscriptions-spec': 3.0.3(typescript@5.9.3)
       '@solana/rpc-transformers': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/rpc-types': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -14168,7 +14398,7 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transaction-confirmation@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+  '@solana/transaction-confirmation@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/addresses': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/codecs-strings': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -14176,7 +14406,7 @@ snapshots:
       '@solana/keys': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/promises': 3.0.3(typescript@5.9.3)
       '@solana/rpc': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/rpc-subscriptions': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/rpc-subscriptions': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@solana/rpc-types': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/transaction-messages': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/transactions': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -14482,6 +14712,16 @@ snapshots:
       dom-accessibility-api: 0.6.3
       picocolors: 1.1.1
       redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@testing-library/dom': 10.4.1
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+    optionalDependencies:
+      '@types/react': 18.3.27
+      '@types/react-dom': 18.3.7(@types/react@18.3.27)
 
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
     dependencies:
@@ -14946,7 +15186,7 @@ snapshots:
       '@vitest/mocker': 4.0.15(vite@7.2.6(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
       playwright: 1.57.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.15(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.15)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+      vitest: 4.0.15(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.15)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -14962,7 +15202,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.0.3
-      vitest: 4.0.15(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.15)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+      vitest: 4.0.15(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.15)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
       ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
@@ -14983,7 +15223,7 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.15(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.15)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+      vitest: 4.0.15(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.15)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
     optionalDependencies:
       '@vitest/browser': 4.0.15(bufferutil@4.0.9)(utf-8-validate@5.0.10)(vite@7.2.6(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(vitest@4.0.15)
     transitivePeerDependencies:
@@ -15050,19 +15290,19 @@ snapshots:
       '@vitest/pretty-format': 4.0.15
       tinyrainbow: 3.0.3
 
-  '@wagmi/connectors@6.2.0(34c7fdd01b715715548043cbba06572f)':
+  '@wagmi/connectors@6.2.0(12a0478795d71457f946ad0a52e954a5)':
     dependencies:
-      '@base-org/account': 2.4.0(@types/react@18.3.27)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.1))(utf-8-validate@5.0.10)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
+      '@base-org/account': 2.4.0(@types/react@18.3.27)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.1))(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
       '@coinbase/wallet-sdk': 4.3.6(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.1))(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@gemini-wallet/core': 0.3.2(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@gemini-wallet/core': 0.3.2(viem@2.52.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       '@metamask/sdk': 0.33.1(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
       '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.12)(@types/react@18.3.27)(react@19.2.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.1))(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       '@walletconnect/ethereum-provider': 2.21.1(@types/react@18.3.27)(@vercel/blob@2.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.2.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
-      porto: 0.2.35(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.12)(@types/react@18.3.27)(react@19.2.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.1))(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@19.2.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.1))(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@vercel/blob@2.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))
-      viem: 2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      porto: 0.2.35(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.12)(@types/react@18.3.27)(react@19.2.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.1))(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@19.2.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.1))(viem@2.52.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@vercel/blob@2.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))
+      viem: 2.52.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -15104,19 +15344,19 @@ snapshots:
       - ws
       - zod
 
-  '@wagmi/connectors@6.2.0(48148c372af62fb1ae03215f20f3a3bb)':
+  '@wagmi/connectors@6.2.0(70ad7647487a1cac42bd1bf7644ccd60)':
     dependencies:
-      '@base-org/account': 2.4.0(@types/react@18.3.27)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.1))(utf-8-validate@5.0.10)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
+      '@base-org/account': 2.4.0(@types/react@18.3.27)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.1))(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
       '@coinbase/wallet-sdk': 4.3.6(@types/react@18.3.27)(bufferutil@4.0.9)(react@19.2.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.1))(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@gemini-wallet/core': 0.3.2(viem@2.52.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@gemini-wallet/core': 0.3.2(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       '@metamask/sdk': 0.33.1(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
       '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.12)(@types/react@18.3.27)(react@19.2.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.1))(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       '@walletconnect/ethereum-provider': 2.21.1(@types/react@18.3.27)(@vercel/blob@2.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.2.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
-      porto: 0.2.35(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.12)(@types/react@18.3.27)(react@19.2.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.1))(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@19.2.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.1))(viem@2.52.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@vercel/blob@2.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))
-      viem: 2.52.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      porto: 0.2.35(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.12)(@types/react@18.3.27)(react@19.2.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.1))(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@19.2.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.1))(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@vercel/blob@2.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))
+      viem: 2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -16644,6 +16884,10 @@ snapshots:
     dependencies:
       tweetnacl: 0.14.5
 
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
   big.js@5.2.2: {}
 
   big.js@6.2.2: {}
@@ -16970,6 +17214,11 @@ snapshots:
       css-color-keywords: 1.0.0
       postcss-value-parser: 4.2.0
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   css.escape@1.5.1: {}
 
   csstype@3.1.3: {}
@@ -17168,6 +17417,13 @@ snapshots:
 
   data-uri-to-buffer@4.0.1: {}
 
+  data-urls@7.0.0(@noble/hashes@1.8.0):
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1(@noble/hashes@1.8.0)
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   data-view-buffer@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -17211,6 +17467,8 @@ snapshots:
       ms: 2.1.3
 
   decamelize@1.2.0: {}
+
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.2.0:
     dependencies:
@@ -17400,6 +17658,8 @@ snapshots:
       tapable: 2.3.0
 
   entities@6.0.1: {}
+
+  entities@8.0.0: {}
 
   es-abstract@1.24.0:
     dependencies:
@@ -18539,6 +18799,12 @@ snapshots:
 
   hono@4.10.7: {}
 
+  html-encoding-sniffer@6.0.0(@noble/hashes@1.8.0):
+    dependencies:
+      '@exodus/bytes': 1.15.1(@noble/hashes@1.8.0)
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-escaper@2.0.2: {}
 
   html-url-attributes@3.0.1: {}
@@ -18782,6 +19048,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-promise@4.0.0: {}
 
   is-regex@1.2.1:
@@ -18962,6 +19230,32 @@ snapshots:
       argparse: 2.0.1
 
   jsbn@0.1.1: {}
+
+  jsdom@29.1.1(@noble/hashes@1.8.0):
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.6(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1(@noble/hashes@1.8.0)
+      css-tree: 3.2.1
+      data-urls: 7.0.0(@noble/hashes@1.8.0)
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0(@noble/hashes@1.8.0)
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.2
+      undici: 7.28.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1(@noble/hashes@1.8.0)
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@3.1.0: {}
 
@@ -19239,6 +19533,8 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
+  lru-cache@11.5.2: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -19469,6 +19765,8 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
+
+  mdn-data@2.27.1: {}
 
   media-typer@1.1.0: {}
 
@@ -20002,21 +20300,6 @@ snapshots:
       regex: 6.0.1
       regex-recursion: 6.0.2
 
-  openai@4.104.0(encoding@0.1.13)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76):
-    dependencies:
-      '@types/node': 18.19.130
-      '@types/node-fetch': 2.6.13
-      abort-controller: 3.0.0
-      agentkeepalive: 4.6.0
-      form-data-encoder: 1.7.2
-      formdata-node: 4.4.1
-      node-fetch: 2.7.0(encoding@0.1.13)
-    optionalDependencies:
-      ws: 8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - encoding
-
   openai@4.104.0(encoding@0.1.13)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76):
     dependencies:
       '@types/node': 18.19.130
@@ -20032,9 +20315,9 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  openai@5.23.2(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76):
+  openai@5.23.2(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76):
     optionalDependencies:
-      ws: 8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       zod: 3.25.76
 
   openapi-fetch@0.13.8:
@@ -20268,6 +20551,10 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   parseurl@1.3.3: {}
 
   partial-json@0.1.7:
@@ -20454,7 +20741,7 @@ snapshots:
 
   pony-cause@2.1.11: {}
 
-  porto@0.2.35(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.12)(@types/react@18.3.27)(react@19.2.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.1))(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@19.2.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.1))(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@vercel/blob@2.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)):
+  porto@0.2.35(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.12)(@types/react@18.3.27)(react@19.2.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.1))(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@19.2.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.1))(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@vercel/blob@2.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)):
     dependencies:
       '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.12)(@types/react@18.3.27)(react@19.2.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.1))(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       hono: 4.10.7
@@ -20468,13 +20755,13 @@ snapshots:
       '@tanstack/react-query': 5.90.12(react@19.2.1)
       react: 19.2.1
       typescript: 5.9.3
-      wagmi: 2.19.5(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@vercel/blob@2.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
+      wagmi: 2.19.5(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@vercel/blob@2.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
     transitivePeerDependencies:
       - '@types/react'
       - immer
       - use-sync-external-store
 
-  porto@0.2.35(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.12)(@types/react@18.3.27)(react@19.2.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.1))(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@19.2.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.1))(viem@2.52.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@vercel/blob@2.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)):
+  porto@0.2.35(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.12)(@types/react@18.3.27)(react@19.2.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.1))(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@19.2.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.1))(viem@2.52.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@vercel/blob@2.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)):
     dependencies:
       '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.12)(@types/react@18.3.27)(react@19.2.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.1))(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       hono: 4.10.7
@@ -20488,7 +20775,7 @@ snapshots:
       '@tanstack/react-query': 5.90.12(react@19.2.1)
       react: 19.2.1
       typescript: 5.9.3
-      wagmi: 2.19.5(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@vercel/blob@2.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
+      wagmi: 2.19.5(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@vercel/blob@2.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
     transitivePeerDependencies:
       - '@types/react'
       - immer
@@ -21133,6 +21420,10 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   scheduler@0.27.0: {}
 
   schema-utils@2.7.1:
@@ -21610,7 +21901,7 @@ snapshots:
 
   substyle@9.4.1(react@19.2.1):
     dependencies:
-      '@babel/runtime': 7.4.5
+      '@babel/runtime': 7.28.4
       invariant: 2.2.4
       react: 19.2.1
 
@@ -21638,6 +21929,8 @@ snapshots:
       dequal: 2.0.3
       react: 19.2.1
       use-sync-external-store: 1.6.0(react@19.2.1)
+
+  symbol-tree@3.2.4: {}
 
   tabbable@6.3.0: {}
 
@@ -21717,9 +22010,15 @@ snapshots:
 
   tldts-core@6.1.86: {}
 
+  tldts-core@7.4.9: {}
+
   tldts@6.1.86:
     dependencies:
       tldts-core: 6.1.86
+
+  tldts@7.4.9:
+    dependencies:
+      tldts-core: 7.4.9
 
   to-buffer@1.2.2:
     dependencies:
@@ -21751,9 +22050,17 @@ snapshots:
     dependencies:
       tldts: 6.1.86
 
+  tough-cookie@6.0.2:
+    dependencies:
+      tldts: 7.4.9
+
   tr46@0.0.3: {}
 
   tr46@1.0.1:
+    dependencies:
+      punycode: 2.3.1
+
+  tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
 
@@ -21882,6 +22189,8 @@ snapshots:
   undici-types@7.28.0: {}
 
   undici@6.24.1: {}
+
+  undici@7.28.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
@@ -22238,7 +22547,7 @@ snapshots:
       terser: 5.44.1
       yaml: 2.8.2
 
-  vitest@4.0.15(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.15)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2):
+  vitest@4.0.15(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.15)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.15
       '@vitest/mocker': 4.0.15(vite@7.2.6(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
@@ -22264,6 +22573,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@types/node': 20.19.25
       '@vitest/browser-playwright': 4.0.15(bufferutil@4.0.9)(playwright@1.57.0)(utf-8-validate@5.0.10)(vite@7.2.6(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(vitest@4.0.15)
+      jsdom: 29.1.1(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - jiti
       - less
@@ -22294,10 +22604,14 @@ snapshots:
 
   vscode-uri@3.0.8: {}
 
-  wagmi@2.19.5(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@vercel/blob@2.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76):
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  wagmi@2.19.5(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@vercel/blob@2.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76):
     dependencies:
       '@tanstack/react-query': 5.90.12(react@19.2.1)
-      '@wagmi/connectors': 6.2.0(34c7fdd01b715715548043cbba06572f)
+      '@wagmi/connectors': 6.2.0(70ad7647487a1cac42bd1bf7644ccd60)
       '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.12)(@types/react@18.3.27)(react@19.2.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.1))(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       react: 19.2.1
       use-sync-external-store: 1.4.0(react@19.2.1)
@@ -22340,10 +22654,10 @@ snapshots:
       - ws
       - zod
 
-  wagmi@2.19.5(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@vercel/blob@2.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.52.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76):
+  wagmi@2.19.5(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@vercel/blob@2.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.52.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76):
     dependencies:
       '@tanstack/react-query': 5.90.12(react@19.2.1)
-      '@wagmi/connectors': 6.2.0(48148c372af62fb1ae03215f20f3a3bb)
+      '@wagmi/connectors': 6.2.0(12a0478795d71457f946ad0a52e954a5)
       '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.12)(@types/react@18.3.27)(react@19.2.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.1))(viem@2.52.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       react: 19.2.1
       use-sync-external-store: 1.4.0(react@19.2.1)
@@ -22403,6 +22717,8 @@ snapshots:
 
   webidl-conversions@4.0.2: {}
 
+  webidl-conversions@8.0.1: {}
+
   webpack-sources@1.4.3:
     dependencies:
       source-list-map: 2.0.1
@@ -22441,6 +22757,16 @@ snapshots:
       - '@swc/core'
       - esbuild
       - uglify-js
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1(@noble/hashes@1.8.0):
+    dependencies:
+      '@exodus/bytes': 1.15.1(@noble/hashes@1.8.0)
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   whatwg-url@5.0.0:
     dependencies:
@@ -22682,13 +23008,13 @@ snapshots:
       bufferutil: 4.0.9
       utf-8-validate: 5.0.10
 
-  x402-mcp@0.1.1(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@vercel/blob@2.3.2)(ai@6.0.165(zod@3.25.76))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(next@16.0.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
+  x402-mcp@0.1.1(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@vercel/blob@2.3.2)(ai@6.0.165(zod@3.25.76))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(next@16.0.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
     dependencies:
       '@modelcontextprotocol/sdk': 1.24.3(zod@3.25.76)
       ai: 6.0.165(zod@3.25.76)
       mcp-handler: 1.0.4(@modelcontextprotocol/sdk@1.24.3(zod@3.25.76))(next@16.0.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
       viem: 2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      x402: 0.5.3(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@vercel/blob@2.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      x402: 0.5.3(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@vercel/blob@2.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       zod: 3.25.76
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -22730,10 +23056,10 @@ snapshots:
       - utf-8-validate
       - ws
 
-  x402@0.5.3(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@vercel/blob@2.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
+  x402@0.5.3(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@vercel/blob@2.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
     dependencies:
       viem: 2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      wagmi: 2.19.5(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@vercel/blob@2.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
+      wagmi: 2.19.5(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@vercel/blob@2.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -22773,7 +23099,7 @@ snapshots:
       - utf-8-validate
       - ws
 
-  x402@0.7.3(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@vercel/blob@2.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
+  x402@0.7.3(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@vercel/blob@2.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
     dependencies:
       '@scure/base': 1.2.6
       '@solana-program/compute-budget': 0.11.0(@solana/kit@5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))
@@ -22786,7 +23112,7 @@ snapshots:
       '@wallet-standard/base': 1.1.0
       '@wallet-standard/features': 1.1.0
       viem: 2.52.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      wagmi: 2.19.5(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@vercel/blob@2.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.52.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
+      wagmi: 2.19.5(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@18.3.27)(@vercel/blob@2.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.52.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -22827,7 +23153,11 @@ snapshots:
       - utf-8-validate
       - ws
 
+  xml-name-validator@5.0.0: {}
+
   xmlbuilder@13.0.2: {}
+
+  xmlchars@2.2.0: {}
 
   xmlhttprequest-ssl@2.1.2: {}
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   test: {
     environment: "node",
     globals: true,
-    include: ["**/__tests__/**/*.test.ts"],
+    include: ["**/__tests__/**/*.test.{ts,tsx}"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Part of recoupable/chat#1867 ("State-derived onboarding router: resume-on-landing + skip-for-now").

## What

On every authenticated landing on chat home, the app derives the account's onboarding step from the activation checkpoint predicates and routes accordingly:

- **Incomplete account** -> renders the onboarding sequence at the first unmet step, with an always-visible "Skip for now".
- **Skip** -> drops to the normal app with a dismissible checklist pinned bottom-right; "Resume setup" re-opens the sequence.
- **Fully activated account** -> normal home, never sees the sequence.

Checkpoint predicates (in sequence order), all over existing data:

| Step | Predicate | Source |
|------|-----------|--------|
| `artists` | account has >= 1 rostered artist | roster via existing `fetchArtists` (`account_artist_ids`) |
| `socials` | every rostered artist has >= 1 linked social | `account_socials` on the roster response |
| `catalog` | account has >= 1 claimed catalog | existing `getCatalogs` (`account_catalogs`) |
| `task` | account has >= 1 enabled scheduled task | existing `getTasks` (`scheduled_actions.enabled`) |

## Derived, never stored

Per the issue's architecture decision: there is **no `onboarding_step` column and no wizard cursor**. The step is a pure function of account state recomputed on every landing, so:

- drop-off/return and multi-device resume are correct for free (state lives in the DB, not the browser);
- out-of-band completion (valuation auto-claim, chat, API) auto-advances the step and can never desync;
- "skip" and "checklist dismissed" are session-scoped escape hatches (`sessionStorage`), not persisted state: the next visit re-derives and resumes by default.

The gate also fails open: while any checkpoint source is loading or errored, the normal app renders, so the sequence never flashes for activated accounts and a failed fetch never walls anyone off.

## Structure

- `lib/onboarding/getOnboardingCheckpoints.ts` - the four predicates -> checkpoint flags (pure)
- `lib/onboarding/getOnboardingStep.ts` - first unmet checkpoint -> step enum (pure, core logic)
- `lib/onboarding/getOnboardingView.ts` - {isReady, step, skipped, dismissed} -> none | sequence | checklist (pure)
- `lib/onboarding/getOnboardingStepContent.ts` - placeholder card copy + link per step
- `hooks/useOnboardingState.ts` - composes existing data hooks (`useArtistProvider`, `useCatalogs`, `useScheduledActions`) into derived state
- `hooks/useOnboardingGate.ts` - view decision + session-scoped skip/resume/dismiss
- `components/Onboarding/*` - sequence container, step placeholder card, checkpoint list, pinned checklist
- `components/Home/HomePage.tsx` - chat-home integration point

Step cards are titled placeholders (purpose + link to the existing page where the step can be completed today); each step's real in-sequence experience ships in the sibling PRs on #1867, slotting into this frame.

## Tests

TDD (failing tests first, then implementation). 18 new unit tests in `lib/onboarding/__tests__/`:

- `getOnboardingStep`: all 16 predicate combinations against the spec's priority order, plus null/undefined/empty socials, per-artist socials requirement, disabled and paused (null-enabled) tasks, out-of-band advancement (valuation auto-claim lands on `task`), fully-activated -> `complete`, determinism.
- `getOnboardingCheckpoints`: order, independence of flags, socials incomplete while roster empty.
- `getOnboardingView`: loading -> none, activated -> never, resume-by-default, skip -> checklist, dismiss -> none.
- `getOnboardingStepContent`: every step has title/description/link to an existing route.

## Verification

- `pnpm exec vitest run`: 40 files / 148 tests, all green (130 pre-existing + 18 new).
- `pnpm exec tsc --noEmit`: 8 errors, all pre-existing on `main` (verified identical with this change stashed); 0 in new files.
- `pnpm build` (local): webpack compile passed and the build's TypeScript phase passed (no type errors); the build then fails at "Collecting page data" for `/api/agent-creator` with `Missing Supabase credentials: { hasUrl: false, hasKey: false }` - environmental (this checkout has no `.env`, only `.env.example`), unrelated to this client-side change and identical without it. The Vercel preview build (which has env) is the authoritative build check.
- Prettier clean on all touched files (`next lint` is broken on `main`: `Invalid project directory ... /lint`).
- Preview verification: pending (see below).

## How to test on preview

1. **Fresh/incomplete account**: sign in with an account that has a valuation-claimed catalog but no enabled task -> landing on `/` shows the sequence at its derived step (e.g. "Schedule your first report" with earlier checkpoints ticked). Complete a step out-of-band (e.g. create a task via API/chat), reload -> the sequence auto-advances or disappears.
2. **Skip**: click "Skip for now" -> normal chat home with the "Finish setting up" checklist pinned bottom-right; "Resume setup" returns to the sequence; X dismisses the checklist for the session; a fresh session resumes the sequence.
3. **Activated account**: sign in with an account that has artists + socials + catalog + an enabled task -> normal home, no sequence, no checklist.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a state-derived onboarding router that resumes on landing and supports “skip for now.” After skip, a pinned checklist stays visible until setup is complete; a “Continue” button re-opens onboarding. Activated accounts go straight to chat.

- **New Features**
  - Derives the current step from account data (artists → socials → catalog → task). No stored cursor.
  - Soft gate via `useOnboardingGate`: incomplete accounts see the sequence; after skip, a persistent pinned checklist appears with a clear “Continue” button to resume.
  - One fresh catalogs read per landing on the onboarding path to avoid stale steps after out‑of‑band claims.

- **Bug Fixes**
  - Checklist positioning avoids right‑rail clipping.
  - Session skip flag is account‑scoped and storage‑safe (fail‑open on errors).
  - Roster fetch errors keep onboarding unresolved (no flash) via `isError` and `deriveOnboardingState`.
  - Corrected step card heading to h3 and stabilized first‑landing verification.

<sup>Written for commit ea068a8efa9917cacd9935981b6b453e2953420c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a guided onboarding sequence showing setup progress and the next recommended step.
  * Added a dismissible onboarding checklist with options to resume setup or skip it temporarily.
  * Onboarding progress now reflects completed artists, social links, catalogs, and scheduled tasks.
  * Added session-based controls for skipping or dismissing onboarding.
* **Bug Fixes**
  * Improved handling of artist roster errors so failed loading is not treated as an empty roster.
  * Catalog information is refreshed when returning to the landing page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->