### PR TITLE
feat(setup): /setup onboarding pages for the welcome-email links (chat#1885)

### DIFF
--- a/app/setup/artists/page.tsx
+++ b/app/setup/artists/page.tsx
@@ -1,0 +1,9 @@
+import RosterSocialsFlow from "@/components/Onboarding/RosterSocialsFlow";
+
+/**
+ * `/setup/artists` — welcome email step 1 ("Confirm your artists"). Opens the
+ * roster + socials flow at the roster step.
+ */
+const SetupArtistsPage = () => <RosterSocialsFlow />;
+
+export default SetupArtistsPage;

--- a/app/setup/catalog/page.tsx
+++ b/app/setup/catalog/page.tsx
@@ -1,0 +1,10 @@
+import { redirect } from "next/navigation";
+
+/**
+ * `/setup/catalog` — welcome email step 3 ("Claim your catalog"). There is no
+ * dedicated claim-catalog onboarding step component yet; the catalog surface is
+ * `/catalogs`, so route there. Revisit if a first-class claim step is built.
+ */
+export default function SetupCatalogPage() {
+  redirect("/catalogs");
+}

--- a/app/setup/page.tsx
+++ b/app/setup/page.tsx
@@ -1,0 +1,9 @@
+import { redirect } from "next/navigation";
+
+/**
+ * `/setup` — the welcome email's "Confirm your roster" CTA target. Sends the
+ * user straight into the interactive setup flow at the first step (roster).
+ */
+export default function SetupPage() {
+  redirect("/setup/artists");
+}

--- a/app/setup/socials/page.tsx
+++ b/app/setup/socials/page.tsx
@@ -1,0 +1,9 @@
+import RosterSocialsFlow from "@/components/Onboarding/RosterSocialsFlow";
+
+/**
+ * `/setup/socials` — welcome email step 2 ("Verify their socials"). Opens the
+ * roster + socials flow directly at the socials step.
+ */
+const SetupSocialsPage = () => <RosterSocialsFlow initialStep="socials" />;
+
+export default SetupSocialsPage;

--- a/app/setup/tasks/page.tsx
+++ b/app/setup/tasks/page.tsx
@@ -1,0 +1,9 @@
+import FirstTaskStep from "@/components/Onboarding/FirstTaskStep";
+
+/**
+ * `/setup/tasks` — welcome email step 5 ("Automate with tasks"). Mounts the
+ * self-contained first-task step (same as /onboarding/first-task).
+ */
+const SetupTasksPage = () => <FirstTaskStep />;
+
+export default SetupTasksPage;

--- a/app/setup/valuation/page.tsx
+++ b/app/setup/valuation/page.tsx
@@ -1,0 +1,11 @@
+import { redirect } from "next/navigation";
+
+/**
+ * `/setup/valuation` — welcome email step 4 ("See your baseline valuation").
+ * The baseline valuation is the catalog report (`/catalogs/[catalogId]`), which
+ * is not addressable without a catalog id here, so route to the catalog list.
+ * Revisit if a dedicated valuation landing is built.
+ */
+export default function SetupValuationPage() {
+  redirect("/catalogs");
+}

--- a/components/Onboarding/RosterSocialsFlow.tsx
+++ b/components/Onboarding/RosterSocialsFlow.tsx
@@ -12,9 +12,17 @@ type FlowStep = "roster" | "socials" | "done";
  * slice is user-testable at /onboarding/roster today. The sibling
  * onboarding-sequence router (chat#1867) mounts `ConfirmRosterStep` and
  * `VerifySocialsStep` directly with its own state-derived stepping.
+ *
+ * `initialStep` lets a deep link open the flow directly at a given step (e.g.
+ * the welcome email's "verify socials" link → `/setup/socials`); it defaults to
+ * "roster" so existing mounts are unchanged.
  */
-const RosterSocialsFlow = () => {
-  const [step, setStep] = useState<FlowStep>("roster");
+const RosterSocialsFlow = ({
+  initialStep = "roster",
+}: {
+  initialStep?: "roster" | "socials";
+} = {}) => {
+  const [step, setStep] = useState<FlowStep>(initialStep);
 
   return (
     <div className="w-full max-w-xl mx-auto grow py-8 px-6">


### PR DESCRIPTION
Adds the `/setup/*` onboarding routes that the redesigned **welcome email** ([api#774](https://github.com/recoupable/api/pull/774)) deep-links. Those routes don't exist yet (`app/setup` was absent), so every link in the email would 404 in production. Part of [chat#1885](https://github.com/recoupable/chat/issues/1885).

## What this adds

Six thin pages, built by **reusing existing onboarding components** (no new UI, no duplicated scaffolding):

| Route | Email step | Renders |
|-------|-----------|---------|
| `/setup` | CTA "Confirm your roster" | redirect → `/setup/artists` |
| `/setup/artists` | 1. Confirm your artists | `RosterSocialsFlow` (roster step) |
| `/setup/socials` | 2. Verify their socials | `RosterSocialsFlow` opened at the socials step |
| `/setup/catalog` | 3. Claim your catalog | redirect → `/catalogs` |
| `/setup/valuation` | 4. See your baseline valuation | redirect → `/catalogs` |
| `/setup/tasks` | 5. Automate with tasks | `FirstTaskStep` |

Pages inherit all providers/chrome from the root `app/layout.tsx` (no per-route layout, and there's no auth wall to add — Privy auto-login is soft).

## Only code change beyond the pages

`RosterSocialsFlow` gains an optional `initialStep` prop (defaults to `"roster"`, so the existing `/onboarding/roster` mount is unchanged) so `/setup/socials` can open directly at the socials step. This reuses the existing roster→socials→verified flow rather than re-mounting the granular steps with duplicated container/nav.

## Decisions to confirm (the two "gaps")

There is **no dedicated component today** for two steps, so I chose the pragmatic redirect:

- **`/setup/catalog` → `/catalogs`** — the onboarding `catalog` checkpoint itself just links to `/catalogs`; there's no claim-catalog step component.
- **`/setup/valuation` → `/catalogs`** — the baseline valuation is the catalog report (`/catalogs/[catalogId]`), which isn't addressable without a catalog id from a generic email, so it routes to the catalog list.

If you'd prefer dedicated pages (or different targets) for either, say so and I'll build them.

## `/setup` behavior

`/setup` redirects to `/setup/artists` so the "Confirm your roster" CTA lands on the interactive roster step. (An alternative was mounting `OnboardingSequence` as a progress hub, but its step cards link to the legacy `/artists`/`/catalogs`/`/tasks` pages, which would be inconsistent with these interactive `/setup/*` deep links — happy to switch if you want the hub instead.)

## Coordinates with [chat#1887](https://github.com/recoupable/chat/pull/1887)

That PR converges the onboarding surfaces / retires the interim `/onboarding/*` mounts. These `/setup/*` routes should become the converged home for these steps rather than a third parallel surface — flagging so they're reconciled.

## Verification

- `tsc --noEmit` + `eslint` clean on all touched files.
- Full `pnpm build` + preview screenshots: pending CI / preview (will add authed screenshots of each `/setup/*` page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `/setup/*` onboarding routes for the redesigned welcome email links to prevent 404s and reuse existing onboarding components. Supports chat#1885 and the welcome email in api#774.

- **New Features**
  - Add routes:
    - /setup → redirect to /setup/artists
    - /setup/artists → RosterSocialsFlow
    - /setup/socials → RosterSocialsFlow with initialStep="socials"
    - /setup/tasks → FirstTaskStep
    - /setup/catalog → redirect to /catalogs
    - /setup/valuation → redirect to /catalogs
  - RosterSocialsFlow: add optional initialStep prop (defaults to "roster"); existing mounts unchanged.

<sup>Written for commit 6ba18c39254ba6fc6cf3dd31d6d0ea1d4d96f316. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

