### PR TITLE
feat(onboarding): render social avatar on verify-socials SocialRow

### DIFF
--- a/components/Onboarding/SocialRow.tsx
+++ b/components/Onboarding/SocialRow.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { Pencil } from "lucide-react";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import getSocialPlatformByLink from "@/lib/getSocialPlatformByLink";
 import { getSocialFollowerCount } from "@/lib/onboarding/getSocialFollowerCount";
@@ -33,6 +34,10 @@ const SocialRow = ({ social, isSubmitting, onFix }: SocialRowProps) => {
       ? social.username
       : `@${social.username}`
     : social.link;
+  const initial = (social.username || platform || "?")
+    .replace(/^@/, "")
+    .charAt(0)
+    .toUpperCase();
 
   const handleFix = async (url: string) => {
     const saved = await onFix(url);
@@ -43,13 +48,23 @@ const SocialRow = ({ social, isSubmitting, onFix }: SocialRowProps) => {
   return (
     <div className="py-2">
       <div className="flex items-center justify-between gap-3">
-        <div className="min-w-0">
-          <p className="text-sm font-medium text-card-foreground">{platform}</p>
-          <p className="text-xs text-muted-foreground truncate">
-            {handle}
-            {followerCount !== null &&
-              ` · ${formatFollowerCount(followerCount)} followers`}
-          </p>
+        <div className="flex min-w-0 items-center gap-3">
+          <Avatar className="size-9 shrink-0">
+            {social.avatar ? (
+              <AvatarImage src={social.avatar} alt="" />
+            ) : null}
+            <AvatarFallback>{initial}</AvatarFallback>
+          </Avatar>
+          <div className="min-w-0">
+            <p className="text-sm font-medium text-card-foreground">
+              {platform}
+            </p>
+            <p className="text-xs text-muted-foreground truncate">
+              {handle}
+              {followerCount !== null &&
+                ` · ${formatFollowerCount(followerCount)} followers`}
+            </p>
+          </div>
         </div>
         <Button
           type="button"


### PR DESCRIPTION
## What

In the verify-socials onboarding step, `SocialRow` rendered platform + `@handle · N followers` but no profile image, even though the `avatar` field is now populated. This renders each connected social's avatar so users can **visually confirm the auto-match**.

## Changes

- `components/Onboarding/SocialRow.tsx` — add the shared shadcn `Avatar` (circular, `radius-full` per DESIGN.md) before the platform/handle text.
  - `AvatarImage` from `social.avatar` when present.
  - `AvatarFallback` to the handle/platform initial when `avatar` is null — achromatic chrome, no color introduced.

Render-side only; mirrors the sibling `RosterArtistRow` avatar pattern.

## Verification

- `pnpm exec tsc --noEmit` — clean for `SocialRow.tsx`.
- `pnpm exec eslint components/Onboarding/SocialRow.tsx` — clean.
- Screenshot: **pending** — the verify-socials step requires an authenticated account with a claimed roster + matched socials to reach; not captured in this render-only change. Follow-up visual check recommended on preview.

Targets `main`. Part of chat#1885 (converge/polish onboarding backlog — verify-socials pfp row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render profile images for connected socials in the verify-socials step so users can visually confirm the auto-match. Adds the shared shadcn `Avatar` to `components/Onboarding/SocialRow.tsx`, showing `social.avatar` before the text and falling back to the uppercase first letter of the handle/platform when missing (refs chat#1885).

<sup>Written for commit 64c7474c01e8f86fc886363c5ef803aa865546e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1886?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

