### PR TITLE
feat(onboarding): platform picker when adding a social (chat#1889 row 12)

### DIFF
--- a/components/Onboarding/ArtistSocialsCard.tsx
+++ b/components/Onboarding/ArtistSocialsCard.tsx
@@ -59,6 +59,7 @@ const ArtistSocialsCard = ({
       {/* Always available: a matched-social list can still be missing platforms. */}
       {adding ? (
         <SocialSearchOrPaste
+          withPlatformPicker
           pastePlaceholder="Paste a profile link"
           isSubmitting={isFixing}
           onSubmit={handleAdd}

--- a/components/Onboarding/SocialPlatformPicker.tsx
+++ b/components/Onboarding/SocialPlatformPicker.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { getConnectorIcon } from "@/lib/composio/getConnectorIcon";
+import { getSocialPlatformOptions } from "@/lib/onboarding/getSocialPlatformOptions";
+import type { SocialPlatformOption } from "@/lib/onboarding/getSocialPlatformOptions";
+
+/**
+ * Which platform am I adding? (chat#1889) Verify-socials previously jumped
+ * straight to a Spotify search, so an artist missing their Instagram had no
+ * obvious path. Branded icons come from the existing connector-icon helper.
+ */
+const SocialPlatformPicker = ({
+  onSelect,
+  disabled,
+}: {
+  onSelect: (option: SocialPlatformOption) => void;
+  disabled?: boolean;
+}) => (
+  <div className="flex flex-col gap-2">
+    <p className="text-xs text-muted-foreground">Which platform?</p>
+    <div className="flex flex-wrap gap-2">
+      {getSocialPlatformOptions().map((option) => (
+        <Button
+          key={option.slug}
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={disabled}
+          className="gap-2"
+          onClick={() => onSelect(option)}
+        >
+          {getConnectorIcon(option.slug, 16)}
+          {option.label}
+        </Button>
+      ))}
+    </div>
+  </div>
+);
+
+export default SocialPlatformPicker;

--- a/components/Onboarding/SocialSearchOrPaste.tsx
+++ b/components/Onboarding/SocialSearchOrPaste.tsx
@@ -4,6 +4,8 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import SpotifyArtistSearch from "@/components/Artists/SpotifyArtistSearch";
 import SocialFixForm from "./SocialFixForm";
+import SocialPlatformPicker from "./SocialPlatformPicker";
+import type { SocialPlatformOption } from "@/lib/onboarding/getSocialPlatformOptions";
 import type { SpotifyArtistSearchResult } from "@/types/spotify";
 
 interface SocialSearchOrPasteProps {
@@ -11,43 +13,64 @@ interface SocialSearchOrPasteProps {
   pastePlaceholder: string;
   isSubmitting: boolean;
   onSubmit: (url: string) => Promise<boolean>;
+  /**
+   * Ask which platform first. Used on the ADD path, where the missing platform
+   * is unknown; the edit path already knows which social it is replacing.
+   */
+  withPlatformPicker?: boolean;
 }
 
 /**
- * Add/replace a social by searching Spotify (typeahead, reusing #1878's
- * SpotifyArtistSearch) instead of pasting a link — picking an artist submits
- * their Spotify profile URL, which the existing platform-detection path keys
- * as SPOTIFY. A "paste a link instead" fallback stays available for the other
- * platforms (Instagram, TikTok, YouTube, ...) the Spotify search can't reach.
+ * Add/replace a social. Picking a Spotify artist submits their profile URL,
+ * which the existing platform-detection path keys as SPOTIFY; a paste-a-link
+ * fallback covers the platforms Spotify search can't reach.
+ *
+ * On the add path this leads with a platform picker (chat#1889): it used to jump
+ * straight to a Spotify search, so an artist whose Instagram was unmatched had
+ * no obvious way to supply it.
  */
 const SocialSearchOrPaste = ({
   pastePlaceholder,
   isSubmitting,
   onSubmit,
+  withPlatformPicker = false,
 }: SocialSearchOrPasteProps) => {
+  const [platform, setPlatform] = useState<SocialPlatformOption | null>(null);
   const [pasting, setPasting] = useState(false);
 
   const handleSelect = (artist: SpotifyArtistSearchResult) => {
     void onSubmit(artist.external_urls.spotify);
   };
 
-  if (pasting) {
+  if (withPlatformPicker && !platform) {
+    return (
+      <SocialPlatformPicker disabled={isSubmitting} onSelect={setPlatform} />
+    );
+  }
+
+  const canSearch = platform ? platform.supportsSearch : true;
+  const placeholder = platform?.placeholder ?? pastePlaceholder;
+
+  if (!canSearch || pasting) {
     return (
       <div className="flex flex-col gap-2">
         <SocialFixForm
-          placeholder={pastePlaceholder}
+          placeholder={placeholder}
           isSubmitting={isSubmitting}
           onSubmit={onSubmit}
         />
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          className="self-start text-muted-foreground"
-          onClick={() => setPasting(false)}
-        >
-          Search Spotify instead
-        </Button>
+        {/* Only Spotify has a typeahead worth going back to. */}
+        {canSearch && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="self-start text-muted-foreground"
+            onClick={() => setPasting(false)}
+          >
+            Search Spotify instead
+          </Button>
+        )}
       </div>
     );
   }

--- a/lib/onboarding/__tests__/getSocialPlatformOptions.test.ts
+++ b/lib/onboarding/__tests__/getSocialPlatformOptions.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { getSocialPlatformOptions } from "@/lib/onboarding/getSocialPlatformOptions";
+
+describe("getSocialPlatformOptions", () => {
+  it("offers the platforms reports actually pull from", () => {
+    const slugs = getSocialPlatformOptions().map((o) => o.slug);
+
+    expect(slugs).toContain("spotify");
+    expect(slugs).toContain("instagram");
+    expect(slugs).toContain("twitter");
+    expect(slugs).toContain("youtube");
+    expect(slugs).toContain("tiktok");
+  });
+
+  it("marks Spotify as the one platform with a typeahead", () => {
+    const options = getSocialPlatformOptions();
+    const spotify = options.find((o) => o.slug === "spotify");
+    const instagram = options.find((o) => o.slug === "instagram");
+
+    // SocialFixForm used to guide everyone to Spotify (chat#1889); the others
+    // have no search endpoint, so they get a platform-specific paste prompt.
+    expect(spotify?.supportsSearch).toBe(true);
+    expect(instagram?.supportsSearch).toBe(false);
+  });
+
+  it("gives every platform its own paste placeholder naming that platform", () => {
+    for (const option of getSocialPlatformOptions()) {
+      expect(option.placeholder.toLowerCase()).toContain(
+        option.label.toLowerCase(),
+      );
+    }
+  });
+});

--- a/lib/onboarding/getSocialPlatformOptions.ts
+++ b/lib/onboarding/getSocialPlatformOptions.ts
@@ -1,0 +1,52 @@
+export interface SocialPlatformOption {
+  /** Connector slug, for `getConnectorIcon`. */
+  slug: string;
+  label: string;
+  /** Paste-a-link placeholder, naming the platform so the ask is unambiguous. */
+  placeholder: string;
+  /** True when a typeahead exists for this platform (Spotify only, today). */
+  supportsSearch: boolean;
+}
+
+/**
+ * Platforms a user can attach during verify-socials (chat#1889).
+ *
+ * `SocialFixForm` guided everyone to Spotify regardless of what was missing, so
+ * an artist whose Instagram was unmatched had no obvious way to add it. Leading
+ * with a platform choice makes the ask explicit; only Spotify has a search
+ * endpoint, so the rest fall back to a platform-specific paste prompt.
+ */
+export function getSocialPlatformOptions(): SocialPlatformOption[] {
+  return [
+    {
+      slug: "spotify",
+      label: "Spotify",
+      placeholder: "Paste a Spotify artist link",
+      supportsSearch: true,
+    },
+    {
+      slug: "instagram",
+      label: "Instagram",
+      placeholder: "Paste an Instagram profile link",
+      supportsSearch: false,
+    },
+    {
+      slug: "twitter",
+      label: "X",
+      placeholder: "Paste an X profile link",
+      supportsSearch: false,
+    },
+    {
+      slug: "youtube",
+      label: "YouTube",
+      placeholder: "Paste a YouTube channel link",
+      supportsSearch: false,
+    },
+    {
+      slug: "tiktok",
+      label: "TikTok",
+      placeholder: "Paste a TikTok profile link",
+      supportsSearch: false,
+    },
+  ];
+}


### PR DESCRIPTION
Matrix row 12 in chat#1889 — **partial**, see Scope below. Independent of the other row-12 PR (#1896, per-artist panels): different files.

## Why

`SocialFixForm` guided every add to a **Spotify** search regardless of what was actually missing. An artist whose unmatched profile was their Instagram had no obvious way to supply it — the only visible affordance searched the wrong platform.

## What changed

- **`getSocialPlatformOptions`** — the platforms reports pull from (Spotify, Instagram, X, YouTube, TikTok), each with its own paste placeholder, and a `supportsSearch` flag marking Spotify as the only one with a typeahead endpoint.
- **`SocialPlatformPicker`** — leads the add path, branded with the **existing** `getConnectorIcon` helper.
- **`SocialSearchOrPaste`** takes `withPlatformPicker`, set only on the add path. Spotify keeps its typeahead; the others get a platform-specific paste prompt ("Paste an Instagram profile link"). The **edit** path is untouched — it already knows which social it is replacing, so asking again would be friction.

## Scope: what is still open on this row

The issue's row 12 also asks to **confirm a pasted handle with a pfp + follower count** (e.g. via Apify) so the match is verifiable. That needs an api resolve path that does not exist yet, so it is **not** in this PR. Row 12 stays open in the matrix for that part rather than being marked done.

## Verification

TDD, red → green:

\`\`\`
# RED — module not found
Test Files  1 failed (1)
     Tests  no tests

# GREEN
pnpm exec vitest run lib/onboarding components/Onboarding
  Test Files  18 passed (18)
       Tests  71 passed (71)
\`\`\`

The unit tests assert the platform set, that only Spotify is marked searchable, and that every placeholder names its own platform (so a copy edit can't leave a generic prompt behind).

`pnpm exec tsc --noEmit` clean for the touched files. Preview click-through pending.

Tracked in chat#1889 (matrix row 12).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a platform picker to the “add social” flow so users can choose Spotify, Instagram, X, YouTube, or TikTok; only Spotify keeps search, others show a platform-specific paste prompt. Partial for chat#1889 row 12; the handle confirmation step (pfp + followers) is not included.

- New Features
  - Added SocialPlatformPicker using existing getConnectorIcon.
  - Added getSocialPlatformOptions with `supportsSearch` and platform-specific placeholders.
  - Updated SocialSearchOrPaste to accept `withPlatformPicker` (add path only); edit flow unchanged.
  - Added unit tests for platform set, search support, and placeholders.

<sup>Written for commit a0f0c12a4ab93fee447b81e7f4db16cb33f2fd2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1897?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

