### PR TITLE
feat(onboarding): report CTA → first-task step, not blank /tasks (chat#1881 item 2b)

### DIFF
--- a/components/Catalog/report/CatalogReportCta.tsx
+++ b/components/Catalog/report/CatalogReportCta.tsx
@@ -2,8 +2,9 @@ import Link from "next/link";
 
 /**
  * The report's ONE primary next action: set up the weekly report that keeps
- * this valuation measured (onboarding sequence advance, chat#1867). Links to
- * /tasks until the dedicated first-task step ships in a sibling PR.
+ * this valuation measured (onboarding sequence advance, chat#1867). Routes to
+ * the one-click first-task step — pre-runs the first weekly report, then
+ * confirms the Monday schedule — instead of a blank /tasks page.
  */
 const CatalogReportCta = () => {
   return (
@@ -19,7 +20,7 @@ const CatalogReportCta = () => {
         re-measures your catalog and emails you the trend.
       </p>
       <Link
-        href="/tasks"
+        href="/onboarding/first-task"
         className="mt-4 inline-flex items-center justify-center rounded-xl bg-primary px-5 py-2.5 font-heading text-sm font-semibold text-primary-foreground transition-colors duration-200 hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
       >
         Set up your weekly report


### PR DESCRIPTION
## What

The post-valuation catalog report's primary CTA — **"Set up your weekly report"** — routed to a blank `/tasks` page. This points it at **`/onboarding/first-task`**, the existing one-click first-task flow:

1. Pre-runs the first weekly catalog report through the normal chat pipeline
2. Shows the finished report (real tool components, not a text dump)
3. Then asks the one confirm question — *"get this every Monday?"* — which schedules the task

So marketing-funnel users get the same first-report moment the direct signup already delivers.

Part of #1881 — **item 2b**.

## Changes

- `components/Catalog/report/CatalogReportCta.tsx` — `href="/tasks"` → `href="/onboarding/first-task"`; refreshed the stale "links to /tasks until the first-task step ships" comment (that step shipped in #1880).

The first-task step (`FirstTaskStep` → `FirstTaskReportRun` → `FirstTaskConfirm`) and its route already exist on `main` (#1880); this PR is the wiring the CTA's own comment flagged as pending.

## Verification gate

Full end-to-end verification (report actually generates + schedules) needs a **populated roster**, which is **gated on api item 1b** ([api#777](https://github.com/recoupable/api/pull/777) — link the searched Spotify artist). Until 1b is live, a funnel signup can land on an empty roster and `FirstTaskStep` shows "Select an artist to generate your first report." The CTA rewire itself is complete and correct; the destination flow is exercised by the direct-signup path today.

Refs #1881

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reroutes the “Set up your weekly report” CTA to `/onboarding/first-task` instead of a blank `/tasks`. This runs the one‑click flow that pre‑generates the first weekly report and confirms Monday scheduling, matching the direct‑signup experience and addressing #1881 item 2b.

<sup>Written for commit 58081488d5b39ead1c1e5f6d601e78a01e5aca4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1884?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

