### PR TITLE
fix(onboarding): /setup/tasks must not re-create an existing schedule (chat#1889 row 12)

### DIFF
--- a/components/Onboarding/ExistingWeeklyReportPanel.tsx
+++ b/components/Onboarding/ExistingWeeklyReportPanel.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import Link from "next/link";
+import { CalendarClock } from "lucide-react";
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import type { Task } from "@/lib/tasks/getTasks";
+
+/**
+ * Shown at `/setup/tasks` when the account already has an enabled schedule
+ * (chat#1889): the step used to pre-run a fresh report and schedule again on
+ * every visit, which billed a duplicate run and left a second schedule behind.
+ * Surfaces the existing schedule and its most recent run instead.
+ */
+const ExistingWeeklyReportPanel = ({ task }: { task: Task }) => {
+  const latestRun = task.recent_runs?.[0];
+  const nextRun = task.upcoming?.[0];
+
+  return (
+    <section className="flex flex-col items-center gap-4 py-8 text-center">
+      <CalendarClock className="size-10 text-muted-foreground" />
+      <div>
+        <h1 className="text-2xl font-semibold text-foreground">
+          Your weekly report is already set up
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          {nextRun
+            ? `Next run ${new Date(nextRun).toLocaleString()}.`
+            : "It runs on its schedule and emails you the result."}
+          {latestRun?.createdAt
+            ? ` Last run ${new Date(latestRun.createdAt).toLocaleString()}.`
+            : " No runs yet."}
+        </p>
+      </div>
+      <Link
+        href="/tasks"
+        className={cn(buttonVariants(), "min-w-[200px]")}
+      >
+        View your reports
+      </Link>
+    </section>
+  );
+};
+
+export default ExistingWeeklyReportPanel;

--- a/components/Onboarding/FirstTaskStep.tsx
+++ b/components/Onboarding/FirstTaskStep.tsx
@@ -68,7 +68,7 @@ const FirstTaskStep = () => {
         </h1>
         <p className="text-sm text-muted-foreground">
           {artistName
-            ? `This week's catalog report for ${artistName} — the kind of update Recoup can send you every Monday.`
+            ? `This week's catalog report for ${artistName}. The kind of update Recoup can send you every Monday.`
             : "The kind of update Recoup can send you every Monday."}
         </p>
       </header>

--- a/components/Onboarding/FirstTaskStep.tsx
+++ b/components/Onboarding/FirstTaskStep.tsx
@@ -4,7 +4,10 @@ import { usePrivy } from "@privy-io/react-auth";
 import { useArtistProvider } from "@/providers/ArtistProvider";
 import useCatalogs from "@/hooks/useCatalogs";
 import { useNewChatBootstrap } from "@/hooks/useNewChatBootstrap";
+import { useScheduledActions } from "@/hooks/useScheduledActions";
 import { buildFirstTaskPrompt } from "@/lib/onboarding/buildFirstTaskPrompt";
+import { findExistingWeeklyReportTask } from "@/lib/onboarding/findExistingWeeklyReportTask";
+import ExistingWeeklyReportPanel from "./ExistingWeeklyReportPanel";
 import FirstTaskReportRun from "./FirstTaskReportRun";
 import SetupSkipLink from "./SetupSkipLink";
 
@@ -20,6 +23,7 @@ import SetupSkipLink from "./SetupSkipLink";
 const FirstTaskStep = () => {
   const { selectedArtist, isLoading: isArtistsLoading } = useArtistProvider();
   const catalogsQuery = useCatalogs();
+  const tasksQuery = useScheduledActions({});
   const bootstrap = useNewChatBootstrap();
   const { user, ready } = usePrivy();
   const artistName = selectedArtist?.name;
@@ -33,6 +37,28 @@ const FirstTaskStep = () => {
   const isPreparing =
     isArtistsLoading || catalogsQuery.isLoading || bootstrap.status !== "ready";
   const catalogName = catalogsQuery.data?.catalogs?.[0]?.name;
+
+  // Never pre-run + re-schedule over an existing schedule (chat#1889): a return
+  // visit (or a re-click of the welcome email's step link) billed a duplicate
+  // run and left a second schedule behind. Wait for the read before deciding, so
+  // the pre-run isn't kicked off while tasks are still loading.
+  const existingTask = findExistingWeeklyReportTask(tasksQuery.data);
+  if (tasksQuery.isLoading) {
+    return (
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-4 px-4 py-8">
+        <p className="animate-pulse text-sm text-muted-foreground" role="status">
+          Checking your reports...
+        </p>
+      </div>
+    );
+  }
+  if (existingTask) {
+    return (
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-4 px-4 py-8">
+        <ExistingWeeklyReportPanel task={existingTask} />
+      </div>
+    );
+  }
 
   return (
     <div className="mx-auto flex w-full max-w-3xl flex-col gap-4 px-4 py-8">

--- a/lib/onboarding/__tests__/buildFirstTaskParams.test.ts
+++ b/lib/onboarding/__tests__/buildFirstTaskParams.test.ts
@@ -14,7 +14,7 @@ describe("buildFirstTaskParams", () => {
   it("builds POST /api/tasks params with a personalized title", () => {
     const params = buildFirstTaskParams(input);
     expect(params).toEqual({
-      title: "Weekly Catalog Report — Luh Tyler",
+      title: "Weekly Catalog Report: Luh Tyler",
       prompt: buildFirstTaskPrompt({
         artistName: "Luh Tyler",
         artistAccountId: "artist-123",

--- a/lib/onboarding/__tests__/findExistingWeeklyReportTask.test.ts
+++ b/lib/onboarding/__tests__/findExistingWeeklyReportTask.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { findExistingWeeklyReportTask } from "@/lib/onboarding/findExistingWeeklyReportTask";
+import type { Task } from "@/lib/tasks/getTasks";
+
+const task = (over: Partial<Task>): Task =>
+  ({ id: "t1", enabled: true, title: "Weekly report", ...over }) as Task;
+
+describe("findExistingWeeklyReportTask", () => {
+  it("returns the enabled task so setup can show it instead of scheduling a duplicate", () => {
+    const existing = task({ id: "abc" });
+
+    expect(findExistingWeeklyReportTask([existing])?.id).toBe("abc");
+  });
+
+  it("ignores disabled tasks — a paused schedule is not an active report", () => {
+    expect(findExistingWeeklyReportTask([task({ enabled: false })])).toBeNull();
+  });
+
+  it("returns null for an empty or missing list, so first-run still pre-runs", () => {
+    expect(findExistingWeeklyReportTask([])).toBeNull();
+    expect(findExistingWeeklyReportTask(undefined)).toBeNull();
+  });
+
+  it("prefers the first enabled task when several exist", () => {
+    const tasks = [
+      task({ id: "off", enabled: false }),
+      task({ id: "on-1" }),
+      task({ id: "on-2" }),
+    ];
+
+    expect(findExistingWeeklyReportTask(tasks)?.id).toBe("on-1");
+  });
+});

--- a/lib/onboarding/buildFirstTaskParams.ts
+++ b/lib/onboarding/buildFirstTaskParams.ts
@@ -23,7 +23,7 @@ export function buildFirstTaskParams({
   catalogName,
 }: BuildFirstTaskParamsInput): Omit<CreateTaskParams, "model"> {
   return {
-    title: `Weekly Catalog Report — ${artistName}`,
+    title: `Weekly Catalog Report: ${artistName}`,
     prompt: buildFirstTaskPrompt({
       artistName,
       artistAccountId,

--- a/lib/onboarding/findExistingWeeklyReportTask.ts
+++ b/lib/onboarding/findExistingWeeklyReportTask.ts
@@ -1,0 +1,18 @@
+import type { Task } from "@/lib/tasks/getTasks";
+
+/**
+ * The account's already-scheduled report, if any (chat#1889).
+ *
+ * `/setup/tasks` pre-ran a fresh report and re-scheduled on every visit, so a
+ * returning user (or anyone re-clicking the welcome email's step link) paid for
+ * a duplicate run and ended up with a second schedule. When an enabled task
+ * already exists, setup should show it instead.
+ *
+ * Only enabled tasks count: a paused schedule is not an active report, so the
+ * step should still offer to set one up.
+ */
+export function findExistingWeeklyReportTask(
+  tasks: Task[] | undefined,
+): Task | null {
+  return tasks?.find((task) => task.enabled === true) ?? null;
+}


### PR DESCRIPTION
Matrix row 12 in chat#1889. Independent of the other row-12 PRs (#1896, #1897).

## Why

`FirstTaskStep` pre-ran a fresh weekly report and then scheduled it — **on every visit**, unconditionally. So a user who returned to `/setup/tasks`, or simply re-clicked the welcome email's step 4 link, got:

- a **duplicate billed LLM run** (the pre-run is a real agent turn), and
- a **second schedule** on the account

This is the same duplicate-schedule class of bug the task-email audit has hit before, reached through onboarding this time.

## What changed

- **`findExistingWeeklyReportTask`** — returns the account's `enabled` task. A **paused** schedule deliberately does not count, so a user who disabled theirs can still set one up.
- **`ExistingWeeklyReportPanel`** — surfaces the existing schedule with its next run and most recent run, linking to `/tasks`, instead of running anything.
- **`FirstTaskStep`** waits for the tasks read before deciding, so the pre-run cannot fire while `useScheduledActions` is still loading — otherwise the race would re-introduce the duplicate on a slow read.

## Verification

TDD, red → green:

\`\`\`
# RED — module not found
Test Files  1 failed (1)
     Tests  no tests

# GREEN
pnpm exec vitest run lib/onboarding components/Onboarding
  Test Files  18 passed (18)
       Tests  72 passed (72)
\`\`\`

Unit tests cover: enabled task returned, disabled ignored, empty/undefined → null (first-run still pre-runs), and first-enabled-wins with a mixed list.

`pnpm exec tsc --noEmit` clean for the touched files. Preview click-through pending (needs an authed account with an existing enabled task).

Tracked in chat#1889 (matrix row 12).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes onboarding so `/setup/tasks` no longer re-runs and re-schedules the weekly report when one already exists. Prevents duplicate billed LLM runs and multiple schedules; also updates first-task copy/title to use a colon (chat#1889, row 12).

- **Bug Fixes**
  - Detect an existing enabled weekly report and skip pre-run; paused schedules don’t count.
  - Show an existing-schedule panel with next/last run info and a link to `/tasks`.
  - Wait for tasks to load before deciding, preventing race conditions that could trigger a duplicate run.
  - Replace em dashes with a colon in first-task copy and task title.

<sup>Written for commit e9e1e49de255d7f8ef275fce2fba9ab8528c8537. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

