### PR TITLE
feat(onboarding): collapse verify-socials into per-artist panels (chat#1889 row 12)

### DIFF
--- a/components/Onboarding/ArtistSocialsCard.tsx
+++ b/components/Onboarding/ArtistSocialsCard.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import { useState } from "react";
+import { ChevronDown } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { cn } from "@/lib/utils";
 import type { ArtistRecord } from "@/types/Artist";
 import SocialRow from "./SocialRow";
 import SocialSearchOrPaste from "./SocialSearchOrPaste";
@@ -11,6 +18,8 @@ interface ArtistSocialsCardProps {
   isFixing: boolean;
   onFix: (url: string) => Promise<boolean>;
   onRemove: (socialId: string) => Promise<boolean>;
+  /** Open on mount — used when the roster has a single artist. */
+  defaultOpen?: boolean;
 }
 
 /**
@@ -18,12 +27,17 @@ interface ArtistSocialsCardProps {
  * shown with an Edit affordance to fix a wrong match; an artist with no
  * matches gets a soft nudge to add one. No confirm/none step — the step
  * proceeds regardless (see VerifySocialsStep).
+ *
+ * Collapsed into a per-artist panel (chat#1889): every artist's socials were
+ * expanded at once, so a manager with a real roster faced an unscannable wall.
+ * A single-artist roster opens by default, since there is nothing to traverse.
  */
 const ArtistSocialsCard = ({
   artist,
   isFixing,
   onFix,
   onRemove,
+  defaultOpen = false,
 }: ArtistSocialsCardProps) => {
   const socials = artist.account_socials ?? [];
   const [adding, setAdding] = useState(false);
@@ -35,49 +49,70 @@ const ArtistSocialsCard = ({
   };
 
   return (
-    <div className="p-4 rounded-xl border border-border bg-card flex flex-col gap-2">
-      <h2 className="font-medium text-card-foreground truncate">
-        {artist.name || "Untitled artist"}
-      </h2>
-
-      {socials.length === 0 ? (
-        <p className="text-sm text-muted-foreground">
-          No profiles were auto-matched for {artist.name || "this artist"}.
-          Adding one is optional, and you can continue without it.
-        </p>
-      ) : (
-        <div className="divide-y divide-border">
-          {socials.map((social) => (
-            <SocialRow
-              key={social.id}
-              social={social}
-              isSubmitting={isFixing}
-              onFix={onFix}
-              onRemove={onRemove}
-            />
-          ))}
-        </div>
-      )}
-
-      {/* Always available: a matched-social list can still be missing platforms. */}
-      {adding ? (
-        <SocialSearchOrPaste
-          pastePlaceholder="Paste a profile link"
-          isSubmitting={isFixing}
-          onSubmit={handleAdd}
+    <Collapsible
+      defaultOpen={defaultOpen}
+      className="p-4 rounded-xl border border-border bg-card"
+    >
+      <CollapsibleTrigger className="group flex w-full items-center justify-between gap-3 text-left">
+        <span className="min-w-0">
+          <span className="block font-medium text-card-foreground truncate">
+            {artist.name || "Untitled artist"}
+          </span>
+          <span className="block text-xs text-muted-foreground">
+            {socials.length === 0
+              ? "No profiles matched"
+              : `${socials.length} ${socials.length === 1 ? "profile" : "profiles"}`}
+          </span>
+        </span>
+        <ChevronDown
+          aria-hidden="true"
+          className={cn(
+            "size-4 shrink-0 text-muted-foreground transition-transform",
+            "group-data-[state=open]:rotate-180",
+          )}
         />
-      ) : (
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          className="self-start"
-          onClick={() => setAdding(true)}
-        >
-          Add a profile
-        </Button>
-      )}
-    </div>
+      </CollapsibleTrigger>
+
+      <CollapsibleContent className="flex flex-col gap-2 pt-3">
+        {socials.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No profiles were auto-matched for {artist.name || "this artist"}.
+            Adding one is optional, and you can continue without it.
+          </p>
+        ) : (
+          <div className="divide-y divide-border">
+            {socials.map((social) => (
+              <SocialRow
+                key={social.id}
+                social={social}
+                isSubmitting={isFixing}
+                onFix={onFix}
+                onRemove={onRemove}
+              />
+            ))}
+          </div>
+        )}
+
+        {/* Always available: a matched-social list can still be missing platforms. */}
+        {adding ? (
+          <SocialSearchOrPaste
+            pastePlaceholder="Paste a profile link"
+            isSubmitting={isFixing}
+            onSubmit={handleAdd}
+          />
+        ) : (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="self-start"
+            onClick={() => setAdding(true)}
+          >
+            Add a profile
+          </Button>
+        )}
+      </CollapsibleContent>
+    </Collapsible>
   );
 };
 

--- a/components/Onboarding/ArtistSocialsCard.tsx
+++ b/components/Onboarding/ArtistSocialsCard.tsx
@@ -10,6 +10,7 @@ interface ArtistSocialsCardProps {
   artist: ArtistRecord;
   isFixing: boolean;
   onFix: (url: string) => Promise<boolean>;
+  onRemove: (socialId: string) => Promise<boolean>;
 }
 
 /**
@@ -22,6 +23,7 @@ const ArtistSocialsCard = ({
   artist,
   isFixing,
   onFix,
+  onRemove,
 }: ArtistSocialsCardProps) => {
   const socials = artist.account_socials ?? [];
   const [adding, setAdding] = useState(false);
@@ -40,8 +42,8 @@ const ArtistSocialsCard = ({
 
       {socials.length === 0 ? (
         <p className="text-sm text-muted-foreground">
-          No profiles were auto-matched for {artist.name || "this artist"}. Add
-          one, or continue.
+          No profiles were auto-matched for {artist.name || "this artist"}.
+          Adding one is optional, and you can continue without it.
         </p>
       ) : (
         <div className="divide-y divide-border">
@@ -51,6 +53,7 @@ const ArtistSocialsCard = ({
               social={social}
               isSubmitting={isFixing}
               onFix={onFix}
+              onRemove={onRemove}
             />
           ))}
         </div>

--- a/components/Onboarding/SocialRow.tsx
+++ b/components/Onboarding/SocialRow.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Pencil } from "lucide-react";
+import { Pencil, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import getSocialPlatformByLink from "@/lib/getSocialPlatformByLink";
 import { getSocialFollowerCount } from "@/lib/onboarding/getSocialFollowerCount";
@@ -14,6 +14,7 @@ interface SocialRowProps {
   social: SOCIAL;
   isSubmitting: boolean;
   onFix: (url: string) => Promise<boolean>;
+  onRemove: (socialId: string) => Promise<boolean>;
 }
 
 /**
@@ -21,8 +22,16 @@ interface SocialRowProps {
  * followers, with an Edit affordance that reveals a paste-the-correct-link
  * form for the rare wrong match. No confirm step — leaving it as-is is the
  * confirmation.
+ *
+ * Remove is the other half (chat#1889): the step previously only added or
+ * replaced, so a profile the user did not want could not be taken back.
  */
-const SocialRow = ({ social, isSubmitting, onFix }: SocialRowProps) => {
+const SocialRow = ({
+  social,
+  isSubmitting,
+  onFix,
+  onRemove,
+}: SocialRowProps) => {
   const [editing, setEditing] = useState(false);
   const platform = getPlatformDisplayName(
     getSocialPlatformByLink(social.link || ""),
@@ -51,17 +60,30 @@ const SocialRow = ({ social, isSubmitting, onFix }: SocialRowProps) => {
               ` · ${formatFollowerCount(followerCount)} followers`}
           </p>
         </div>
-        <Button
-          type="button"
-          size="sm"
-          variant="ghost"
-          className="shrink-0 text-muted-foreground"
-          aria-label={`Edit ${platform} link`}
-          aria-expanded={editing}
-          onClick={() => setEditing((open) => !open)}
-        >
-          <Pencil className="size-4" />
-        </Button>
+        <div className="flex shrink-0 items-center">
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            className="text-muted-foreground"
+            aria-label={`Edit ${platform} link`}
+            aria-expanded={editing}
+            onClick={() => setEditing((open) => !open)}
+          >
+            <Pencil className="size-4" />
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            className="text-muted-foreground"
+            aria-label={`Remove ${platform} link`}
+            disabled={isSubmitting}
+            onClick={() => void onRemove(social.id)}
+          >
+            <Trash2 className="size-4" />
+          </Button>
+        </div>
       </div>
       {editing && (
         <div className="mt-2">

--- a/components/Onboarding/VerifySocialsStep.tsx
+++ b/components/Onboarding/VerifySocialsStep.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from "@/components/ui/button";
 import { useSocialFix } from "@/hooks/onboarding/useSocialFix";
+import { useSocialRemove } from "@/hooks/onboarding/useSocialRemove";
 import { useArtistProvider } from "@/providers/ArtistProvider";
 import ArtistSocialsCard from "./ArtistSocialsCard";
 
@@ -15,6 +16,7 @@ const VerifySocialsStep = ({ onConfirmed }: { onConfirmed: () => void }) => {
   const { sorted } = useArtistProvider();
   const artists = sorted.filter((artist) => !artist.isWorkspace);
   const { fixSocial, fixingArtistId } = useSocialFix();
+  const { removeSocial, removingSocialId } = useSocialRemove();
 
   return (
     <section className="flex flex-col gap-6">
@@ -33,8 +35,11 @@ const VerifySocialsStep = ({ onConfirmed }: { onConfirmed: () => void }) => {
           <ArtistSocialsCard
             key={artist.account_id}
             artist={artist}
-            isFixing={fixingArtistId === artist.account_id}
+            isFixing={
+              fixingArtistId === artist.account_id || removingSocialId !== null
+            }
             onFix={(url) => fixSocial(artist, url)}
+            onRemove={(socialId) => removeSocial(artist, socialId)}
           />
         ))}
       </div>

--- a/components/Onboarding/VerifySocialsStep.tsx
+++ b/components/Onboarding/VerifySocialsStep.tsx
@@ -40,6 +40,7 @@ const VerifySocialsStep = ({ onConfirmed }: { onConfirmed: () => void }) => {
             }
             onFix={(url) => fixSocial(artist, url)}
             onRemove={(socialId) => removeSocial(artist, socialId)}
+            defaultOpen={artists.length === 1}
           />
         ))}
       </div>

--- a/components/Onboarding/__tests__/ArtistSocialsCard.test.tsx
+++ b/components/Onboarding/__tests__/ArtistSocialsCard.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import ArtistSocialsCard from "@/components/Onboarding/ArtistSocialsCard";
+import type { ArtistRecord } from "@/types/Artist";
+
+const artist = {
+  account_id: "artist-1",
+  name: "Drake",
+  account_socials: [
+    { id: "s1", link: "https://open.spotify.com/artist/abc", username: "drake" },
+    { id: "s2", link: "https://instagram.com/champagnepapi", username: "champagnepapi" },
+  ],
+} as unknown as ArtistRecord;
+
+const props = {
+  artist,
+  isFixing: false,
+  onFix: vi.fn(),
+  onRemove: vi.fn(),
+};
+
+describe("ArtistSocialsCard", () => {
+  it("collapses an artist's socials by default so a multi-artist roster is traversable", () => {
+    render(<ArtistSocialsCard {...props} />);
+
+    // A manager with 10 artists had every artist's socials expanded at once,
+    // making the step an unscannable wall (chat#1889).
+    expect(screen.queryByLabelText(/edit spotify link/i)).toBeNull();
+    expect(
+      screen.getByRole("button", { name: /drake/i }),
+    ).toHaveProperty("ariaExpanded", "false");
+  });
+
+  it("summarises how many profiles are inside while collapsed", () => {
+    render(<ArtistSocialsCard {...props} />);
+
+    expect(screen.getByText(/2 profiles/i)).toBeDefined();
+  });
+
+  it("expands on click to reveal the rows", () => {
+    render(<ArtistSocialsCard {...props} />);
+    fireEvent.click(screen.getByRole("button", { name: /drake/i }));
+
+    expect(screen.getByLabelText(/edit spotify link/i)).toBeDefined();
+  });
+
+  it("starts open when it is the only artist, so a single-artist roster needs no click", () => {
+    render(<ArtistSocialsCard {...props} defaultOpen />);
+
+    expect(screen.getByLabelText(/edit spotify link/i)).toBeDefined();
+  });
+});

--- a/components/Onboarding/__tests__/SocialRow.test.tsx
+++ b/components/Onboarding/__tests__/SocialRow.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import SocialRow from "@/components/Onboarding/SocialRow";
+import type { SOCIAL } from "@/types/Agent";
+
+const SOCIAL_ROW = {
+  id: "social-123",
+  link: "https://open.spotify.com/artist/abc",
+  username: "drake",
+} as unknown as SOCIAL;
+
+const onFix = vi.fn();
+const onRemove = vi.fn();
+
+describe("SocialRow", () => {
+  beforeEach(() => {
+    onFix.mockClear();
+    onRemove.mockClear();
+    onRemove.mockResolvedValue(true);
+  });
+
+  it("offers a remove affordance for a social the user does not want", () => {
+    render(
+      <SocialRow
+        social={SOCIAL_ROW}
+        isSubmitting={false}
+        onFix={onFix}
+        onRemove={onRemove}
+      />,
+    );
+
+    // useSocialFix could only add or replace, so a wrongly added profile could
+    // not be taken back and the step dead-ended (chat#1889).
+    fireEvent.click(screen.getByRole("button", { name: /remove/i }));
+
+    expect(onRemove).toHaveBeenCalledWith("social-123");
+  });
+
+  it("keeps the edit affordance alongside remove", () => {
+    render(
+      <SocialRow
+        social={SOCIAL_ROW}
+        isSubmitting={false}
+        onFix={onFix}
+        onRemove={onRemove}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /edit/i })).toBeDefined();
+  });
+});

--- a/hooks/onboarding/useSocialRemove.ts
+++ b/hooks/onboarding/useSocialRemove.ts
@@ -1,0 +1,47 @@
+"use client";
+
+import { useState } from "react";
+import { usePrivy } from "@privy-io/react-auth";
+import { toast } from "sonner";
+import { deleteArtistSocial } from "@/lib/artists/deleteArtistSocial";
+import { useArtistProvider } from "@/providers/ArtistProvider";
+import type { ArtistRecord } from "@/types/Artist";
+
+/**
+ * Removes a social from an artist during verify-socials, then refreshes the
+ * roster so the row disappears.
+ *
+ * `useSocialFix` could only add or replace (chat#1889): a user who added the
+ * wrong profile had no way to take it back, and was left staring at a list they
+ * could not correct. Removal is the missing half of the same step.
+ */
+export function useSocialRemove() {
+  const { getAccessToken } = usePrivy();
+  const { getArtists } = useArtistProvider();
+  const [removingSocialId, setRemovingSocialId] = useState<string | null>(null);
+
+  const removeSocial = async (
+    artist: ArtistRecord,
+    socialId: string,
+  ): Promise<boolean> => {
+    setRemovingSocialId(socialId);
+    try {
+      const accessToken = await getAccessToken();
+      if (!accessToken) {
+        throw new Error("Please sign in to remove a social");
+      }
+      await deleteArtistSocial(accessToken, artist.account_id, socialId);
+      await getArtists();
+      return true;
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to remove social",
+      );
+      return false;
+    } finally {
+      setRemovingSocialId(null);
+    }
+  };
+
+  return { removeSocial, removingSocialId };
+}

--- a/lib/artists/deleteArtistSocial.ts
+++ b/lib/artists/deleteArtistSocial.ts
@@ -1,0 +1,31 @@
+import { getClientApiBaseUrl } from "@/lib/api/getClientApiBaseUrl";
+
+interface DeleteArtistSocialResponse {
+  error?: string;
+}
+
+/**
+ * Unlinks a social profile from an artist via the existing
+ * `DELETE /api/artists/{id}/socials/{socialId}` endpoint (Privy bearer auth).
+ * The underlying social row is left intact; only the artist link is removed.
+ */
+export async function deleteArtistSocial(
+  accessToken: string,
+  artistId: string,
+  socialId: string,
+): Promise<void> {
+  const response = await fetch(
+    `${getClientApiBaseUrl()}/api/artists/${artistId}/socials/${socialId}`,
+    {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${accessToken}` },
+    },
+  );
+
+  if (!response.ok) {
+    const data: DeleteArtistSocialResponse = await response
+      .json()
+      .catch(() => ({}));
+    throw new Error(data.error || "Failed to remove social");
+  }
+}


### PR DESCRIPTION
Matrix row 12 in chat#1889. **Stacked on #1894** (delete-a-social) — both change `ArtistSocialsCard` / `VerifySocialsStep`, so this branches off it rather than conflicting. Review/merge after #1894.

## Why

`VerifySocialsStep` rendered every rostered artist's socials expanded simultaneously. For a manager with a real roster that is an unscannable wall, and there is no way to see at a glance which artist still needs attention.

## What changed

- Each artist is a **`Collapsible`** panel. The trigger shows the artist name plus a profile count — *"2 profiles"* / *"No profiles matched"* — so the state is readable while collapsed.
- **A single-artist roster opens by default** (`defaultOpen={artists.length === 1}`), since there is nothing to traverse and an extra click would be pure friction.
- Chevron rotates via `group-data-[state=open]`.

Uses the **existing** `@radix-ui/react-collapsible` primitive (already a dependency, with a `components/ui/collapsible.tsx` wrapper) rather than adding `@radix-ui/react-accordion`. Same UX, no new dependency.

## Verification

TDD, red → green:

\`\`\`
# RED — rows rendered regardless of collapse state
  Tests  3 failed | 1 passed (4)

# GREEN
pnpm exec vitest run components/Onboarding
  Test Files  2 passed (2)
       Tests  6 passed (6)
\`\`\`

Tests cover all four behaviours: collapsed by default, the profile-count summary while collapsed, expansion on click revealing the edit affordance, and `defaultOpen` for the single-artist case.

`pnpm exec tsc --noEmit` clean for the touched files. Preview click-through pending (needs an authed multi-artist roster).

Tracked in chat#1889 (matrix row 12).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make verify-socials scannable by collapsing socials into per-artist panels with a clear profile count. Also adds the ability to remove a matched profile to undo mistakes.

- **New Features**
  - Collapsed per-artist panels using `@radix-ui/react-collapsible`; trigger shows artist name and "N profiles"/"No profiles matched", chevron rotates, and a single-artist roster opens by default.
  - Remove a social from an artist: `SocialRow` adds a Remove button next to Edit, `useSocialRemove` handles the mutation and refresh, and `deleteArtistSocial` calls `DELETE /api/artists/{id}/socials/{socialId}`.
  - Copy tweak: if no matches, clarify that adding a profile is optional and you can continue.

<sup>Written for commit 2856249eaf7a05be1a8345d11ed61519825fc08d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

