### PR TITLE
feat(onboarding): end setup on the catalog valuation (chat#1889 row 10)

### DIFF
--- a/app/setup/valuation/page.tsx
+++ b/app/setup/valuation/page.tsx
@@ -1,11 +1,12 @@
-import { redirect } from "next/navigation";
+import SetupValuation from "@/components/Onboarding/SetupValuation";
 
 /**
- * `/setup/valuation` — welcome email step 4 ("See your baseline valuation").
- * The baseline valuation is the catalog report (`/catalogs/[catalogId]`), which
- * is not addressable without a catalog id here, so route to the catalog list.
- * Revisit if a dedicated valuation landing is built.
+ * `/setup/valuation` — the welcome email's payoff link. Renders the account's
+ * baseline valuation (chat#1889) instead of the bare `/catalogs` redirect it
+ * used to be, which left the email's "See your baseline valuation" link with no
+ * real destination. Reading the valuation needs client state, so the page mounts
+ * `SetupValuation`.
  */
 export default function SetupValuationPage() {
-  redirect("/catalogs");
+  return <SetupValuation />;
 }

--- a/components/Onboarding/RosterVerifiedPanel.tsx
+++ b/components/Onboarding/RosterVerifiedPanel.tsx
@@ -3,25 +3,66 @@
 import Link from "next/link";
 import { CheckCircle2 } from "lucide-react";
 import { buttonVariants } from "@/components/ui/button";
+import ValuationHero from "@/components/Home/ValuationHero";
+import useHomeValuation from "@/hooks/useHomeValuation";
 import { cn } from "@/lib/utils";
 
-/** Shown when both roster and socials steps are complete. */
-const RosterVerifiedPanel = () => (
-  <section className="flex flex-col items-center gap-4 text-center py-12">
-    <CheckCircle2 className="size-10 text-[#22c55e]" />
-    <div>
-      <h1 className="text-2xl font-semibold text-foreground">
-        Roster verified
-      </h1>
-      <p className="text-sm text-muted-foreground mt-1">
-        Your artists and their socials are confirmed. Reports, research, and
-        tasks will use them from here on.
-      </p>
-    </div>
-    <Link href="/" className={cn(buttonVariants(), "min-w-[200px]")}>
-      Back to Recoup
-    </Link>
-  </section>
-);
+/**
+ * Shown when both roster and socials steps are complete.
+ *
+ * Ends setup on the account's catalog valuation — the number a valuation lead
+ * converted on — rather than a generic green check (chat#1889). Reuses the
+ * homepage hero (`useHomeValuation` + `ValuationHero`) instead of building a
+ * second valuation surface. Falls back to the confirmation state when there is
+ * no valuation yet, so a cold-start account still gets a clear finish and a
+ * pointer at the step that unlocks one.
+ */
+const RosterVerifiedPanel = () => {
+  const valuation = useHomeValuation();
+
+  if (valuation.show) {
+    return (
+      <section className="flex flex-col items-center gap-4 py-8">
+        <ValuationHero
+          artistName={valuation.artistName}
+          artistImage={valuation.artistImage}
+          valuation={valuation.valuation}
+          measuredTrackCount={valuation.measuredTrackCount}
+        />
+        <p className="text-sm text-muted-foreground text-center">
+          This is your baseline. A weekly report re-measures it and emails you
+          the trend.
+        </p>
+        <Link
+          href="/setup/tasks"
+          className={cn(buttonVariants(), "min-w-[200px]")}
+        >
+          Set up your weekly report
+        </Link>
+      </section>
+    );
+  }
+
+  return (
+    <section className="flex flex-col items-center gap-4 text-center py-12">
+      <CheckCircle2 className="size-10 text-[#22c55e]" />
+      <div>
+        <h1 className="text-2xl font-semibold text-foreground">
+          Roster verified
+        </h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Your artists and their socials are confirmed. Claim your catalog to
+          see what it is worth.
+        </p>
+      </div>
+      <Link
+        href="/setup/catalog"
+        className={cn(buttonVariants(), "min-w-[200px]")}
+      >
+        Claim your catalog
+      </Link>
+    </section>
+  );
+};
 
 export default RosterVerifiedPanel;

--- a/components/Onboarding/SetupValuation.tsx
+++ b/components/Onboarding/SetupValuation.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { buttonVariants } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import ValuationHero from "@/components/Home/ValuationHero";
+import useCatalogs from "@/hooks/useCatalogs";
+import useHomeValuation from "@/hooks/useHomeValuation";
+import { cn } from "@/lib/utils";
+
+/**
+ * `/setup/valuation` — the welcome email's payoff link. Renders the account's
+ * baseline valuation with the shared homepage hero (chat#1889); the route used
+ * to be a bare redirect to `/catalogs`, so the email's "See your baseline
+ * valuation" link had no real destination.
+ *
+ * Falls back to `/catalogs` only when the account has no catalog to value, so a
+ * cold-start signup still lands somewhere actionable rather than on an empty
+ * hero.
+ */
+const SetupValuation = () => {
+  const router = useRouter();
+  const valuation = useHomeValuation();
+  const { data, isLoading, isError } = useCatalogs();
+  const hasCatalog = !!data?.catalogs?.length;
+
+  useEffect(() => {
+    if (isLoading) return;
+    if (!hasCatalog || isError) router.replace("/catalogs");
+  }, [isLoading, hasCatalog, isError, router]);
+
+  if (isLoading || !valuation.show) {
+    return (
+      <div className="mx-auto flex w-full max-w-xl flex-col gap-4 px-6 py-8">
+        <Skeleton className="h-8 w-1/2 rounded-lg" />
+        <Skeleton className="h-[168px] w-full rounded-xl" />
+      </div>
+    );
+  }
+
+  return (
+    <section className="mx-auto flex w-full max-w-xl flex-col items-center gap-4 px-6 py-8">
+      <ValuationHero
+        artistName={valuation.artistName}
+        artistImage={valuation.artistImage}
+        valuation={valuation.valuation}
+        measuredTrackCount={valuation.measuredTrackCount}
+      />
+      <p className="text-center text-sm text-muted-foreground">
+        This estimate goes stale the day you close the tab. A weekly report
+        re-measures your catalog and emails you the trend.
+      </p>
+      <Link
+        href="/setup/tasks"
+        className={cn(buttonVariants(), "min-w-[200px]")}
+      >
+        Set up your weekly report
+      </Link>
+    </section>
+  );
+};
+
+export default SetupValuation;

--- a/components/Onboarding/SetupValuation.tsx
+++ b/components/Onboarding/SetupValuation.tsx
@@ -23,15 +23,20 @@ import { cn } from "@/lib/utils";
 const SetupValuation = () => {
   const router = useRouter();
   const valuation = useHomeValuation();
-  const { data, isLoading, isError } = useCatalogs();
+  // `isPending`, not `isLoading`: useCatalogs is `enabled: !!accountId &&
+  // authenticated`, and a disabled TanStack Query v5 query reports
+  // isPending true / isFetching false — so isLoading is false while Privy is
+  // still resolving. Redirecting on that bounced every cold load of this
+  // route, which is exactly where the welcome email's payoff link points.
+  const { data, isPending, isError } = useCatalogs();
   const hasCatalog = !!data?.catalogs?.length;
 
   useEffect(() => {
-    if (isLoading) return;
+    if (isPending) return;
     if (!hasCatalog || isError) router.replace("/catalogs");
-  }, [isLoading, hasCatalog, isError, router]);
+  }, [isPending, hasCatalog, isError, router]);
 
-  if (isLoading || !valuation.show) {
+  if (isPending || !valuation.show) {
     return (
       <div className="mx-auto flex w-full max-w-xl flex-col gap-4 px-6 py-8">
         <Skeleton className="h-8 w-1/2 rounded-lg" />

--- a/components/Onboarding/__tests__/RosterVerifiedPanel.test.tsx
+++ b/components/Onboarding/__tests__/RosterVerifiedPanel.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import RosterVerifiedPanel from "@/components/Onboarding/RosterVerifiedPanel";
+
+const valuation = {
+  show: true,
+  artistName: "Drake",
+  artistImage: "",
+  valuation: { low: 900000, mid: 1400000, high: 2100000 },
+  measuredTrackCount: 42,
+};
+
+const homeValuation = { current: valuation as unknown };
+
+vi.mock("@/hooks/useHomeValuation", () => ({
+  default: () => homeValuation.current,
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: React.ComponentProps<"a"> & { href: string }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+describe("RosterVerifiedPanel", () => {
+  it("ends setup on the catalog valuation, not a generic green check", () => {
+    homeValuation.current = valuation;
+
+    render(<RosterVerifiedPanel />);
+
+    // The payoff: the number the lead converted on (chat#1889).
+    expect(screen.getByText(/\$1\.4M/)).toBeDefined();
+    expect(screen.getByText(/42 tracks measured/i)).toBeDefined();
+    expect(screen.queryByText(/^roster verified$/i)).toBeNull();
+  });
+
+  it("falls back to the confirmation state when no valuation exists yet", () => {
+    homeValuation.current = { show: false };
+
+    render(<RosterVerifiedPanel />);
+
+    expect(screen.getByText(/roster verified/i)).toBeDefined();
+  });
+});

--- a/components/Onboarding/__tests__/SetupValuation.test.tsx
+++ b/components/Onboarding/__tests__/SetupValuation.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+import React from "react";
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import SetupValuation from "@/components/Onboarding/SetupValuation";
+
+const replace = vi.fn();
+let catalogsResult: Record<string, unknown>;
+let valuationResult: Record<string, unknown>;
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace }),
+}));
+
+vi.mock("@/hooks/useCatalogs", () => ({
+  default: () => catalogsResult,
+}));
+
+vi.mock("@/hooks/useHomeValuation", () => ({
+  default: () => valuationResult,
+}));
+
+vi.mock("@/components/Home/ValuationHero", () => ({
+  default: () => <div>hero</div>,
+}));
+
+describe("SetupValuation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    valuationResult = { show: false };
+  });
+
+  // `useCatalogs` is `enabled: !!accountId && authenticated`, and a *disabled*
+  // TanStack Query v5 query reports isPending true / isFetching false — so
+  // `isLoading` is false while Privy is still resolving. Redirecting on that
+  // bounced every cold load of /setup/valuation, which is the route the
+  // welcome email's payoff link points at (chat#1889).
+  it("does not redirect while the catalogs query has not resolved", () => {
+    catalogsResult = {
+      data: undefined,
+      isLoading: false,
+      isPending: true,
+      isError: false,
+    };
+
+    render(<SetupValuation />);
+
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it("redirects to /catalogs once settled with no catalog", () => {
+    catalogsResult = {
+      data: { catalogs: [] },
+      isLoading: false,
+      isPending: false,
+      isError: false,
+    };
+
+    render(<SetupValuation />);
+
+    expect(replace).toHaveBeenCalledWith("/catalogs");
+  });
+
+  it("redirects to /catalogs when the catalogs read fails", () => {
+    catalogsResult = {
+      data: undefined,
+      isLoading: false,
+      isPending: false,
+      isError: true,
+    };
+
+    render(<SetupValuation />);
+
+    expect(replace).toHaveBeenCalledWith("/catalogs");
+  });
+
+  it("renders the hero and does not redirect when a valuation is available", () => {
+    catalogsResult = {
+      data: { catalogs: [{ id: "cat-1" }] },
+      isLoading: false,
+      isPending: false,
+      isError: false,
+    };
+    valuationResult = {
+      show: true,
+      artistName: "Ana Bárbara",
+      artistImage: "https://i.scdn.co/image/x.jpg",
+      valuation: { low: 267000, mid: 389000, high: 547000 },
+      measuredTrackCount: 79,
+    };
+
+    const { getByText } = render(<SetupValuation />);
+
+    expect(getByText("hero")).toBeDefined();
+    expect(replace).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Matrix row 10 in chat#1889 — **the payoff the issue is named for**. Independent of the convergence chain.

## Why

Two dead ends on the same number:

1. Finishing roster + socials ended on a generic green `CheckCircle2` and a "Back to Recoup" button.
2. `/setup/valuation` was a bare `redirect("/catalogs")` — so the welcome email's **"See your baseline valuation"** link had no real destination.

A signup converts on a valuation and then never sees it again inside the product.

## What changed

- **`RosterVerifiedPanel`** renders the account's valuation using the **existing** homepage hero (`useHomeValuation` + `ValuationHero`) — no second valuation surface — then points at the weekly report that keeps it measured.
- **New `SetupValuation`** mounts at `/setup/valuation` with the same hero, and falls back to `/catalogs` only when the account genuinely has no catalog to value.
- The **no-valuation fallback** now points at the step that unlocks one (`/setup/catalog`) instead of dead-ending on "Back to Recoup".

## Verification

TDD, red → green:

\`\`\`
# RED — panel still renders the generic check, no valuation
× ends setup on the catalog valuation, not a generic green check
  Tests  1 failed | 1 passed (2)

# GREEN
pnpm exec vitest run components/Onboarding
  Test Files  1 passed (1)
       Tests  2 passed (2)
\`\`\`

Tests assert both directions: the valuation figure and measured-track count render when a valuation exists (`$1.4M`, `42 tracks measured`), and the confirmation state still appears when it does not — so a cold-start account can't hit an empty hero.

`pnpm exec tsc --noEmit` clean for the touched files. Preview click-through pending (needs an authed account with a measured catalog).

Tracked in chat#1889 (matrix row 10).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
End onboarding on the catalog valuation and make `/setup/valuation` show the same valuation instead of redirecting. Delivers chat#1889 row 10 and adds a guard to prevent cold-load bounces.

- **New Features**
  - `RosterVerifiedPanel` now shows the account’s valuation using `ValuationHero` + `useHomeValuation`, with a CTA to `/setup/tasks`. If no valuation, show confirmation with a CTA to `/setup/catalog`.
  - New `SetupValuation` at `/setup/valuation` renders the same hero and weekly report CTA; only redirects to `/catalogs` when the account has no catalog. Tests cover the hero view, fallbacks, and `/setup/valuation` redirects.

- **Bug Fixes**
  - Gate `/setup/valuation` on `isPending` (not `isLoading`) from `useCatalogs` to avoid redirecting before auth enables the query, preventing cold-load bounces from the welcome email link.

<sup>Written for commit 61911a6ad459a1e162f5473311878faddfd9aad1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a baseline valuation step to the onboarding flow.
  * Displays valuation details, artist information, and measured track counts.
  * Added a link to set up weekly reports after valuation is available.
  * Added loading placeholders while valuation and catalog information loads.
  * Routes users without an existing catalog to catalog setup.

* **Bug Fixes**
  * Welcome email links now open the intended valuation onboarding experience instead of redirecting immediately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->