### PR TITLE
feat(onboarding): Spotify typeahead in verify-socials (item 3b of #1881)

### DIFF
--- a/components/Onboarding/ArtistSocialsCard.tsx
+++ b/components/Onboarding/ArtistSocialsCard.tsx
@@ -3,8 +3,8 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import type { ArtistRecord } from "@/types/Artist";
-import SocialFixForm from "./SocialFixForm";
 import SocialRow from "./SocialRow";
+import SocialSearchOrPaste from "./SocialSearchOrPaste";
 
 interface ArtistSocialsCardProps {
   artist: ArtistRecord;
@@ -58,8 +58,8 @@ const ArtistSocialsCard = ({
 
       {/* Always available: a matched-social list can still be missing platforms. */}
       {adding ? (
-        <SocialFixForm
-          placeholder="Paste a profile link"
+        <SocialSearchOrPaste
+          pastePlaceholder="Paste a profile link"
           isSubmitting={isFixing}
           onSubmit={handleAdd}
         />

--- a/components/Onboarding/SocialRow.tsx
+++ b/components/Onboarding/SocialRow.tsx
@@ -7,7 +7,7 @@ import getSocialPlatformByLink from "@/lib/getSocialPlatformByLink";
 import { getSocialFollowerCount } from "@/lib/onboarding/getSocialFollowerCount";
 import getPlatformDisplayName from "@/lib/socials/getPlatformDisplayName";
 import formatFollowerCount from "@/lib/utils/formatFollowerCount";
-import SocialFixForm from "./SocialFixForm";
+import SocialSearchOrPaste from "./SocialSearchOrPaste";
 import type { SOCIAL } from "@/types/Agent";
 
 interface SocialRowProps {
@@ -65,8 +65,8 @@ const SocialRow = ({ social, isSubmitting, onFix }: SocialRowProps) => {
       </div>
       {editing && (
         <div className="mt-2">
-          <SocialFixForm
-            placeholder="Paste the correct profile link"
+          <SocialSearchOrPaste
+            pastePlaceholder="Paste the correct profile link"
             isSubmitting={isSubmitting}
             onSubmit={handleFix}
           />

--- a/components/Onboarding/SocialSearchOrPaste.tsx
+++ b/components/Onboarding/SocialSearchOrPaste.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import SpotifyArtistSearch from "@/components/Artists/SpotifyArtistSearch";
+import SocialFixForm from "./SocialFixForm";
+import type { SpotifyArtistSearchResult } from "@/types/spotify";
+
+interface SocialSearchOrPasteProps {
+  /** Placeholder for the paste-a-link fallback input. */
+  pastePlaceholder: string;
+  isSubmitting: boolean;
+  onSubmit: (url: string) => Promise<boolean>;
+}
+
+/**
+ * Add/replace a social by searching Spotify (typeahead, reusing #1878's
+ * SpotifyArtistSearch) instead of pasting a link — picking an artist submits
+ * their Spotify profile URL, which the existing platform-detection path keys
+ * as SPOTIFY. A "paste a link instead" fallback stays available for the other
+ * platforms (Instagram, TikTok, YouTube, ...) the Spotify search can't reach.
+ */
+const SocialSearchOrPaste = ({
+  pastePlaceholder,
+  isSubmitting,
+  onSubmit,
+}: SocialSearchOrPasteProps) => {
+  const [pasting, setPasting] = useState(false);
+
+  const handleSelect = (artist: SpotifyArtistSearchResult) => {
+    void onSubmit(artist.external_urls.spotify);
+  };
+
+  if (pasting) {
+    return (
+      <div className="flex flex-col gap-2">
+        <SocialFixForm
+          placeholder={pastePlaceholder}
+          isSubmitting={isSubmitting}
+          onSubmit={onSubmit}
+        />
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="self-start text-muted-foreground"
+          onClick={() => setPasting(false)}
+        >
+          Search Spotify instead
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <SpotifyArtistSearch onSelect={handleSelect} isBusy={isSubmitting} />
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="self-start text-muted-foreground"
+        onClick={() => setPasting(true)}
+      >
+        Paste a link instead
+      </Button>
+    </div>
+  );
+};
+
+export default SocialSearchOrPaste;


### PR DESCRIPTION
## Item 3b of #1881 — Spotify typeahead in verify-socials

The verify-socials Add/Edit flow made users paste a Spotify link. This reuses the existing **`SpotifyArtistSearch`** typeahead (shipped in #1878) so users search Spotify and pick their artist instead.

### What changed
- New `components/Onboarding/SocialSearchOrPaste.tsx` — leads with the `SpotifyArtistSearch` typeahead; selecting an artist submits their `external_urls.spotify` URL, which the existing `buildSocialFixPayload` path keys as `SPOTIFY`.
- A **"Paste a link instead"** fallback stays available for the non-Spotify platforms (Instagram, TikTok, YouTube, X, Facebook, Threads, Apple Music) the Spotify search can't reach — so nothing regresses.
- Wired into both `ArtistSocialsCard` (Add a profile) and `SocialRow` (Edit) in place of the raw `SocialFixForm`.

The `onSubmit(url) => Promise<boolean>` contract is unchanged, so `useSocialFix` and the existing PATCH `profileUrls` path are untouched (DRY).

### Verification
- `pnpm exec eslint` on the changed files: clean.
- `tsc`: no new errors from these files (pre-existing test-file errors unrelated).
- `pnpm build`: compiles successfully (full page-data collection needs Supabase secrets, unavailable locally).
- `buildSocialFixPayload` tests: 6/6 pass (Spotify URL → `SPOTIFY` payload already covered).

Tracking: #1881

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use Spotify artist typeahead in verify-socials Add/Edit so users search and pick their artist instead of pasting links. Addresses item 3b in #1881 and keeps a paste-a-link fallback for non-Spotify platforms.

- **New Features**
  - Added `components/Onboarding/SocialSearchOrPaste.tsx`, leading with `SpotifyArtistSearch` and falling back to `SocialFixForm`.
  - Integrated into `ArtistSocialsCard` and `SocialRow`, replacing direct `SocialFixForm` usage.
  - Selecting an artist submits `external_urls.spotify` to the unchanged `onSubmit(url)` contract, which maps to `SPOTIFY` via the existing path.

<sup>Written for commit abf8738c01a387ed4b774723569c7037a4f900df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

