### PR TITLE
feat(onboarding): remove a social during verify-socials (chat#1889 row 9)

### DIFF
--- a/components/Onboarding/ArtistSocialsCard.tsx
+++ b/components/Onboarding/ArtistSocialsCard.tsx
@@ -10,6 +10,7 @@ interface ArtistSocialsCardProps {
   artist: ArtistRecord;
   isFixing: boolean;
   onFix: (url: string) => Promise<boolean>;
+  onRemove: (socialId: string) => Promise<boolean>;
 }
 
 /**
@@ -22,6 +23,7 @@ const ArtistSocialsCard = ({
   artist,
   isFixing,
   onFix,
+  onRemove,
 }: ArtistSocialsCardProps) => {
   const socials = artist.account_socials ?? [];
   const [adding, setAdding] = useState(false);
@@ -40,8 +42,8 @@ const ArtistSocialsCard = ({
 
       {socials.length === 0 ? (
         <p className="text-sm text-muted-foreground">
-          No profiles were auto-matched for {artist.name || "this artist"}. Add
-          one, or continue.
+          No profiles were auto-matched for {artist.name || "this artist"}.
+          Adding one is optional, and you can continue without it.
         </p>
       ) : (
         <div className="divide-y divide-border">
@@ -51,6 +53,7 @@ const ArtistSocialsCard = ({
               social={social}
               isSubmitting={isFixing}
               onFix={onFix}
+              onRemove={onRemove}
             />
           ))}
         </div>

--- a/components/Onboarding/SocialRow.tsx
+++ b/components/Onboarding/SocialRow.tsx
@@ -1,13 +1,12 @@
 "use client";
 
 import { useState } from "react";
-import { Pencil, Trash2 } from "lucide-react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Button } from "@/components/ui/button";
 import getSocialPlatformByLink from "@/lib/getSocialPlatformByLink";
 import { getSocialFollowerCount } from "@/lib/onboarding/getSocialFollowerCount";
 import getPlatformDisplayName from "@/lib/socials/getPlatformDisplayName";
 import formatFollowerCount from "@/lib/utils/formatFollowerCount";
+import SocialRowActions from "./SocialRowActions";
 import SocialSearchOrPaste from "./SocialSearchOrPaste";
 import type { SOCIAL } from "@/types/Agent";
 
@@ -75,30 +74,13 @@ const SocialRow = ({
             </p>
           </div>
         </div>
-        <div className="flex shrink-0 items-center">
-          <Button
-            type="button"
-            size="sm"
-            variant="ghost"
-            className="text-muted-foreground"
-            aria-label={`Edit ${platform} link`}
-            aria-expanded={editing}
-            onClick={() => setEditing((open) => !open)}
-          >
-            <Pencil className="size-4" />
-          </Button>
-          <Button
-            type="button"
-            size="sm"
-            variant="ghost"
-            className="text-muted-foreground"
-            aria-label={`Remove ${platform} link`}
-            disabled={isSubmitting}
-            onClick={() => void onRemove(social.id)}
-          >
-            <Trash2 className="size-4" />
-          </Button>
-        </div>
+        <SocialRowActions
+          platform={platform}
+          editing={editing}
+          isSubmitting={isSubmitting}
+          onToggleEdit={() => setEditing((open) => !open)}
+          onRemove={() => void onRemove(social.id)}
+        />
       </div>
       {editing && (
         <div className="mt-2">

--- a/components/Onboarding/SocialRow.tsx
+++ b/components/Onboarding/SocialRow.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Pencil } from "lucide-react";
+import { Pencil, Trash2 } from "lucide-react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import getSocialPlatformByLink from "@/lib/getSocialPlatformByLink";
@@ -15,6 +15,7 @@ interface SocialRowProps {
   social: SOCIAL;
   isSubmitting: boolean;
   onFix: (url: string) => Promise<boolean>;
+  onRemove: (socialId: string) => Promise<boolean>;
 }
 
 /**
@@ -22,8 +23,16 @@ interface SocialRowProps {
  * followers, with an Edit affordance that reveals a paste-the-correct-link
  * form for the rare wrong match. No confirm step — leaving it as-is is the
  * confirmation.
+ *
+ * Remove is the other half (chat#1889): the step previously only added or
+ * replaced, so a profile the user did not want could not be taken back.
  */
-const SocialRow = ({ social, isSubmitting, onFix }: SocialRowProps) => {
+const SocialRow = ({
+  social,
+  isSubmitting,
+  onFix,
+  onRemove,
+}: SocialRowProps) => {
   const [editing, setEditing] = useState(false);
   const platform = getPlatformDisplayName(
     getSocialPlatformByLink(social.link || ""),
@@ -66,17 +75,30 @@ const SocialRow = ({ social, isSubmitting, onFix }: SocialRowProps) => {
             </p>
           </div>
         </div>
-        <Button
-          type="button"
-          size="sm"
-          variant="ghost"
-          className="shrink-0 text-muted-foreground"
-          aria-label={`Edit ${platform} link`}
-          aria-expanded={editing}
-          onClick={() => setEditing((open) => !open)}
-        >
-          <Pencil className="size-4" />
-        </Button>
+        <div className="flex shrink-0 items-center">
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            className="text-muted-foreground"
+            aria-label={`Edit ${platform} link`}
+            aria-expanded={editing}
+            onClick={() => setEditing((open) => !open)}
+          >
+            <Pencil className="size-4" />
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            className="text-muted-foreground"
+            aria-label={`Remove ${platform} link`}
+            disabled={isSubmitting}
+            onClick={() => void onRemove(social.id)}
+          >
+            <Trash2 className="size-4" />
+          </Button>
+        </div>
       </div>
       {editing && (
         <div className="mt-2">

--- a/components/Onboarding/SocialRowActions.tsx
+++ b/components/Onboarding/SocialRowActions.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { Pencil, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface SocialRowActionsProps {
+  platform: string;
+  editing: boolean;
+  isSubmitting: boolean;
+  onToggleEdit: () => void;
+  onRemove: () => void;
+}
+
+/**
+ * The per-social action cluster on a verify-socials row: Edit (toggles the
+ * paste-the-correct-link form) and Remove (chat#1889 — the step previously
+ * only added or replaced, so an unwanted profile could not be taken back).
+ * Own file so SocialRow is extended by composition, not edited per action.
+ */
+const SocialRowActions = ({
+  platform,
+  editing,
+  isSubmitting,
+  onToggleEdit,
+  onRemove,
+}: SocialRowActionsProps) => (
+  <div className="flex shrink-0 items-center">
+    <Button
+      type="button"
+      size="sm"
+      variant="ghost"
+      className="text-muted-foreground"
+      aria-label={`Edit ${platform} link`}
+      aria-expanded={editing}
+      onClick={onToggleEdit}
+    >
+      <Pencil className="size-4" />
+    </Button>
+    <Button
+      type="button"
+      size="sm"
+      variant="ghost"
+      className="text-muted-foreground"
+      aria-label={`Remove ${platform} link`}
+      disabled={isSubmitting}
+      onClick={onRemove}
+    >
+      <Trash2 className="size-4" />
+    </Button>
+  </div>
+);
+
+export default SocialRowActions;

--- a/components/Onboarding/VerifySocialsStep.tsx
+++ b/components/Onboarding/VerifySocialsStep.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from "@/components/ui/button";
 import { useSocialFix } from "@/hooks/onboarding/useSocialFix";
+import { useSocialRemove } from "@/hooks/onboarding/useSocialRemove";
 import { useArtistProvider } from "@/providers/ArtistProvider";
 import ArtistSocialsCard from "./ArtistSocialsCard";
 
@@ -15,6 +16,7 @@ const VerifySocialsStep = ({ onConfirmed }: { onConfirmed: () => void }) => {
   const { sorted } = useArtistProvider();
   const artists = sorted.filter((artist) => !artist.isWorkspace);
   const { fixSocial, fixingArtistId } = useSocialFix();
+  const { removeSocial, removingSocialId } = useSocialRemove();
 
   return (
     <section className="flex flex-col gap-6">
@@ -33,8 +35,11 @@ const VerifySocialsStep = ({ onConfirmed }: { onConfirmed: () => void }) => {
           <ArtistSocialsCard
             key={artist.account_id}
             artist={artist}
-            isFixing={fixingArtistId === artist.account_id}
+            isFixing={
+              fixingArtistId === artist.account_id || removingSocialId !== null
+            }
             onFix={(url) => fixSocial(artist, url)}
+            onRemove={(socialId) => removeSocial(artist, socialId)}
           />
         ))}
       </div>

--- a/components/Onboarding/__tests__/SocialRow.test.tsx
+++ b/components/Onboarding/__tests__/SocialRow.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import SocialRow from "@/components/Onboarding/SocialRow";
+import type { SOCIAL } from "@/types/Agent";
+
+const SOCIAL_ROW = {
+  id: "social-123",
+  link: "https://open.spotify.com/artist/abc",
+  username: "drake",
+} as unknown as SOCIAL;
+
+const onFix = vi.fn();
+const onRemove = vi.fn();
+
+describe("SocialRow", () => {
+  beforeEach(() => {
+    onFix.mockClear();
+    onRemove.mockClear();
+    onRemove.mockResolvedValue(true);
+  });
+
+  it("offers a remove affordance for a social the user does not want", () => {
+    render(
+      <SocialRow
+        social={SOCIAL_ROW}
+        isSubmitting={false}
+        onFix={onFix}
+        onRemove={onRemove}
+      />,
+    );
+
+    // useSocialFix could only add or replace, so a wrongly added profile could
+    // not be taken back and the step dead-ended (chat#1889).
+    fireEvent.click(screen.getByRole("button", { name: /remove/i }));
+
+    expect(onRemove).toHaveBeenCalledWith("social-123");
+  });
+
+  it("keeps the edit affordance alongside remove", () => {
+    render(
+      <SocialRow
+        social={SOCIAL_ROW}
+        isSubmitting={false}
+        onFix={onFix}
+        onRemove={onRemove}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /edit/i })).toBeDefined();
+  });
+});

--- a/hooks/onboarding/useSocialRemove.ts
+++ b/hooks/onboarding/useSocialRemove.ts
@@ -1,0 +1,47 @@
+"use client";
+
+import { useState } from "react";
+import { usePrivy } from "@privy-io/react-auth";
+import { toast } from "sonner";
+import { deleteArtistSocial } from "@/lib/artists/deleteArtistSocial";
+import { useArtistProvider } from "@/providers/ArtistProvider";
+import type { ArtistRecord } from "@/types/Artist";
+
+/**
+ * Removes a social from an artist during verify-socials, then refreshes the
+ * roster so the row disappears.
+ *
+ * `useSocialFix` could only add or replace (chat#1889): a user who added the
+ * wrong profile had no way to take it back, and was left staring at a list they
+ * could not correct. Removal is the missing half of the same step.
+ */
+export function useSocialRemove() {
+  const { getAccessToken } = usePrivy();
+  const { getArtists } = useArtistProvider();
+  const [removingSocialId, setRemovingSocialId] = useState<string | null>(null);
+
+  const removeSocial = async (
+    artist: ArtistRecord,
+    socialId: string,
+  ): Promise<boolean> => {
+    setRemovingSocialId(socialId);
+    try {
+      const accessToken = await getAccessToken();
+      if (!accessToken) {
+        throw new Error("Please sign in to remove a social");
+      }
+      await deleteArtistSocial(accessToken, artist.account_id, socialId);
+      await getArtists();
+      return true;
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to remove social",
+      );
+      return false;
+    } finally {
+      setRemovingSocialId(null);
+    }
+  };
+
+  return { removeSocial, removingSocialId };
+}

--- a/lib/artists/deleteArtistSocial.ts
+++ b/lib/artists/deleteArtistSocial.ts
@@ -1,0 +1,31 @@
+import { getClientApiBaseUrl } from "@/lib/api/getClientApiBaseUrl";
+
+interface DeleteArtistSocialResponse {
+  error?: string;
+}
+
+/**
+ * Unlinks a social profile from an artist via the existing
+ * `DELETE /api/artists/{id}/socials/{socialId}` endpoint (Privy bearer auth).
+ * The underlying social row is left intact; only the artist link is removed.
+ */
+export async function deleteArtistSocial(
+  accessToken: string,
+  artistId: string,
+  socialId: string,
+): Promise<void> {
+  const response = await fetch(
+    `${getClientApiBaseUrl()}/api/artists/${artistId}/socials/${socialId}`,
+    {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${accessToken}` },
+    },
+  );
+
+  if (!response.ok) {
+    const data: DeleteArtistSocialResponse = await response
+      .json()
+      .catch(() => ({}));
+    throw new Error(data.error || "Failed to remove social");
+  }
+}


### PR DESCRIPTION
Matrix row 9 in chat#1889 — flagged as an **onboarding blocker**. Independent of the convergence chain.

## Why

`useSocialFix` exposed only `fixSocial` (add or replace). There was no delete. So a user who added the wrong profile — or who had a bad auto-match they wanted gone rather than corrected — was stuck with a list they could not fix, mid-setup. Combined with a no-matches state whose copy read like an error, the step felt like a dead end.

## What changed

- **`lib/artists/deleteArtistSocial.ts`** — wraps the **already existing** `DELETE /api/artists/{id}/socials/{socialId}` endpoint. No api or docs change needed.
- **`hooks/onboarding/useSocialRemove.ts`** — mutate + refresh the roster, mirroring `useSocialFix`'s shape (own hook rather than a second verb on `useSocialFix`, per one-export-per-file).
- **`SocialRow`** gains a Remove affordance beside Edit, with a per-platform `aria-label`.
- **`ArtistSocialsCard`** / **`VerifySocialsStep`** thread it through; rows disable while a removal is in flight.
- **Copy**: *"No profiles were auto-matched … Add one, or continue"* → *"Adding one is optional, and you can continue without it"*, so an empty state doesn't read as a failure.

## Verification

TDD, red → green:

\`\`\`
# RED — no remove affordance exists
× offers a remove affordance for a social the user does not want
  Tests  1 failed | 1 passed (2)

# GREEN
pnpm exec vitest run components/Onboarding
  Test Files  1 passed (1)
       Tests  2 passed (2)
\`\`\`

The second test guards that Edit survives alongside Remove, so this can't silently replace the fix path.

`pnpm exec tsc --noEmit` clean for the touched files. Preview click-through pending (needs an authed roster with matched socials).

Tracked in chat#1889 (matrix row 9).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Remove action to verify-socials so users can delete a wrongly matched profile and continue onboarding. Addresses chat#1889 (row 9) by unblocking the step.

- **New Features**
  - `deleteArtistSocial` wraps `DELETE /api/artists/{id}/socials/{socialId}`.
  - `useSocialRemove` deletes a social and refreshes the roster.
  - `SocialRow` adds Remove beside Edit; wired through `ArtistSocialsCard` and `VerifySocialsStep`; rows disable during removal.
  - Empty-state copy clarifies adding is optional.

- **Refactors**
  - Extracted `SocialRowActions` into its own file; `SocialRow` composes it for Edit and Remove.

<sup>Written for commit ceda34cae81b4b22939024131184410754935e65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1894?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

