### PR TITLE
feat(onboarding): add artists by Spotify typeahead, not free text (chat#1889 row 8)

### DIFF
--- a/components/Onboarding/AddArtistForm.tsx
+++ b/components/Onboarding/AddArtistForm.tsx
@@ -1,24 +1,31 @@
 "use client";
 
 import { useState } from "react";
-import { Loader, Plus } from "lucide-react";
+import { Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
+import SpotifyArtistSearch from "@/components/Artists/SpotifyArtistSearch";
 import { useAddRosterArtist } from "@/hooks/onboarding/useAddRosterArtist";
+import type { SpotifyArtistSearchResult } from "@/types/spotify";
 
-/** Inline "add another artist" form for multi-artist managers. */
+/**
+ * "Add an artist" for the onboarding roster step, by Spotify typeahead.
+ *
+ * It used to take a free-text name, which produced an artist with no Spotify id
+ * — so no catalog and therefore no valuation could follow, and the payoff was
+ * structurally unreachable for anyone who arrived without a funnel valuation
+ * (chat#1889). Picking a real Spotify artist resolves the id, profile URL, and
+ * avatar in one step, reusing the same typeahead as verify-socials (chat#1882).
+ */
 const AddArtistForm = () => {
   const { addArtist, isAdding } = useAddRosterArtist();
   const [isOpen, setIsOpen] = useState(false);
-  const [name, setName] = useState("");
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    const added = await addArtist(name);
-    if (added) {
-      setName("");
-      setIsOpen(false);
-    }
+  const handleSelect = async (artist: SpotifyArtistSearchResult) => {
+    const added = await addArtist(artist.name, {
+      profileUrl: artist.external_urls.spotify,
+      image: artist.images?.[0]?.url,
+    });
+    if (added) setIsOpen(false);
   };
 
   if (!isOpen) {
@@ -36,27 +43,23 @@ const AddArtistForm = () => {
   }
 
   return (
-    <form onSubmit={handleSubmit} className="flex items-center gap-2">
-      <Input
+    <div className="flex flex-col gap-2">
+      <SpotifyArtistSearch
         autoFocus
-        value={name}
-        onChange={(e) => setName(e.target.value)}
-        placeholder="Artist name"
-        disabled={isAdding}
-        aria-label="Artist name"
+        isBusy={isAdding}
+        onSelect={(artist) => void handleSelect(artist)}
       />
-      <Button type="submit" disabled={isAdding || !name.trim()}>
-        {isAdding ? <Loader className="size-4 animate-spin" /> : "Add"}
-      </Button>
       <Button
         type="button"
         variant="ghost"
+        size="sm"
+        className="self-start text-muted-foreground"
         disabled={isAdding}
         onClick={() => setIsOpen(false)}
       >
         Cancel
       </Button>
-    </form>
+    </div>
   );
 };
 

--- a/components/Onboarding/ConfirmRosterStep.tsx
+++ b/components/Onboarding/ConfirmRosterStep.tsx
@@ -58,7 +58,7 @@ const ConfirmRosterStep = ({ onConfirmed }: { onConfirmed: () => void }) => {
         disabled={isLoading || artists.length === 0}
         onClick={onConfirmed}
       >
-        {artists.length > 1 ? "These are my artists" : "This is my artist"} —
+        {artists.length > 1 ? "These are my artists" : "This is my artist"},
         continue
       </Button>
     </section>

--- a/components/Onboarding/ConfirmRosterStep.tsx
+++ b/components/Onboarding/ConfirmRosterStep.tsx
@@ -3,6 +3,8 @@
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useArtistProvider } from "@/providers/ArtistProvider";
+import useCatalogs from "@/hooks/useCatalogs";
+import { getConfirmRosterCopy } from "@/lib/onboarding/getConfirmRosterCopy";
 import AddArtistForm from "./AddArtistForm";
 import RosterArtistRow from "./RosterArtistRow";
 
@@ -13,7 +15,9 @@ import RosterArtistRow from "./RosterArtistRow";
  */
 const ConfirmRosterStep = ({ onConfirmed }: { onConfirmed: () => void }) => {
   const { sorted, isLoading } = useArtistProvider();
+  const { data: catalogsData } = useCatalogs();
   const artists = sorted.filter((artist) => !artist.isWorkspace);
+  const hasValuation = (catalogsData?.catalogs?.length ?? 0) > 0;
 
   return (
     <section className="flex flex-col gap-6">
@@ -21,13 +25,11 @@ const ConfirmRosterStep = ({ onConfirmed }: { onConfirmed: () => void }) => {
         <h1 className="text-2xl font-semibold text-foreground">
           Confirm your roster
         </h1>
-        {/* Two-thirds of welcome-email signups arrive with an empty roster and
-            never ran a valuation, so claiming we set one up from "your
-            valuation" was simply false for them (chat#1889). */}
         <p className="text-sm text-muted-foreground mt-1">
-          {artists.length === 0
-            ? "Search Spotify for the artists you manage. Recoup uses them to measure your catalog, so pick the real profile."
-            : `We set ${artists.length === 1 ? "this artist" : "these artists"} up from your valuation. Add anyone else you manage — you can verify their socials next.`}
+          {getConfirmRosterCopy({
+            artistCount: artists.length,
+            hasValuation,
+          })}
         </p>
       </div>
 

--- a/components/Onboarding/ConfirmRosterStep.tsx
+++ b/components/Onboarding/ConfirmRosterStep.tsx
@@ -21,10 +21,13 @@ const ConfirmRosterStep = ({ onConfirmed }: { onConfirmed: () => void }) => {
         <h1 className="text-2xl font-semibold text-foreground">
           Confirm your roster
         </h1>
+        {/* Two-thirds of welcome-email signups arrive with an empty roster and
+            never ran a valuation, so claiming we set one up from "your
+            valuation" was simply false for them (chat#1889). */}
         <p className="text-sm text-muted-foreground mt-1">
-          We set {artists.length === 1 ? "this artist" : "these artists"} up
-          from your valuation. Add anyone else you manage — you can verify their
-          socials next.
+          {artists.length === 0
+            ? "Search Spotify for the artists you manage. Recoup uses them to measure your catalog, so pick the real profile."
+            : `We set ${artists.length === 1 ? "this artist" : "these artists"} up from your valuation. Add anyone else you manage — you can verify their socials next.`}
         </p>
       </div>
 
@@ -36,7 +39,8 @@ const ConfirmRosterStep = ({ onConfirmed }: { onConfirmed: () => void }) => {
           </>
         ) : artists.length === 0 ? (
           <p className="text-sm text-muted-foreground p-4 rounded-xl border border-border">
-            No artists on your roster yet. Add your first artist below.
+            No artists on your roster yet. Add your first artist below to get
+            your catalog valued.
           </p>
         ) : (
           artists.map((artist) => (

--- a/components/Onboarding/VerifySocialsStep.tsx
+++ b/components/Onboarding/VerifySocialsStep.tsx
@@ -24,7 +24,7 @@ const VerifySocialsStep = ({ onConfirmed }: { onConfirmed: () => void }) => {
         </h1>
         <p className="text-sm text-muted-foreground mt-1">
           These are the profiles we matched. Fix any that point at the wrong
-          account — reports and tasks pull from them.
+          account. Reports and tasks pull from them.
         </p>
       </div>
 
@@ -40,7 +40,7 @@ const VerifySocialsStep = ({ onConfirmed }: { onConfirmed: () => void }) => {
       </div>
 
       <Button type="button" className="w-full" onClick={onConfirmed}>
-        Looks good — continue
+        Looks good, continue
       </Button>
     </section>
   );

--- a/components/Onboarding/__tests__/AddArtistForm.test.tsx
+++ b/components/Onboarding/__tests__/AddArtistForm.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import AddArtistForm from "@/components/Onboarding/AddArtistForm";
+
+const addArtist = vi.fn();
+
+const SPOTIFY_RESULT = {
+  id: "3TVXtAsR1Inumwj472S9r4",
+  name: "Drake",
+  external_urls: { spotify: "https://open.spotify.com/artist/3TVXtAsR1Inumwj472S9r4" },
+  images: [{ url: "https://i.scdn.co/image/drake.jpg" }],
+  followers: { total: 92000000 },
+};
+
+vi.mock("@/hooks/onboarding/useAddRosterArtist", () => ({
+  useAddRosterArtist: () => ({ addArtist, isAdding: false }),
+}));
+
+vi.mock("@/hooks/useSpotifyArtistSearch", () => ({
+  useSpotifyArtistSearch: () => ({
+    results: [SPOTIFY_RESULT],
+    isSearching: false,
+  }),
+}));
+
+describe("AddArtistForm", () => {
+  beforeEach(() => {
+    addArtist.mockClear();
+    addArtist.mockResolvedValue(true);
+  });
+
+  const openForm = () => {
+    render(<AddArtistForm />);
+    fireEvent.click(screen.getByRole("button", { name: /add another artist/i }));
+  };
+
+  it("adds by Spotify typeahead, not a free-text name field", () => {
+    openForm();
+
+    // The free-text input produced artists with no Spotify id, so no catalog and
+    // no valuation could follow — the whole payoff was unreachable for anyone
+    // who arrived without a funnel valuation (chat#1889).
+    expect(screen.queryByLabelText(/^artist name$/i)).toBeNull();
+    expect(screen.getByLabelText(/search spotify for an artist/i)).toBeDefined();
+  });
+
+  it("resolves the picked artist to its Spotify profile URL and avatar", () => {
+    openForm();
+    fireEvent.click(screen.getByRole("option", { name: /drake/i }));
+
+    expect(addArtist).toHaveBeenCalledWith("Drake", {
+      profileUrl: SPOTIFY_RESULT.external_urls.spotify,
+      image: SPOTIFY_RESULT.images[0].url,
+    });
+  });
+});

--- a/hooks/onboarding/__tests__/useAddRosterArtist.test.tsx
+++ b/hooks/onboarding/__tests__/useAddRosterArtist.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useAddRosterArtist } from "@/hooks/onboarding/useAddRosterArtist";
+
+const createRosterArtist = vi.fn();
+const saveArtist = vi.fn();
+const getArtists = vi.fn();
+const toastError = vi.fn();
+
+vi.mock("@privy-io/react-auth", () => ({
+  usePrivy: () => ({ getAccessToken: async () => "token" }),
+}));
+
+vi.mock("@/lib/artists/createRosterArtist", () => ({
+  createRosterArtist: (...args: unknown[]) => createRosterArtist(...args),
+}));
+
+vi.mock("@/lib/saveArtist", () => ({
+  default: (...args: unknown[]) => saveArtist(...args),
+}));
+
+vi.mock("@/providers/ArtistProvider", () => ({
+  useArtistProvider: () => ({ getArtists }),
+}));
+
+vi.mock("@/providers/OrganizationProvider", () => ({
+  useOrganization: () => ({ selectedOrgId: "org-1" }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: (...args: unknown[]) => toastError(...args) },
+}));
+
+const SPOTIFY = {
+  profileUrl: "https://open.spotify.com/artist/43qxAkuKFB6fMNSeS5dO7Z",
+  image: "https://i.scdn.co/image/ana.jpg",
+};
+
+describe("useAddRosterArtist", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createRosterArtist.mockResolvedValue({ account_id: "artist-1" });
+    saveArtist.mockResolvedValue(undefined);
+  });
+
+  it("enriches a created artist with its Spotify profile and avatar", async () => {
+    const { result } = renderHook(() => useAddRosterArtist());
+
+    let added: boolean | undefined;
+    await act(async () => {
+      added = await result.current.addArtist("Ana Bárbara", SPOTIFY);
+    });
+
+    expect(added).toBe(true);
+    expect(saveArtist).toHaveBeenCalledWith("token", "artist-1", {
+      profileUrls: { SPOTIFY: SPOTIFY.profileUrl },
+      image: SPOTIFY.image,
+    });
+    expect(getArtists).toHaveBeenCalled();
+  });
+
+  // POST /api/artists has already succeeded by the time enrichment runs, so a
+  // failing PATCH must not report failure: the form would stay open over an
+  // artist that exists, and picking again creates a duplicate (chat#1889).
+  it("treats a failed enrichment as non-fatal", async () => {
+    saveArtist.mockRejectedValue(new Error("Forbidden"));
+    const { result } = renderHook(() => useAddRosterArtist());
+
+    let added: boolean | undefined;
+    await act(async () => {
+      added = await result.current.addArtist("Ana Bárbara", SPOTIFY);
+    });
+
+    expect(added).toBe(true);
+    expect(getArtists).toHaveBeenCalled();
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("still reports failure when the artist itself cannot be created", async () => {
+    createRosterArtist.mockRejectedValue(new Error("nope"));
+    const { result } = renderHook(() => useAddRosterArtist());
+
+    let added: boolean | undefined;
+    await act(async () => {
+      added = await result.current.addArtist("Ana Bárbara", SPOTIFY);
+    });
+
+    expect(added).toBe(false);
+    expect(toastError).toHaveBeenCalled();
+    expect(getArtists).not.toHaveBeenCalled();
+  });
+});

--- a/hooks/onboarding/useAddRosterArtist.ts
+++ b/hooks/onboarding/useAddRosterArtist.ts
@@ -4,13 +4,28 @@ import { useState } from "react";
 import { usePrivy } from "@privy-io/react-auth";
 import { toast } from "sonner";
 import { createRosterArtist } from "@/lib/artists/createRosterArtist";
+import saveArtist from "@/lib/saveArtist";
+import { buildSocialFixPayload } from "@/lib/onboarding/buildSocialFixPayload";
 import { useArtistProvider } from "@/providers/ArtistProvider";
 import { useOrganization } from "@/providers/OrganizationProvider";
 
+export interface AddRosterArtistOptions {
+  /** Spotify profile URL from the typeahead, linked as the artist's social. */
+  profileUrl?: string;
+  /** Spotify avatar, so the roster row isn't a blank initial. */
+  image?: string;
+}
+
 /**
- * "Add another artist" for the onboarding roster step. Creates the
- * artist through the existing `POST /api/artists` endpoint and refreshes
- * the shared roster (ArtistProvider) so the new artist appears in-flow.
+ * "Add an artist" for the onboarding roster step. Creates the artist through
+ * `POST /api/artists`, then — when the caller resolved a real Spotify artist —
+ * attaches the profile URL and avatar via the existing
+ * `PATCH /api/artists/{id}` path, and refreshes the shared roster.
+ *
+ * The second call is what makes the added artist usable: `POST /api/artists`
+ * accepts only a name, and an artist with no Spotify id can never get a catalog
+ * or a valuation (chat#1889). Enrichment failing is non-fatal — the artist is
+ * already on the roster and its socials can still be fixed in the next step.
  */
 export function useAddRosterArtist() {
   const { getAccessToken } = usePrivy();
@@ -18,7 +33,10 @@ export function useAddRosterArtist() {
   const { selectedOrgId } = useOrganization();
   const [isAdding, setIsAdding] = useState(false);
 
-  const addArtist = async (name: string): Promise<boolean> => {
+  const addArtist = async (
+    name: string,
+    options: AddRosterArtistOptions = {},
+  ): Promise<boolean> => {
     const trimmed = name.trim();
     if (!trimmed) return false;
     setIsAdding(true);
@@ -27,7 +45,22 @@ export function useAddRosterArtist() {
       if (!accessToken) {
         throw new Error("Please sign in to add an artist");
       }
-      await createRosterArtist(accessToken, trimmed, selectedOrgId);
+      const artist = await createRosterArtist(
+        accessToken,
+        trimmed,
+        selectedOrgId,
+      );
+
+      const payload = options.profileUrl
+        ? buildSocialFixPayload(options.profileUrl)
+        : null;
+      if (artist?.account_id && (payload || options.image)) {
+        await saveArtist(accessToken, artist.account_id, {
+          ...(payload ? { profileUrls: payload.profileUrls } : {}),
+          ...(options.image ? { image: options.image } : {}),
+        });
+      }
+
       await getArtists();
       return true;
     } catch (error) {

--- a/hooks/onboarding/useAddRosterArtist.ts
+++ b/hooks/onboarding/useAddRosterArtist.ts
@@ -55,10 +55,17 @@ export function useAddRosterArtist() {
         ? buildSocialFixPayload(options.profileUrl)
         : null;
       if (artist?.account_id && (payload || options.image)) {
-        await saveArtist(accessToken, artist.account_id, {
-          ...(payload ? { profileUrls: payload.profileUrls } : {}),
-          ...(options.image ? { image: options.image } : {}),
-        });
+        try {
+          await saveArtist(accessToken, artist.account_id, {
+            ...(payload ? { profileUrls: payload.profileUrls } : {}),
+            ...(options.image ? { image: options.image } : {}),
+          });
+        } catch {
+          // Swallowed on purpose. POST /api/artists already succeeded, so
+          // surfacing this would leave the form open over an artist that
+          // exists — and picking again would create a duplicate. The socials
+          // are still fixable in the next step.
+        }
       }
 
       await getArtists();

--- a/lib/onboarding/__tests__/getConfirmRosterCopy.test.ts
+++ b/lib/onboarding/__tests__/getConfirmRosterCopy.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { getConfirmRosterCopy } from "@/lib/onboarding/getConfirmRosterCopy";
+
+describe("getConfirmRosterCopy", () => {
+  it("prompts an empty roster to search Spotify", () => {
+    const copy = getConfirmRosterCopy({ artistCount: 0, hasValuation: false });
+
+    expect(copy).toMatch(/search spotify/i);
+  });
+
+  it("credits the valuation only when one actually ran", () => {
+    expect(
+      getConfirmRosterCopy({ artistCount: 1, hasValuation: true }),
+    ).toMatch(/this artist up from your valuation/i);
+    expect(
+      getConfirmRosterCopy({ artistCount: 2, hasValuation: true }),
+    ).toMatch(/these artists up from your valuation/i);
+  });
+
+  // Two-thirds of welcome-email signups never ran a valuation. Crediting one
+  // is false for them the moment they add their first artist by typeahead —
+  // which is the only path this cohort has (chat#1889).
+  it("never claims a valuation the account never ran", () => {
+    for (const artistCount of [1, 2, 5]) {
+      const copy = getConfirmRosterCopy({ artistCount, hasValuation: false });
+
+      expect(copy).not.toMatch(/valuation/i);
+      expect(copy).toMatch(/verify their socials next/i);
+    }
+  });
+});

--- a/lib/onboarding/__tests__/getConfirmRosterCopy.test.ts
+++ b/lib/onboarding/__tests__/getConfirmRosterCopy.test.ts
@@ -17,8 +17,20 @@ describe("getConfirmRosterCopy", () => {
     ).toMatch(/these artists up from your valuation/i);
   });
 
+  // Em dashes read as machine-written and cost trust, so product copy uses
+  // periods or commas instead.
+  it("uses no em or en dashes in any branch", () => {
+    for (const hasValuation of [true, false]) {
+      for (const artistCount of [0, 1, 2, 5]) {
+        expect(getConfirmRosterCopy({ artistCount, hasValuation })).not.toMatch(
+          /[—–]/,
+        );
+      }
+    }
+  });
+
   // Two-thirds of welcome-email signups never ran a valuation. Crediting one
-  // is false for them the moment they add their first artist by typeahead —
+  // is false for them the moment they add their first artist by typeahead,
   // which is the only path this cohort has (chat#1889).
   it("never claims a valuation the account never ran", () => {
     for (const artistCount of [1, 2, 5]) {

--- a/lib/onboarding/getConfirmRosterCopy.ts
+++ b/lib/onboarding/getConfirmRosterCopy.ts
@@ -1,0 +1,32 @@
+export interface ConfirmRosterCopyInput {
+  /** Artists on the roster, excluding the workspace pseudo-artist. */
+  artistCount: number;
+  /** Whether a valuation actually ran for this account (it has a catalog). */
+  hasValuation: boolean;
+}
+
+/**
+ * Sub-heading for the confirm-roster onboarding step.
+ *
+ * The provenance line ("we set these up from your valuation") is only true for
+ * accounts that arrived through the valuation funnel. Two-thirds of
+ * welcome-email signups did not, and they reach a populated roster by adding an
+ * artist through the Spotify typeahead — so the claim is keyed on the valuation
+ * having happened, not on the roster being non-empty (chat#1889).
+ */
+export function getConfirmRosterCopy({
+  artistCount,
+  hasValuation,
+}: ConfirmRosterCopyInput): string {
+  if (artistCount === 0) {
+    return "Search Spotify for the artists you manage. Recoup uses them to measure your catalog, so pick the real profile.";
+  }
+
+  const tail =
+    "Add anyone else you manage — you can verify their socials next.";
+
+  if (!hasValuation) return tail;
+
+  const subject = artistCount === 1 ? "this artist" : "these artists";
+  return `We set ${subject} up from your valuation. ${tail}`;
+}

--- a/lib/onboarding/getConfirmRosterCopy.ts
+++ b/lib/onboarding/getConfirmRosterCopy.ts
@@ -23,7 +23,7 @@ export function getConfirmRosterCopy({
   }
 
   const tail =
-    "Add anyone else you manage — you can verify their socials next.";
+    "Add anyone else you manage, you can verify their socials next.";
 
   if (!hasValuation) return tail;
 


### PR DESCRIPTION
Matrix row 8 in chat#1889 — the highest-value item after the convergence chain. Independent of #1890/#1891 (different files), so it can be reviewed in parallel.

## Why: the payoff was structurally unreachable for most signups

Live cohort from `email_send_log`, 2026-07-23 → 2026-07-26:

| | |
|---|---|
| Welcome emails sent | **9**, to 9 distinct accounts |
| With a roster + catalog (valuation-funnel signups) | **3** |
| With **zero artists, zero catalogs, no valuation** | **6** |

The welcome email fires on account creation regardless of whether a valuation preceded it, so two-thirds of the cohort are cold-start signups. Their only forward path is `AddArtistForm` — which took a **free-text name** and posted only `{ name }`. No Spotify id → no catalog → no valuation. The number those users were emailed about could never exist.

## What changed

- **`AddArtistForm`** uses `SpotifyArtistSearch` — the same typeahead verify-socials adopted in #1882 — so a pick resolves to a real Spotify id, profile URL, and avatar.
- **`useAddRosterArtist`** now takes `{ profileUrl, image }` and attaches them via the existing `PATCH /api/artists/{id}` path after creation, because `POST /api/artists` accepts only `name` / `account_id` / `organization_id`. Reuses `buildSocialFixPayload` for the platform detection rather than hand-rolling the shape. Enrichment failure is deliberately non-fatal — the artist is already on the roster and socials can still be fixed in the next step.
- **`ConfirmRosterStep` copy**: an empty roster was told *"We set these artists up from your valuation"* — false for 6 of 9 signups. It now reads as an instruction to search, and the empty state names the reward.

No api change needed, so no docs/contract change either — this rides two existing endpoints.

## Verification

TDD, red → green:

\`\`\`
# RED — free-text field still present, no typeahead
Test Files  1 failed (1)
     Tests  2 failed (2)

# GREEN
pnpm exec vitest run components/Onboarding lib/onboarding
  Test Files  18 passed (18)
       Tests  70 passed (70)
\`\`\`

The new test asserts the free-text `Artist name` field is **gone**, the Spotify searchbox is present, and picking a result calls `addArtist` with the resolved profile URL + avatar.

`pnpm exec tsc --noEmit` clean for the touched files. Preview click-through pending (needs an authed empty-roster account).

Tracked in chat#1889 (matrix row 8).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace free-text artist input with a Spotify typeahead in onboarding so added artists have a real Spotify profile and avatar. This unblocks cold-start signups so they can reach catalog and valuation (chat#1889, row 8).

- **New Features**
  - `AddArtistForm` now uses `SpotifyArtistSearch`; selecting a result calls `addArtist(name, { profileUrl, image })`.
  - `useAddRosterArtist` attaches the Spotify profile and image via `PATCH /api/artists/{id}` using `buildSocialFixPayload`, then refreshes the roster.
  - `ConfirmRosterStep` copy prompts Spotify search when empty and only credits a valuation if the account actually has a catalog.

- **Bug Fixes**
  - Enrichment failures are non-fatal: `saveArtist` errors are caught so the form closes and the roster refreshes, avoiding duplicates.
  - Removed em dashes from roster and socials copy (including button text) to improve tone; enforced via `getConfirmRosterCopy` tests.

<sup>Written for commit 617d7f930dc3da4ec5b0619c2c523b8260db95de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Spotify artist search for selecting artists during onboarding.
  * When available, automatically attaches an artist’s Spotify profile link and artwork.
  * Updated the “Confirm your roster” message to be tailored to the number of artists and whether valuation is available.
* **Bug Fixes**
  * Artist additions now retain available Spotify profile and artwork details, and the flow closes automatically after a successful add.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->