### PR TITLE
fix(onboarding): verify-socials renders a skeleton while the roster loads (chat#1889 row 11)

### DIFF
--- a/components/Onboarding/VerifySocialsStep.tsx
+++ b/components/Onboarding/VerifySocialsStep.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 import { useSocialFix } from "@/hooks/onboarding/useSocialFix";
 import { useArtistProvider } from "@/providers/ArtistProvider";
 import ArtistSocialsCard from "./ArtistSocialsCard";
@@ -10,9 +11,14 @@ import ArtistSocialsCard from "./ArtistSocialsCard";
  * artist. Matches are accepted by default — edit any that point at the
  * wrong account, or add one where none were found. Continue always
  * proceeds; an artist with no socials simply has none.
+ *
+ * Reads `isLoading` and renders skeletons, mirroring `ConfirmRosterStep`: the
+ * step used to read only `sorted`, so a direct `/setup/socials` visit (the
+ * welcome email's step 2 link) rendered a blank step that looked broken until
+ * the roster arrived (chat#1889).
  */
 const VerifySocialsStep = ({ onConfirmed }: { onConfirmed: () => void }) => {
-  const { sorted } = useArtistProvider();
+  const { sorted, isLoading } = useArtistProvider();
   const artists = sorted.filter((artist) => !artist.isWorkspace);
   const { fixSocial, fixingArtistId } = useSocialFix();
 
@@ -29,19 +35,28 @@ const VerifySocialsStep = ({ onConfirmed }: { onConfirmed: () => void }) => {
       </div>
 
       <div className="flex flex-col gap-3">
-        {artists.map((artist) => (
-          <ArtistSocialsCard
-            key={artist.account_id}
-            artist={artist}
-            isFixing={fixingArtistId === artist.account_id}
-            onFix={(url) => fixSocial(artist, url)}
-          />
-        ))}
+        {isLoading ? (
+          <>
+            <Skeleton className="h-[104px] w-full rounded-xl" />
+            <Skeleton className="h-[104px] w-full rounded-xl" />
+          </>
+        ) : (
+          artists.map((artist) => (
+            <ArtistSocialsCard
+              key={artist.account_id}
+              artist={artist}
+              isFixing={fixingArtistId === artist.account_id}
+              onFix={(url) => fixSocial(artist, url)}
+            />
+          ))
+        )}
       </div>
 
-      <Button type="button" className="w-full" onClick={onConfirmed}>
-        Looks good — continue
-      </Button>
+      {!isLoading && (
+        <Button type="button" className="w-full" onClick={onConfirmed}>
+          Looks good — continue
+        </Button>
+      )}
     </section>
   );
 };

--- a/components/Onboarding/__tests__/VerifySocialsStep.test.tsx
+++ b/components/Onboarding/__tests__/VerifySocialsStep.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import VerifySocialsStep from "@/components/Onboarding/VerifySocialsStep";
+
+const artistProvider = { sorted: [] as unknown[], isLoading: true };
+
+vi.mock("@/providers/ArtistProvider", () => ({
+  useArtistProvider: () => artistProvider,
+}));
+
+vi.mock("@/hooks/onboarding/useSocialFix", () => ({
+  useSocialFix: () => ({ fixSocial: vi.fn(), fixingArtistId: null }),
+}));
+
+describe("VerifySocialsStep", () => {
+  it("renders a loading skeleton instead of an empty step while the roster loads", () => {
+    artistProvider.sorted = [];
+    artistProvider.isLoading = true;
+
+    const { container } = render(<VerifySocialsStep onConfirmed={vi.fn()} />);
+
+    // The step read only `sorted`, so a direct /setup/socials visit rendered a
+    // blank step that looked broken until the roster arrived (chat#1889).
+    expect(container.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0);
+    expect(screen.queryByRole("button", { name: /looks good/i })).toBeNull();
+  });
+
+  it("shows the step once the roster has resolved", () => {
+    artistProvider.sorted = [];
+    artistProvider.isLoading = false;
+
+    const { container } = render(<VerifySocialsStep onConfirmed={vi.fn()} />);
+
+    expect(container.querySelectorAll('.animate-pulse').length).toBe(0);
+    expect(screen.getByRole("button", { name: /looks good/i })).toBeDefined();
+  });
+});


### PR DESCRIPTION
Matrix row 11 in chat#1889. Small, independent of every other row.

## Why

`VerifySocialsStep` destructured only `{ sorted }` from `useArtistProvider` — no `isLoading`. So a direct visit to `/setup/socials` (the welcome email's **step 2** link) rendered:

- an empty socials list, and
- a live **"Looks good, continue"** button

until the roster arrived. It read as broken, and a user who clicked through early skipped verifying socials they never saw.

## What changed

Mirrors the sibling `ConfirmRosterStep`: read `isLoading`, render two skeletons, and hold the continue button until the roster resolves.

## Verification

TDD, red → green:

\`\`\`
# RED — no skeleton while loading, continue button already live
× renders a loading skeleton instead of an empty step while the roster loads
  Tests  1 failed | 1 passed (2)

# GREEN
pnpm exec vitest run components/Onboarding
  Test Files  passed
       Tests  passed
\`\`\`

The second test guards the other direction — no skeletons once resolved, continue button present — so this can't regress into a permanent skeleton.

`pnpm exec tsc --noEmit` clean for the touched file. Preview click-through pending.

Tracked in chat#1889 (matrix row 11).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the onboarding socials step by showing loading skeletons while the roster loads and delaying the continue button until ready. Prevents an empty step and early skip when visiting `/setup/socials` directly (chat#1889, row 11).

- **Bug Fixes**
  - `VerifySocialsStep` now reads `isLoading` from `useArtistProvider`, renders two `Skeleton`s, and only shows the "Looks good — continue" button when not loading (mirrors `ConfirmRosterStep`).
  - Added tests for loading and loaded states.

<sup>Written for commit 41babbe681593970be9c9ae68523b3d2b0957174. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1893?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

