### PR TITLE
fix: single-flight the signup account bootstrap to stop the double POST /api/accounts race (#1875)

### DIFF
--- a/hooks/useUser.tsx
+++ b/hooks/useUser.tsx
@@ -6,11 +6,11 @@ import { uploadFile } from "@/lib/arweave/uploadFile";
 import { useAccount } from "wagmi";
 import { toast } from "sonner";
 import { AccountWithDetails } from "@/lib/supabase/accounts/getAccountWithDetails";
-import { fetchOrCreateAccount } from "@/lib/accounts/fetchOrCreateAccount";
+import { ensureAccount } from "@/lib/accounts/ensureAccount";
 import { updateAccountProfile } from "@/lib/accounts/updateAccountProfile";
 
 const useUser = () => {
-  const { login, user, logout, getAccessToken } = usePrivy();
+  const { login, user, logout, getAccessToken, ready } = usePrivy();
   const { address: wagmiAddress } = useAccount();
   const address = (user?.wallet?.address as Address) || wagmiAddress;
   const email = user?.email?.address;
@@ -112,13 +112,19 @@ const useUser = () => {
   };
 
   useEffect(() => {
+    // Wait for Privy to resolve so we never POST /api/accounts before the
+    // identifying payload (email) is known (chat#1875).
+    if (!ready) return;
+    if (!email && !address) return;
+    let cancelled = false;
     const init = async () => {
       const accessToken = await getAccessToken();
-      const data = await fetchOrCreateAccount({
+      const data = await ensureAccount({
         email,
         wallet: address,
         accessToken,
       });
+      if (cancelled) return;
 
       setUserData(data);
       setImage(data.image || "");
@@ -129,9 +135,11 @@ const useUser = () => {
       setRoleType(data.role_type || "");
       setCompanyName(data.company_name || "");
     };
-    if (!email && !address) return;
     init();
-  }, [email, address, getAccessToken]);
+    return () => {
+      cancelled = true;
+    };
+  }, [ready, email, address, getAccessToken]);
 
   return {
     address,

--- a/lib/accounts/__tests__/ensureAccount.test.ts
+++ b/lib/accounts/__tests__/ensureAccount.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { AccountWithDetails } from "@/lib/supabase/accounts/getAccountWithDetails";
+
+vi.mock("@/lib/accounts/fetchOrCreateAccount", () => ({
+  fetchOrCreateAccount: vi.fn(),
+}));
+
+const account = (id: string): AccountWithDetails =>
+  ({ account_id: id }) as AccountWithDetails;
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+/**
+ * Mimics POST /api/accounts semantics: read-then-write keyed by email.
+ * Concurrent calls both miss the read and each create a row (the chat#1875
+ * orphan bug); serialized calls resolve to the same row.
+ */
+function makeRaceyApi() {
+  const rows = new Map<string, string>();
+  let creates = 0;
+  const impl = async ({ email }: { email?: string }) => {
+    const existing = email ? rows.get(email) : undefined;
+    await tick(); // simulate network gap between read and write
+    if (existing) return account(existing);
+    creates += 1;
+    const id = `account-${creates}`;
+    if (email) rows.set(email, id);
+    return account(id);
+  };
+  return { impl, rowCount: () => rows.size, createCount: () => creates };
+}
+
+async function loadModules() {
+  vi.resetModules();
+  const { ensureAccount } = await import("@/lib/accounts/ensureAccount");
+  const { fetchOrCreateAccount } = await import(
+    "@/lib/accounts/fetchOrCreateAccount"
+  );
+  return {
+    ensureAccount,
+    fetchOrCreateAccount: vi.mocked(fetchOrCreateAccount),
+  };
+}
+
+describe("ensureAccount", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("serializes distinct concurrent calls so only one account is created", async () => {
+    const { ensureAccount, fetchOrCreateAccount } = await loadModules();
+    const api = makeRaceyApi();
+    fetchOrCreateAccount.mockImplementation(api.impl);
+
+    // Path 1: fires right after passwordless/authenticate (email only).
+    // Path 2: fires right after embedded-wallet creation (email + wallet).
+    const [first, second] = await Promise.all([
+      ensureAccount({ email: "new@user.com", accessToken: "token" }),
+      ensureAccount({
+        email: "new@user.com",
+        wallet: "0xabc",
+        accessToken: "token",
+      }),
+    ]);
+
+    expect(api.createCount()).toBe(1);
+    expect(first.account_id).toBe(second.account_id);
+  });
+
+  it("shares a single request for identical concurrent calls", async () => {
+    const { ensureAccount, fetchOrCreateAccount } = await loadModules();
+    const api = makeRaceyApi();
+    fetchOrCreateAccount.mockImplementation(api.impl);
+
+    const params = { email: "same@user.com", accessToken: "token" };
+    const [first, second] = await Promise.all([
+      ensureAccount(params),
+      ensureAccount(params),
+    ]);
+
+    expect(fetchOrCreateAccount).toHaveBeenCalledTimes(1);
+    expect(first.account_id).toBe(second.account_id);
+  });
+
+  it("resolves the queued call to the account the API resolves for the session", async () => {
+    const { ensureAccount, fetchOrCreateAccount } = await loadModules();
+    const api = makeRaceyApi();
+    fetchOrCreateAccount.mockImplementation(api.impl);
+
+    await ensureAccount({ email: "new@user.com", accessToken: "token" });
+    const second = await ensureAccount({
+      email: "new@user.com",
+      wallet: "0xabc",
+      accessToken: "token",
+    });
+
+    // The wallet-linking call must resolve to the already-created account.
+    expect(second.account_id).toBe("account-1");
+    expect(api.rowCount()).toBe(1);
+  });
+
+  it("still runs a queued call when the previous call rejects", async () => {
+    const { ensureAccount, fetchOrCreateAccount } = await loadModules();
+    fetchOrCreateAccount
+      .mockRejectedValueOnce(
+        new Error("Account API request failed with status: 500"),
+      )
+      .mockResolvedValueOnce(account("recovered"));
+
+    const failing = ensureAccount({
+      email: "a@user.com",
+      accessToken: "token",
+    });
+    const recovering = ensureAccount({
+      email: "a@user.com",
+      wallet: "0xabc",
+      accessToken: "token",
+    });
+
+    await expect(failing).rejects.toThrow("500");
+    await expect(recovering).resolves.toEqual(account("recovered"));
+  });
+});

--- a/lib/accounts/ensureAccount.ts
+++ b/lib/accounts/ensureAccount.ts
@@ -1,0 +1,46 @@
+import { fetchOrCreateAccount } from "@/lib/accounts/fetchOrCreateAccount";
+import type { AccountWithDetails } from "@/lib/supabase/accounts/getAccountWithDetails";
+
+interface EnsureAccountParams {
+  email?: string;
+  wallet?: string;
+  accessToken?: string | null;
+}
+
+let inFlight: { key: string; promise: Promise<AccountWithDetails> } | null =
+  null;
+let chain: Promise<unknown> = Promise.resolve();
+
+/**
+ * Single-flight wrapper around `fetchOrCreateAccount` (POST /api/accounts).
+ *
+ * On a fresh signup the account bootstrap fires twice (once when the email
+ * lands after passwordless auth, once when the embedded wallet is created).
+ * Racing those POSTs creates an email-less orphan account row (chat#1875), so:
+ * - identical concurrent calls share one in-flight request, and
+ * - distinct concurrent calls run strictly one after another, letting the
+ *   later call resolve to the account the earlier call already created.
+ */
+export function ensureAccount(
+  params: EnsureAccountParams,
+): Promise<AccountWithDetails> {
+  const key = `${params.email ?? ""}|${params.wallet ?? ""}`;
+  if (inFlight?.key === key) return inFlight.promise;
+
+  const promise = chain.then(() => fetchOrCreateAccount(params));
+  const entry = { key, promise };
+  inFlight = entry;
+  chain = promise.then(
+    () => undefined,
+    () => undefined,
+  );
+  promise.then(
+    () => {
+      if (inFlight === entry) inFlight = null;
+    },
+    () => {
+      if (inFlight === entry) inFlight = null;
+    },
+  );
+  return promise;
+}


### PR DESCRIPTION
Fixes #1875. Prerequisite for #1872 per #1867's merge quality bar.

## Root cause

Both `POST /api/accounts` calls come from the **same** effect in `hooks/useUser.tsx:114-134` (pre-fix), which re-fires as Privy resolves identity in two steps. `lib/accounts/fetchOrCreateAccount.ts:20` is the only client wrapper for the endpoint, and `useUser` is its only caller, so the "two paths" from the issue trace are two firings of one effect:

1. **Post-authenticate firing:** right after `passwordless/authenticate`, `user.email.address` becomes set while `address` is still undefined (`hooks/useUser.tsx:15-16`), so the effect (deps `[email, address, getAccessToken]`) fires `POST /api/accounts` with `{ email }`.
2. **Post-wallet firing:** right after `POST auth.privy.io/api/v1/wallets` creates the embedded wallet, `user.wallet.address` populates `address`, the dep changes, and the effect fires a second `POST /api/accounts` with `{ email, wallet }` while call 1 is often still in flight.

Server-side, the two concurrent creates race read-then-write on the email linkage: both miss the lookup, both insert an `accounts` row, only one gets the `account_emails` row. The loser is the email-less orphan (`401bdd34-…` in the issue). Each `init()` closure then does last-write-wins into `setUserData`, so when the orphan-creating response lands last, `userData.account_id` holds the orphan while the bearer token resolves to the real account, and every account-scoped fetch 403-loops (`useCatalogs` → `GET /api/accounts/{id}/catalogs`).

## Before / after per path

| | Before | After |
|---|---|---|
| Post-authenticate firing | `POST {email}` immediately; could also fire before Privy resolved (no `ready` gate) | Gated on Privy `ready` so the identifying payload (email) is always known; goes through `ensureAccount` |
| Post-wallet firing | Second concurrent `POST {email, wallet}` racing the first | Serialized behind the first call's promise; the server finds the existing row and links the wallet, no second create |
| Response handling | Two racing closures both `setUserData`; stale/orphan response could win | Identical concurrent calls share one in-flight promise; distinct calls resolve in call order, and an effect-cleanup `cancelled` flag ensures only the latest run writes `userData` |

## Changes

- **`lib/accounts/ensureAccount.ts`** (new): single-flight wrapper around `fetchOrCreateAccount`. Identical concurrent calls (keyed on `email|wallet`) share one in-flight request; distinct concurrent calls are chained strictly one after another; a rejected call does not block the next.
- **`hooks/useUser.tsx`**: init effect now gates on Privy `ready`, calls `ensureAccount`, and cancels stale runs on cleanup.

## Test evidence (TDD)

`lib/accounts/__tests__/ensureAccount.test.ts` mocks the API's read-then-write semantics (concurrent creates each mint a row, exactly like the production race).

- **RED** (before `ensureAccount.ts` existed): `4 failed (4)` — the suite encodes "two concurrent bootstrap calls must produce one account creation and a consistent `account_id`".
- **GREEN** (after): `4 passed (4)`; full suite `pnpm exec vitest run`: **26 files / 87 tests passed**.

## Verification

- `pnpm exec vitest run`: 87/87 pass locally.
- `pnpm exec tsc --noEmit`: identical error set to clean `main` (verified via `git stash` baseline run; the 8 pre-existing errors are in `SpotifyDeepResearchResult.tsx` and `extractSendEmailResults.test.ts`, untouched here). No new errors.
- Prettier run on all touched files.
- **Preview verification pending:** per #1875's Done-when, sign up on this PR's preview with a fresh `sweetmantech+` alias and confirm: exactly one `POST /api/accounts` creates a row (with email), no `403 Access denied` in console on first landing, and (with #1872) the onboarding sequence renders without a reload.

## API-side follow-up (not in this PR)

Client single-flighting removes this client's race, but `POST /api/accounts` can still be double-hit by other clients (CLI, retries, multiple tabs). The server-side fix is idempotency per authenticated Privy DID (create-or-return under a uniqueness guarantee) in the `api` repo; that is the cross-repo follow-up flagged in #1875.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Single-flights the signup account bootstrap to stop the double POST /api/accounts race. Prevents orphan account rows and the initial 403 loop on first landing.

- **Bug Fixes**
  - Added `lib/accounts/ensureAccount.ts`: identical concurrent calls share one in-flight request; distinct calls are serialized.
  - Updated `hooks/useUser.tsx`: gate init on Privy `ready`, use `ensureAccount`, and cancel stale effect runs so only the latest writes `userData`.
  - Added tests (`lib/accounts/__tests__/ensureAccount.test.ts`) to cover concurrent signup paths and error recovery.

<sup>Written for commit 8e1ca8095857dec91bbf5f31fb7170c79e666f86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

