### PR TITLE
feat(artists): add-by-Spotify-id rides POST /api/artists resolve-or-create (chat#1889 row 8)

### DIFF
--- a/hooks/onboarding/__tests__/useAddRosterArtist.test.tsx
+++ b/hooks/onboarding/__tests__/useAddRosterArtist.test.tsx
@@ -40,7 +40,7 @@ const SPOTIFY = {
 describe("useAddRosterArtist", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    createRosterArtist.mockResolvedValue({ account_id: "artist-1" });
+    createRosterArtist.mockResolvedValue({ artist: { account_id: "artist-1" }, created: true });
     saveArtist.mockResolvedValue(undefined);
   });
 

--- a/hooks/onboarding/useAddRosterArtist.ts
+++ b/hooks/onboarding/useAddRosterArtist.ts
@@ -45,7 +45,7 @@ export function useAddRosterArtist() {
       if (!accessToken) {
         throw new Error("Please sign in to add an artist");
       }
-      const artist = await createRosterArtist(
+      const { artist } = await createRosterArtist(
         accessToken,
         trimmed,
         selectedOrgId,

--- a/lib/artists/__tests__/addSpotifyArtist.test.ts
+++ b/lib/artists/__tests__/addSpotifyArtist.test.ts
@@ -29,31 +29,46 @@ describe("addSpotifyArtist", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(createRosterArtist).mockResolvedValue(created as never);
+    vi.mocked(createRosterArtist).mockResolvedValue({ artist: created, created: true } as never);
     vi.mocked(saveArtist).mockResolvedValue({
       artist: { ...created, image: "https://i.scdn.co/image/big" },
     } as never);
   });
 
-  it("creates the artist by name then links its Spotify image + profile URL", async () => {
+  // Row 8 (chat#1889): the server resolves-or-creates the canonical for the
+  // Spotify id and attaches the social itself — the client no longer PATCHes
+  // profileUrls, which is what minted a duplicate row per signup.
+  it("passes the Spotify id to the create and never PATCHes the social", async () => {
     const result = await addSpotifyArtist(token, spotifyArtist, "org-1");
 
     expect(createRosterArtist).toHaveBeenCalledWith(
       token,
       "Del Water Gap",
       "org-1",
+      spotifyArtist.id,
     );
     expect(saveArtist).toHaveBeenCalledWith(token, "acc-1", {
       image: "https://i.scdn.co/image/big",
-      profileUrls: { SPOTIFY: spotifyArtist.external_urls.spotify },
     });
     expect(result.account_id).toBe("acc-1");
   });
 
-  it("omits the image when the Spotify result has none", async () => {
+  it("skips the image PATCH when the Spotify result has none", async () => {
     await addSpotifyArtist(token, { ...spotifyArtist, images: [] });
-    expect(saveArtist).toHaveBeenCalledWith(token, "acc-1", {
-      profileUrls: { SPOTIFY: spotifyArtist.external_urls.spotify },
-    });
+    expect(saveArtist).not.toHaveBeenCalled();
+  });
+
+  // A reused canonical is SHARED state (chat#1866): writing our image onto it
+  // would overwrite metadata every other rostering account sees.
+  it("never writes the image onto a reused canonical", async () => {
+    vi.mocked(createRosterArtist).mockResolvedValue({
+      artist: { id: "canonical-1", account_id: "canonical-1", name: "Del Water Gap" },
+      created: false,
+    } as never);
+
+    const result = await addSpotifyArtist(token, spotifyArtist, "org-1");
+
+    expect(saveArtist).not.toHaveBeenCalled();
+    expect(result.account_id).toBe("canonical-1");
   });
 });

--- a/lib/artists/__tests__/createRosterArtist.test.ts
+++ b/lib/artists/__tests__/createRosterArtist.test.ts
@@ -20,6 +20,7 @@ describe("createRosterArtist", () => {
     const artist = { id: "artist-1", account_id: "artist-1", name: "New Act" };
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
+      status: 201,
       json: vi.fn().mockResolvedValue({ artist }),
     }) as unknown as typeof fetch;
 
@@ -35,12 +36,13 @@ describe("createRosterArtist", () => {
         body: JSON.stringify({ name: "New Act" }),
       }),
     );
-    expect(result).toEqual(artist);
+    expect(result).toEqual({ artist, created: true });
   });
 
   it("includes organization_id when an org is provided", async () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
+      status: 201,
       json: vi.fn().mockResolvedValue({ artist: { id: "a" } }),
     }) as unknown as typeof fetch;
 
@@ -55,6 +57,7 @@ describe("createRosterArtist", () => {
   it("throws the API error message on failure responses", async () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: false,
+      status: 400,
       json: vi
         .fn()
         .mockResolvedValue({ status: "error", error: "name is required" }),
@@ -68,11 +71,33 @@ describe("createRosterArtist", () => {
   it("throws when the response has no artist", async () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
+      status: 201,
       json: vi.fn().mockResolvedValue({}),
     }) as unknown as typeof fetch;
 
     await expect(createRosterArtist(accessToken, "New Act")).rejects.toThrow(
       "Failed to create artist",
     );
+  });
+  // Row 8 (chat#1889): 200 = the API linked an existing canonical.
+  it("reports created: false when the API returns 200 (canonical reused)", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({ artist: { id: "canonical-1" } }),
+    }) as unknown as typeof fetch;
+
+    const result = await createRosterArtist(
+      accessToken,
+      "Del Water Gap",
+      null,
+      "0xPoVNPnxIIUS1vrxAYV00",
+    );
+
+    expect(result.created).toBe(false);
+    const body = JSON.parse(
+      vi.mocked(global.fetch).mock.calls[0][1]?.body as string,
+    );
+    expect(body.spotify_artist_id).toBe("0xPoVNPnxIIUS1vrxAYV00");
   });
 });

--- a/lib/artists/addSpotifyArtist.ts
+++ b/lib/artists/addSpotifyArtist.ts
@@ -4,27 +4,38 @@ import { createRosterArtist } from "@/lib/artists/createRosterArtist";
 import saveArtist from "@/lib/saveArtist";
 
 /**
- * Adds a Spotify-searched artist to the roster with real data: creates the
- * artist by name (`POST /api/artists`, which only accepts a name), then links
- * its Spotify profile URL and avatar image (`PATCH /api/artists/{id}`) so the
- * roster card and reports have the correct image + a Spotify social to enrich.
+ * Adds a Spotify-searched artist to the roster. The API resolves-or-creates
+ * the canonical artist for the Spotify id and attaches its SPOTIFY social
+ * server-side (chat#1889 row 8) — the old client-side profileUrls PATCH is
+ * gone, because create-then-attach here is what minted a duplicate artist row
+ * per signup.
+ *
+ * The avatar is written only when the artist was CREATED (201): a reused
+ * canonical is shared state, and writing our image onto it would overwrite
+ * metadata every other rostering account sees (chat#1866). The image PATCH is
+ * non-fatal — the artist is already on the roster (chat#1892).
  */
 export async function addSpotifyArtist(
   accessToken: string,
   artist: SpotifyArtistSearchResult,
   orgId?: string | null,
 ): Promise<ArtistRecord> {
-  const created = await createRosterArtist(accessToken, artist.name, orgId);
-
-  const imageUrl = artist.images?.[0]?.url;
-  const { artist: updated } = await saveArtist(
+  const { artist: rosterArtist, created } = await createRosterArtist(
     accessToken,
-    created.account_id,
-    {
-      ...(imageUrl ? { image: imageUrl } : {}),
-      profileUrls: { SPOTIFY: artist.external_urls.spotify },
-    },
+    artist.name,
+    orgId,
+    artist.id,
   );
 
-  return updated ?? created;
+  const imageUrl = artist.images?.[0]?.url;
+  if (!created || !imageUrl) return rosterArtist;
+
+  try {
+    const { artist: updated } = await saveArtist(accessToken, rosterArtist.account_id, {
+      image: imageUrl,
+    });
+    return updated ?? rosterArtist;
+  } catch {
+    return rosterArtist;
+  }
 }

--- a/lib/artists/createRosterArtist.ts
+++ b/lib/artists/createRosterArtist.ts
@@ -6,19 +6,32 @@ interface CreateArtistResponse {
   error?: string;
 }
 
+export interface CreateRosterArtistResult {
+  artist: ArtistRecord;
+  /** false when the API linked an existing canonical (HTTP 200) instead of creating (201). */
+  created: boolean;
+}
+
 /**
- * Creates a new artist on the roster via the existing Recoup API
- * `POST /api/artists` endpoint (Privy bearer auth — the owning account
- * is inferred from the token). Mirrors `fetchArtists` / `createTask`.
+ * Creates a new artist on the roster via the Recoup API `POST /api/artists`
+ * endpoint (Privy bearer auth — the owning account is inferred from the
+ * token). With a `spotifyArtistId` the API resolves-or-creates the canonical
+ * artist for that id — one canonical per Spotify id, shared across accounts
+ * (chat#1889 row 8) — and attaches the SPOTIFY social server-side, so callers
+ * must not PATCH it on afterwards.
  */
 export async function createRosterArtist(
   accessToken: string,
   name: string,
   orgId?: string | null,
-): Promise<ArtistRecord> {
+  spotifyArtistId?: string,
+): Promise<CreateRosterArtistResult> {
   const body: Record<string, string> = { name };
   if (orgId) {
     body.organization_id = orgId;
+  }
+  if (spotifyArtistId) {
+    body.spotify_artist_id = spotifyArtistId;
   }
 
   const response = await fetch(`${getClientApiBaseUrl()}/api/artists`, {
@@ -36,5 +49,5 @@ export async function createRosterArtist(
     throw new Error(data.error || "Failed to create artist");
   }
 
-  return data.artist;
+  return { artist: data.artist, created: response.status === 201 };
 }


### PR DESCRIPTION
chat leg of the row-8 trilogy on [chat#1889](https://github.com/recoupable/chat/issues/1889). **Merge order: [docs#278](https://github.com/recoupable/docs/pull/278) → [api#793](https://github.com/recoupable/api/pull/793) → this.** Depends on api#793 being deployed (falls back gracefully — an api without the param ignores it and behaves exactly as today).

- `createRosterArtist` passes `spotify_artist_id`, returns `{ artist, created }` (`created: response.status === 201`)
- `addSpotifyArtist` **drops its client-side `profileUrls` PATCH** — the server attaches the social; the client-side create-then-attach is what minted a duplicate row per signup
- Avatar written only when **created** (a reused canonical is shared state, chat#1866); image PATCH non-fatal (chat#1892)
- `useAddRosterArtist` call-site updated for the new return shape (file is deleted by chat#1900, which stacks after this conceptually but shares no branch)

TDD red→green (3 failed → green); full chat suite **73 files / 275 tests** pass; `tsc` at the 13 baseline; eslint clean. Preview verification after api#793 merges + test-sync: two accounts adding the same Spotify artist must yield one artist row + two roster links (SQL-asserted).

Tracked in chat#1889 (matrix row 8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add artists by Spotify ID via server-side resolve-or-create to ensure one canonical per Spotify artist and prevent duplicate rows. Drops client-side social patching and only writes the avatar when the artist is newly created.

- New Features
  - `createRosterArtist` accepts `spotify_artist_id` and returns `{ artist, created }` (`created` is true on HTTP 201; false on 200).
  - `addSpotifyArtist` passes the ID and only PATCHes the image when `created` is true; image PATCH errors are ignored.
  - `useAddRosterArtist` updated to consume the new return shape.

- Bug Fixes
  - Removed client-side `profileUrls` PATCH that created duplicate artist rows on signup.
  - Avoids overwriting shared canonical images when linking an existing artist.

<sup>Written for commit 3d0a29e8749ccc1007663cf8e5f23f8c918a1348. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Spotify artist imports to recognize existing roster artists and prevent duplicate entries.
  * Newly added Spotify artists can now receive their profile image automatically.
  * Artist creation continues successfully even if saving the profile image fails.
  * Improved consistency when adding artists during onboarding, including more reliable roster refresh and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->