### PR TITLE
feat(tasks): timezone-aware scheduling picker (chat#1881 item 3c)

### DIFF
--- a/components/TimezoneSelect/TimezoneSelect.tsx
+++ b/components/TimezoneSelect/TimezoneSelect.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useMemo } from "react";
+import { Globe } from "lucide-react";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { getTimezoneOptions } from "@/lib/timezone/getTimezoneOptions";
+import { formatTimezoneLabel } from "@/lib/timezone/formatTimezoneLabel";
+
+interface TimezoneSelectProps {
+  value: string;
+  onValueChange: (value: string) => void;
+  disabled?: boolean;
+}
+
+/**
+ * Picks the IANA timezone a task's cron schedule is interpreted in. Defaults to
+ * the viewer's local zone upstream; the full option list always includes it.
+ */
+const TimezoneSelect: React.FC<TimezoneSelectProps> = ({
+  value,
+  onValueChange,
+  disabled = false,
+}) => {
+  const options = useMemo(() => getTimezoneOptions(), []);
+
+  return (
+    <div className="space-y-2">
+      <Label
+        htmlFor="task-timezone"
+        className="flex items-center gap-2 text-sm font-semibold"
+      >
+        <Globe className="h-4 w-4" />
+        Timezone
+      </Label>
+      <Select value={value} onValueChange={onValueChange} disabled={disabled}>
+        <SelectTrigger id="task-timezone" className="w-full text-xs">
+          <SelectValue placeholder="Select a timezone">
+            {formatTimezoneLabel(value)}
+          </SelectValue>
+        </SelectTrigger>
+        <SelectContent className="max-h-72">
+          {options.map((zone) => (
+            <SelectItem key={zone} value={zone} className="text-xs">
+              {formatTimezoneLabel(zone)}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <p className="text-xs text-muted-foreground">
+        Scheduled runs fire at this zone&apos;s local time.
+      </p>
+    </div>
+  );
+};
+
+export default TimezoneSelect;

--- a/components/VercelChat/dialogs/tasks/TaskDetailsDialog.tsx
+++ b/components/VercelChat/dialogs/tasks/TaskDetailsDialog.tsx
@@ -32,6 +32,8 @@ const TaskDetailsDialog: React.FC<TaskDetailsDialogProps> = ({
     setEditCron,
     editModel,
     setEditModel,
+    editTimezone,
+    setEditTimezone,
     isActive,
     isPaused,
     canEdit,
@@ -60,10 +62,12 @@ const TaskDetailsDialog: React.FC<TaskDetailsDialogProps> = ({
           editPrompt={editPrompt}
           editCron={editCron}
           editModel={editModel}
+          editTimezone={editTimezone}
           onTitleChange={setEditTitle}
           onPromptChange={setEditPrompt}
           onCronChange={setEditCron}
           onModelChange={setEditModel}
+          onTimezoneChange={setEditTimezone}
           canEdit={canEdit}
           isDeleted={isDeleted}
         />
@@ -76,6 +80,7 @@ const TaskDetailsDialog: React.FC<TaskDetailsDialogProps> = ({
             editPrompt={editPrompt}
             editCron={editCron}
             editModel={editModel}
+            editTimezone={editTimezone}
             onSaveSuccess={() => setIsDialogOpen(false)}
             onDeleteSuccess={() => {
               setIsDialogOpen(false);

--- a/components/VercelChat/dialogs/tasks/TaskDetailsDialogActionButtons.tsx
+++ b/components/VercelChat/dialogs/tasks/TaskDetailsDialogActionButtons.tsx
@@ -11,6 +11,7 @@ interface TaskDetailsDialogActionButtonsProps {
   editPrompt: string;
   editCron: string;
   editModel: string;
+  editTimezone: string;
   onSaveSuccess: () => void;
   onDeleteSuccess: () => void;
   isEnabled: boolean;
@@ -25,6 +26,7 @@ const TaskDetailsDialogActionButtons: React.FC<
   editPrompt,
   editCron,
   editModel,
+  editTimezone,
   onSaveSuccess,
   onDeleteSuccess,
   isEnabled,
@@ -77,6 +79,7 @@ const TaskDetailsDialogActionButtons: React.FC<
           prompt: editPrompt,
           schedule: cronExpression,
           model: editModel,
+          timezone: editTimezone,
         },
         onSuccess: () => {
           onSaveSuccess();

--- a/components/VercelChat/dialogs/tasks/TaskDetailsDialogContent.tsx
+++ b/components/VercelChat/dialogs/tasks/TaskDetailsDialogContent.tsx
@@ -19,6 +19,7 @@ const CronEditor = dynamic(
 );
 import TaskLastRunSection from "./TaskLastRunSection";
 import TaskScheduleSection from "./TaskScheduleSection";
+import TimezoneSelect from "@/components/TimezoneSelect/TimezoneSelect";
 import TaskRecentRunsSection from "./TaskRecentRunsSection";
 import TaskUpcomingRunsSection from "./TaskUpcomingRunsSection";
 import { getFeaturedModelConfig } from "@/lib/ai/featuredModels";
@@ -31,10 +32,12 @@ interface TaskDetailsDialogContentProps {
   editPrompt: string;
   editCron: string;
   editModel: string;
+  editTimezone: string;
   onTitleChange: (value: string) => void;
   onPromptChange: (value: string) => void;
   onCronChange: (value: string) => void;
   onModelChange: (value: string) => void;
+  onTimezoneChange: (value: string) => void;
   canEdit: boolean;
   isDeleted?: boolean;
 }
@@ -45,10 +48,12 @@ const TaskDetailsDialogContent: React.FC<TaskDetailsDialogContentProps> = ({
   editPrompt,
   editCron,
   editModel,
+  editTimezone,
   onTitleChange,
   onPromptChange,
   onCronChange,
   onModelChange,
+  onTimezoneChange,
   canEdit,
   isDeleted = false,
 }) => {
@@ -91,14 +96,21 @@ const TaskDetailsDialogContent: React.FC<TaskDetailsDialogContentProps> = ({
 
       {/* Schedule Section */}
       {canEdit ? (
-        <CronEditor
-          cronExpression={editCron}
-          onCronExpressionChange={onCronChange}
-        />
+        <>
+          <CronEditor
+            cronExpression={editCron}
+            onCronExpressionChange={onCronChange}
+          />
+          <TimezoneSelect
+            value={editTimezone}
+            onValueChange={onTimezoneChange}
+          />
+        </>
       ) : (
         <TaskScheduleSection
           schedule={task.schedule}
           nextRun={task.next_run || ""}
+          timezone={editTimezone}
           isDeleted={isDeleted}
         />
       )}

--- a/components/VercelChat/dialogs/tasks/TaskScheduleSection.tsx
+++ b/components/VercelChat/dialogs/tasks/TaskScheduleSection.tsx
@@ -2,16 +2,19 @@ import { CalendarDays, Clock } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatScheduledActionDate } from "@/lib/utils/formatScheduledActionDate";
 import { parseCronToHuman } from "@/lib/tasks/parseCronToHuman";
+import { formatTimezoneLabel } from "@/lib/timezone/formatTimezoneLabel";
 
 interface TaskScheduleSectionProps {
   schedule: string;
   nextRun: string;
+  timezone?: string | null;
   isDeleted?: boolean;
 }
 
 const TaskScheduleSection = ({
   schedule,
   nextRun,
+  timezone,
   isDeleted,
 }: TaskScheduleSectionProps) => {
   return (
@@ -36,6 +39,13 @@ const TaskScheduleSection = ({
           })}>
             {parseCronToHuman(schedule)}
           </div>
+          {timezone && (
+            <div className={cn("text-[10px] mt-0.5 text-muted-foreground", {
+              "text-red-500": isDeleted
+            })}>
+              {formatTimezoneLabel(timezone)}
+            </div>
+          )}
         </div>
       </div>
 

--- a/components/VercelChat/dialogs/tasks/useTaskDetailsDialog.ts
+++ b/components/VercelChat/dialogs/tasks/useTaskDetailsDialog.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { Tables } from "@/types/database.types";
 import { DEFAULT_MODEL } from "@/lib/consts";
+import { getTaskTimezone } from "@/lib/timezone/getTaskTimezone";
 
 interface UseTaskDetailsDialogParams {
   task: Tables<"scheduled_actions">;
@@ -18,6 +19,7 @@ export const useTaskDetailsDialog = ({
     task.schedule?.trim() || "0 9 * * *"
   );
   const [editModel, setEditModel] = useState(task.model || DEFAULT_MODEL);
+  const [editTimezone, setEditTimezone] = useState(() => getTaskTimezone(task));
 
   // Sync edit state when task prop changes
   useEffect(() => {
@@ -25,6 +27,7 @@ export const useTaskDetailsDialog = ({
     setEditPrompt(task.prompt);
     setEditCron(task.schedule?.trim() || "0 9 * * *");
     setEditModel(task.model || DEFAULT_MODEL);
+    setEditTimezone(getTaskTimezone(task));
   }, [task]);
 
   const isActive = Boolean(task.enabled && !isDeleted);
@@ -42,6 +45,8 @@ export const useTaskDetailsDialog = ({
     setEditCron,
     editModel,
     setEditModel,
+    editTimezone,
+    setEditTimezone,
     isActive,
     isPaused,
     canEdit,

--- a/hooks/useCreateTask.ts
+++ b/hooks/useCreateTask.ts
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 import { createTask } from "@/lib/tasks/createTask";
 import { useArtistProvider } from "@/providers/ArtistProvider";
 import { DEFAULT_MODEL } from "@/lib/consts";
+import { getLocalTimezone } from "@/lib/timezone/getLocalTimezone";
 
 const DEFAULT_SCHEDULE = "0 9 * * *";
 
@@ -38,6 +39,7 @@ export function useCreateTask() {
         schedule: DEFAULT_SCHEDULE,
         artist_account_id: artistAccountId,
         model: DEFAULT_MODEL,
+        timezone: getLocalTimezone(),
       });
     },
     onSuccess: async (task) => {

--- a/lib/tasks/__tests__/createTask.test.ts
+++ b/lib/tasks/__tests__/createTask.test.ts
@@ -82,4 +82,52 @@ describe("createTask", () => {
       model: "anthropic/claude-sonnet-4.5",
     });
   });
+
+  it("includes timezone in the body when provided", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        status: "success",
+        tasks: [{ id: "task-3" }],
+      }),
+    }) as unknown as typeof fetch;
+
+    await createTask(accessToken, {
+      title: "Weekly report",
+      prompt: "Generate weekly report",
+      schedule: "0 9 * * 1",
+      artist_account_id: "artist-3",
+      timezone: "America/Los_Angeles",
+    });
+
+    const init = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
+    expect(JSON.parse(String(init.body))).toEqual({
+      title: "Weekly report",
+      prompt: "Generate weekly report",
+      schedule: "0 9 * * 1",
+      artist_account_id: "artist-3",
+      timezone: "America/Los_Angeles",
+    });
+  });
+
+  it("omits timezone when it is an empty string", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        status: "success",
+        tasks: [{ id: "task-4" }],
+      }),
+    }) as unknown as typeof fetch;
+
+    await createTask(accessToken, {
+      title: "No tz",
+      prompt: "Prompt",
+      schedule: "0 9 * * 1",
+      artist_account_id: "artist-4",
+      timezone: "",
+    });
+
+    const init = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
+    expect(JSON.parse(String(init.body))).not.toHaveProperty("timezone");
+  });
 });

--- a/lib/tasks/__tests__/updateTask.test.ts
+++ b/lib/tasks/__tests__/updateTask.test.ts
@@ -41,4 +41,27 @@ describe("updateTask", () => {
     );
     expect(result).toEqual(updatedTask);
   });
+
+  it("includes timezone in the body when provided", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        status: "success",
+        tasks: [{ id: "task-1" }],
+      }),
+    }) as unknown as typeof fetch;
+
+    await updateTask(accessToken, {
+      id: "task-1",
+      schedule: "0 9 * * 1",
+      timezone: "Europe/London",
+    });
+
+    const init = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
+    expect(JSON.parse(String(init.body))).toEqual({
+      id: "task-1",
+      schedule: "0 9 * * 1",
+      timezone: "Europe/London",
+    });
+  });
 });

--- a/lib/tasks/createTask.ts
+++ b/lib/tasks/createTask.ts
@@ -10,6 +10,8 @@ export interface CreateTaskParams {
   /** When omitted, the API uses the authenticated account. When set, must be allowed for the caller (e.g. org membership). */
   account_id?: string;
   model?: string | null;
+  /** IANA timezone (e.g. "America/Los_Angeles") the cron schedule is interpreted in. */
+  timezone?: string;
 }
 
 /**
@@ -37,6 +39,10 @@ export async function createTask(
     params.model !== ""
   ) {
     body.model = params.model;
+  }
+
+  if (params.timezone !== undefined && params.timezone !== "") {
+    body.timezone = params.timezone;
   }
 
   const response = await fetch(`${getClientApiBaseUrl()}/api/tasks`, {

--- a/lib/tasks/updateTask.ts
+++ b/lib/tasks/updateTask.ts
@@ -13,6 +13,8 @@ export interface UpdateTaskParams {
   artist_account_id?: string;
   enabled?: boolean | null;
   model?: string | null;
+  /** IANA timezone (e.g. "America/Los_Angeles") the cron schedule is interpreted in. */
+  timezone?: string;
 }
 
 /**
@@ -43,6 +45,7 @@ export async function updateTask(
         }),
         ...(params.enabled !== undefined && { enabled: params.enabled }),
         ...(params.model !== undefined && { model: params.model }),
+        ...(params.timezone !== undefined && { timezone: params.timezone }),
       }),
     });
 

--- a/lib/timezone/__tests__/getLocalTimezone.test.ts
+++ b/lib/timezone/__tests__/getLocalTimezone.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getLocalTimezone } from "@/lib/timezone/getLocalTimezone";
+
+describe("getLocalTimezone", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the runtime's resolved IANA timezone", () => {
+    vi.spyOn(Intl, "DateTimeFormat").mockImplementation(
+      () =>
+        ({
+          resolvedOptions: () => ({ timeZone: "America/New_York" }),
+        }) as unknown as Intl.DateTimeFormat,
+    );
+
+    expect(getLocalTimezone()).toBe("America/New_York");
+  });
+
+  it("falls back to UTC when resolution throws", () => {
+    vi.spyOn(Intl, "DateTimeFormat").mockImplementation(() => {
+      throw new Error("no Intl");
+    });
+
+    expect(getLocalTimezone()).toBe("UTC");
+  });
+
+  it("falls back to UTC when the resolved zone is empty", () => {
+    vi.spyOn(Intl, "DateTimeFormat").mockImplementation(
+      () =>
+        ({
+          resolvedOptions: () => ({ timeZone: "" }),
+        }) as unknown as Intl.DateTimeFormat,
+    );
+
+    expect(getLocalTimezone()).toBe("UTC");
+  });
+});

--- a/lib/timezone/__tests__/getTimezoneOptions.test.ts
+++ b/lib/timezone/__tests__/getTimezoneOptions.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getTimezoneOptions } from "@/lib/timezone/getTimezoneOptions";
+
+const intlWithSupported = Intl as typeof Intl & {
+  supportedValuesOf?: (key: "timeZone") => string[];
+};
+
+describe("getTimezoneOptions", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the runtime's canonical timezone list when available", () => {
+    vi.spyOn(Intl, "DateTimeFormat").mockImplementation(
+      () =>
+        ({
+          resolvedOptions: () => ({ timeZone: "Europe/Paris" }),
+        }) as unknown as Intl.DateTimeFormat,
+    );
+    vi.spyOn(intlWithSupported, "supportedValuesOf").mockReturnValue([
+      "Europe/Paris",
+      "UTC",
+    ]);
+
+    expect(getTimezoneOptions()).toEqual(["Europe/Paris", "UTC"]);
+  });
+
+  it("prepends the local zone when the canonical list omits it", () => {
+    vi.spyOn(Intl, "DateTimeFormat").mockImplementation(
+      () =>
+        ({
+          resolvedOptions: () => ({ timeZone: "Pacific/Auckland" }),
+        }) as unknown as Intl.DateTimeFormat,
+    );
+    vi.spyOn(intlWithSupported, "supportedValuesOf").mockReturnValue(["UTC"]);
+
+    expect(getTimezoneOptions()[0]).toBe("Pacific/Auckland");
+    expect(getTimezoneOptions()).toContain("UTC");
+  });
+
+  it("uses the fallback list when supportedValuesOf is missing", () => {
+    vi.spyOn(Intl, "DateTimeFormat").mockImplementation(
+      () =>
+        ({
+          resolvedOptions: () => ({ timeZone: "America/New_York" }),
+        }) as unknown as Intl.DateTimeFormat,
+    );
+    vi.spyOn(intlWithSupported, "supportedValuesOf").mockReturnValue(
+      undefined as unknown as string[],
+    );
+
+    const options = getTimezoneOptions();
+    expect(options).toContain("America/New_York");
+    expect(options).toContain("UTC");
+  });
+});

--- a/lib/timezone/formatTimezoneLabel.ts
+++ b/lib/timezone/formatTimezoneLabel.ts
@@ -1,0 +1,21 @@
+/**
+ * Human-friendly label for an IANA timezone, e.g.
+ * "America/Los_Angeles" -> "America/Los Angeles (GMT-7)".
+ *
+ * The GMT offset is computed for "now", so it reflects the zone's current
+ * DST state. Falls back to the raw zone name if the offset can't be resolved.
+ */
+export function formatTimezoneLabel(timezone: string): string {
+  const readableName = timezone.replace(/_/g, " ");
+
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      timeZoneName: "shortOffset",
+    }).formatToParts(new Date());
+    const offset = parts.find((p) => p.type === "timeZoneName")?.value;
+    return offset ? `${readableName} (${offset})` : readableName;
+  } catch {
+    return readableName;
+  }
+}

--- a/lib/timezone/getLocalTimezone.ts
+++ b/lib/timezone/getLocalTimezone.ts
@@ -1,0 +1,13 @@
+/**
+ * Resolve the viewer's local IANA timezone (e.g. "America/Los_Angeles").
+ *
+ * Falls back to "UTC" when the runtime cannot resolve a zone (older engines,
+ * locked-down environments) so callers always get a valid IANA string.
+ */
+export function getLocalTimezone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+  } catch {
+    return "UTC";
+  }
+}

--- a/lib/timezone/getTaskTimezone.ts
+++ b/lib/timezone/getTaskTimezone.ts
@@ -1,0 +1,15 @@
+import { getLocalTimezone } from "./getLocalTimezone";
+
+/**
+ * The timezone a task is scheduled in.
+ *
+ * Reads the optional `timezone` column (added by the sibling api change) off a
+ * task-like record, falling back to the viewer's local zone when it's absent —
+ * so the edit UI is correct before and after the api ships the column.
+ */
+export function getTaskTimezone(
+  task: Record<string, unknown> & { timezone?: string | null },
+): string {
+  const timezone = task.timezone;
+  return typeof timezone === "string" && timezone ? timezone : getLocalTimezone();
+}

--- a/lib/timezone/getTimezoneOptions.ts
+++ b/lib/timezone/getTimezoneOptions.ts
@@ -1,0 +1,49 @@
+import { getLocalTimezone } from "./getLocalTimezone";
+
+/**
+ * A short, sensible fallback list for engines that lack
+ * `Intl.supportedValuesOf` (older Safari/Node). Covers the zones our users
+ * are most likely to schedule against.
+ */
+const FALLBACK_ZONES = [
+  "UTC",
+  "America/Los_Angeles",
+  "America/Denver",
+  "America/Chicago",
+  "America/New_York",
+  "America/Sao_Paulo",
+  "Europe/London",
+  "Europe/Paris",
+  "Europe/Berlin",
+  "Africa/Johannesburg",
+  "Asia/Dubai",
+  "Asia/Kolkata",
+  "Asia/Singapore",
+  "Asia/Tokyo",
+  "Australia/Sydney",
+];
+
+type IntlWithSupportedValues = typeof Intl & {
+  supportedValuesOf?: (key: "timeZone") => string[];
+};
+
+/**
+ * The full list of selectable IANA timezones, always including the viewer's
+ * local zone. Prefers the runtime's canonical list, falling back to a curated
+ * set when `Intl.supportedValuesOf` is unavailable.
+ */
+export function getTimezoneOptions(): string[] {
+  const local = getLocalTimezone();
+  let zones: string[];
+
+  try {
+    const supported = (Intl as IntlWithSupportedValues).supportedValuesOf?.(
+      "timeZone",
+    );
+    zones = supported?.length ? supported : FALLBACK_ZONES;
+  } catch {
+    zones = FALLBACK_ZONES;
+  }
+
+  return zones.includes(local) ? zones : [local, ...zones];
+}

--- a/lib/utils/formatScheduledActionDate.ts
+++ b/lib/utils/formatScheduledActionDate.ts
@@ -1,6 +1,7 @@
 /**
- * Format date for scheduled actions with time (e.g. "Jan 15, 2:30 PM")
- * 
+ * Format date for scheduled actions in the viewer's local time, with the local
+ * timezone abbreviation appended (e.g. "Jan 15, 2:30 PM PST").
+ *
  * @param dateString ISO date string or null
  * @returns Formatted date string or "Never" if null
  */
@@ -12,6 +13,7 @@ export const formatScheduledActionDate = (dateString: string | null): string => 
       day: "numeric",
       hour: "2-digit",
       minute: "2-digit",
+      timeZoneName: "short",
     });
   } catch {
     return "Invalid date";


### PR DESCRIPTION
## What

Adds a **timezone picker** to the task scheduling UI so a task's cron schedule is interpreted in the user's chosen zone. Defaults to the viewer's local IANA timezone (`Intl.DateTimeFormat().resolvedOptions().timeZone`) and sends it to the API on create/update. Scheduled times display in local time with the zone abbreviation.

Part of #1881 — **item 3c (chat side)**. Fixes the "weekly email lands 9am UTC (middle of the US night)" problem so it lands 9am *local*.

## Changes

- `lib/timezone/` — new helpers, one export per file:
  - `getLocalTimezone()` — viewer's IANA zone, UTC fallback
  - `getTimezoneOptions()` — `Intl.supportedValuesOf("timeZone")` with a curated fallback list, always including the local zone
  - `getTaskTimezone(task)` — reads the optional stored `timezone`, falls back to local
  - `formatTimezoneLabel(zone)` — "America/Los_Angeles" → "America/Los Angeles (GMT-7)"
- `components/TimezoneSelect/TimezoneSelect.tsx` — shadcn `Select`-based picker, wired into the task details edit dialog beneath the cron editor
- `lib/tasks/createTask.ts` / `updateTask.ts` — send optional `timezone` in the body
- `hooks/useCreateTask.ts` — defaults new tasks to the local zone
- `formatScheduledActionDate` — appends the local timezone abbreviation (e.g. "Jan 15, 2:30 PM PST")
- Read-only schedule section shows the zone label

## API dependency

The API accepts an optional **`timezone`** field — sibling **api PR in flight** (issue #1881 item 3c, api side). This chat change is forward-compatible: it sends the field, which the API ignores until the column/handler ship, then honors once deployed. Types here read the column optionally, so no regen is blocked.

## Tests / gates

- `pnpm vitest run lib/timezone lib/tasks` — 25 passing (new: getLocalTimezone, getTimezoneOptions, createTask/updateTask include `timezone`)
- `pnpm exec tsc --noEmit` — no new errors from these files (pre-existing baseline unchanged)
- `pnpm build` — compiles successfully (local page-data collection fails only on missing env creds, unrelated)

Refs #1881

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a timezone picker to task scheduling so cron runs in the selected IANA zone. Defaults to the viewer’s local timezone, sends `timezone` on create/update, and shows times with zone labels. Addresses chat#1881 item 3c so weekly emails land at 9am local, not 9am UTC.

- New Features
  - Timezone picker under the cron editor; schedule displays include the zone label.
  - New tasks default to the local zone; create/update send optional `timezone` (empty omitted).
  - Dates render with the local short TZ (e.g. “PST”) in `formatScheduledActionDate`.
  - Helpers in `lib/timezone`: `getLocalTimezone`, `getTimezoneOptions` (with fallback), `getTaskTimezone`, `formatTimezoneLabel`.
  - Tests cover helpers and that create/update bodies include `timezone` when provided.

- Migration
  - No action needed. Forward-compatible: API will honor `timezone` once its change ships.

<sup>Written for commit 19fa51af02469a262ffee27018f115b5248f2243. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

