### PR TITLE
feat(onboarding): seed the catalog by kicking /api/valuation on first artist add (chat#1867)

### DIFF
--- a/hooks/useAddSpotifyArtist.ts
+++ b/hooks/useAddSpotifyArtist.ts
@@ -2,21 +2,31 @@
 
 import { useState } from "react";
 import { usePrivy } from "@privy-io/react-auth";
+import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { addSpotifyArtist } from "@/lib/artists/addSpotifyArtist";
+import { runValuation } from "@/lib/valuation/runValuation";
 import { useArtistProvider } from "@/providers/ArtistProvider";
 import { useOrganization } from "@/providers/OrganizationProvider";
+import useCatalogs from "@/hooks/useCatalogs";
 import type { SpotifyArtistSearchResult } from "@/types/spotify";
 
 /**
  * Adds a Spotify-searched artist to the roster and refreshes + selects it.
  * Wraps `addSpotifyArtist` with auth + the shared roster (ArtistProvider),
  * mirroring `useAddRosterArtist`.
+ *
+ * On the **first** artist add (the account has no catalog yet) it also
+ * fire-and-forget kicks `POST /api/valuation` for that artist's Spotify id —
+ * seeding the onboarding catalog in the background so the "Claim your catalog"
+ * step is already complete by the time the user reaches it (chat#1867).
  */
 export function useAddSpotifyArtist() {
   const { getAccessToken } = usePrivy();
   const { getArtists } = useArtistProvider();
   const { selectedOrgId } = useOrganization();
+  const catalogsQuery = useCatalogs();
+  const queryClient = useQueryClient();
   const [isAdding, setIsAdding] = useState(false);
 
   const add = async (artist: SpotifyArtistSearchResult): Promise<boolean> => {
@@ -33,6 +43,25 @@ export function useAddSpotifyArtist() {
       );
       await getArtists(created.account_id);
       toast.success(`${artist.name} added to your roster`);
+
+      // Seed the onboarding catalog from the first artist's discography.
+      // Only when we know there is no catalog yet (empty, not just unloaded),
+      // and fire-and-forget so the dialog closes immediately — the catalog
+      // materializes in ~20s and the sequence advances on the next landing.
+      const catalogs = catalogsQuery.data?.catalogs;
+      if (catalogs && catalogs.length === 0) {
+        toast.promise(
+          runValuation(accessToken, artist.id).then(() => {
+            queryClient.invalidateQueries({ queryKey: ["catalogs"] });
+          }),
+          {
+            loading: `Valuing ${artist.name}'s catalog…`,
+            success: "Your catalog is ready",
+            error:
+              "Couldn't value the catalog automatically — you can claim it later",
+          },
+        );
+      }
       return true;
     } catch (error) {
       toast.error(

--- a/lib/ai/__tests__/organizeModels.test.ts
+++ b/lib/ai/__tests__/organizeModels.test.ts
@@ -10,9 +10,9 @@ describe("organizeModels", () => {
   it("splits featured and non-featured gateway models", () => {
     const models = [
       {
-        id: "openai/gpt-5.2",
-        name: "gpt-5.2",
-        specification: { specificationVersion: "v2", provider: "openai", modelId: "gpt-5.2" },
+        id: "openai/gpt-5.5",
+        name: "gpt-5.5",
+        specification: { specificationVersion: "v2", provider: "openai", modelId: "gpt-5.5" },
       },
       {
         id: "some/other-model",
@@ -22,7 +22,7 @@ describe("organizeModels", () => {
     ] as never;
 
     const result = organizeModels(models);
-    expect(result.featuredModels.map((m) => m.id)).toContain("openai/gpt-5.2");
+    expect(result.featuredModels.map((m) => m.id)).toContain("openai/gpt-5.5");
     expect(result.otherModels.map((m) => m.id)).toEqual(["some/other-model"]);
   });
 });

--- a/lib/valuation/__tests__/runValuation.test.ts
+++ b/lib/valuation/__tests__/runValuation.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { runValuation } from "@/lib/valuation/runValuation";
+import { getClientApiBaseUrl } from "@/lib/api/getClientApiBaseUrl";
+
+vi.mock("@/lib/api/getClientApiBaseUrl", () => ({
+  getClientApiBaseUrl: vi.fn(),
+}));
+
+describe("runValuation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getClientApiBaseUrl).mockReturnValue("https://api.example.com");
+  });
+
+  it("POSTs the spotify_artist_id to /api/valuation with bearer auth", async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue({ ok: true }) as unknown as typeof fetch;
+
+    await runValuation("tok", "0xPoV");
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://api.example.com/api/valuation",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ Authorization: "Bearer tok" }),
+        body: JSON.stringify({ spotify_artist_id: "0xPoV" }),
+      }),
+    );
+  });
+
+  it("throws on a non-ok response", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 402,
+      text: vi.fn().mockResolvedValue("insufficient credits"),
+    }) as unknown as typeof fetch;
+
+    await expect(runValuation("tok", "0xPoV")).rejects.toThrow("402");
+  });
+});

--- a/lib/valuation/runValuation.ts
+++ b/lib/valuation/runValuation.ts
@@ -1,0 +1,29 @@
+import { getClientApiBaseUrl } from "@/lib/api/getClientApiBaseUrl";
+
+/**
+ * Kicks `POST /api/valuation` for a Spotify artist (api#776): resolves the
+ * artist's releases, measures play counts, and materializes an account-owned
+ * catalog + value band. Used fire-and-forget on the first artist add to seed
+ * the onboarding catalog so "Claim your catalog" is already complete.
+ *
+ * @param accessToken - Privy bearer for the owning account.
+ * @param spotifyArtistId - The Spotify artist id to value.
+ */
+export async function runValuation(
+  accessToken: string,
+  spotifyArtistId: string,
+): Promise<void> {
+  const res = await fetch(`${getClientApiBaseUrl()}/api/valuation`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({ spotify_artist_id: spotifyArtistId }),
+  });
+
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "");
+    throw new Error(`Valuation failed: HTTP ${res.status} ${detail}`.trim());
+  }
+}


### PR DESCRIPTION
## Why

A brand-new signup gets stuck: the onboarding "Claim your catalog" step links to an empty `/catalogs` with no way to create one, so a direct signup can **never finish onboarding** or reach the first-task step (weekly report emails). Verified 2026-07-22 with two fresh accounts.

The pieces to fix it all exist now:
- **#1878** already links the artist's Spotify profile when you add them → we have the `spotify_artist_id` on the account.
- **api#776** (`POST /api/valuation`, merged + synced to `test`) turns a `spotify_artist_id` into an account-owned catalog + value band in ~20s.

## What

`useAddSpotifyArtist` now **fire-and-forget kicks `POST /api/valuation { spotify_artist_id }`** the moment the **first** artist is added (only when the account has no catalog yet) — seeding the onboarding catalog in the background. By the time the user reaches "Claim your catalog," it's already **(complete)**, and the sequence flows through to the first-task step.

- `lib/valuation/runValuation.ts` — client `POST /api/valuation` with bearer.
- `hooks/useAddSpotifyArtist.ts` — background kick gated on an **empty, loaded** catalogs query (never fires when a catalog already exists or the query hasn't resolved); surfaced via `toast.promise` ("Valuing {artist}'s catalog… → Your catalog is ready"), and invalidates `["catalogs"]` on success so the step advances live.

Fire-and-forget: the add dialog closes immediately; the valuation runs in the background. If it fails (e.g. no releases / credits), a soft toast says the catalog can be claimed later — no blocking.

## Tests

TDD red→green — `runValuation` 2/2 (POSTs `spotify_artist_id` with bearer; throws on non-ok). tsc clean on touched files; eslint/prettier clean.

## Verification (pending)

Preview: fresh account → add first artist → confirm a catalog materializes in the background (`account_catalogs`) and the onboarding "Claim your catalog" step flips to complete without a manual step. Base `test`.

Tracking: chat#1867 (seed onboarding catalog on first artist add).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically seeds a catalog during onboarding by triggering `POST /api/valuation` when the first Spotify artist is added, so new signups can complete “Claim your catalog” and proceed to first tasks. Connected to `chat#1867`; uses the artist’s `spotify_artist_id` and runs in the background.

- **New Features**
  - Kicks valuation once on first artist add when the catalogs query has loaded and is empty, using `spotify_artist_id` from `#1878` and `POST /api/valuation` from `api#776`.
  - Adds `runValuation` client helper (Bearer auth, throws on non-ok) with tests; shows non-blocking toast and invalidates `["catalogs"]` on success.

- **Bug Fixes**
  - Fix `organizeModels` test fixture: update featured id to `openai/gpt-5.5` (post-`#1877`).

<sup>Written for commit 67366bfb6479d6fcdea9746075da8c39121651d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic catalog valuation when the first Spotify artist is added.
  * Added progress, success, and error notifications for catalog valuation.
  * Catalog data now refreshes automatically after valuation completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->