### PR TITLE
fix: Start Free Trial prompts login when signed out and redirects same-tab

### DIFF
--- a/hooks/__tests__/useSubscribeClick.test.tsx
+++ b/hooks/__tests__/useSubscribeClick.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import useSubscribeClick from "@/hooks/useSubscribeClick";
+
+const login = vi.fn();
+const getAccessToken = vi.fn();
+const createClientCheckoutSession = vi.fn();
+const createClientPortalSession = vi.fn();
+const toastError = vi.fn();
+
+let userData: { account_id: string } | null = null;
+let isSubscribed = false;
+
+vi.mock("@privy-io/react-auth", () => ({
+  usePrivy: () => ({ login, getAccessToken }),
+}));
+
+vi.mock("@/providers/UserProvder", () => ({
+  useUserProvider: () => ({ userData }),
+}));
+
+vi.mock("@/providers/PaymentProvider", () => ({
+  usePaymentProvider: () => ({ isSubscribed }),
+}));
+
+vi.mock("@/lib/stripe/createClientCheckoutSession", () => ({
+  default: (...args: unknown[]) => createClientCheckoutSession(...args),
+}));
+
+vi.mock("@/lib/stripe/createClientPortalSession", () => ({
+  default: (...args: unknown[]) => createClientPortalSession(...args),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: (...args: unknown[]) => toastError(...args) },
+}));
+
+describe("useSubscribeClick", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    userData = { account_id: "account-1" };
+    isSubscribed = false;
+    getAccessToken.mockResolvedValue("token-1");
+    createClientCheckoutSession.mockResolvedValue(undefined);
+    createClientPortalSession.mockResolvedValue(undefined);
+  });
+
+  it("opens the Privy login modal when signed out instead of no-oping", async () => {
+    userData = null;
+    const { result } = renderHook(() => useSubscribeClick());
+
+    await act(async () => {
+      await result.current.handleClick();
+    });
+
+    expect(login).toHaveBeenCalled();
+    expect(createClientCheckoutSession).not.toHaveBeenCalled();
+    expect(createClientPortalSession).not.toHaveBeenCalled();
+  });
+
+  it("opens the Privy login modal when no access token is available", async () => {
+    getAccessToken.mockResolvedValue(null);
+    const { result } = renderHook(() => useSubscribeClick());
+
+    await act(async () => {
+      await result.current.handleClick();
+    });
+
+    expect(login).toHaveBeenCalled();
+    expect(createClientCheckoutSession).not.toHaveBeenCalled();
+  });
+
+  it("starts a checkout session for signed-in unsubscribed users", async () => {
+    const { result } = renderHook(() => useSubscribeClick());
+
+    await act(async () => {
+      await result.current.handleClick();
+    });
+
+    expect(createClientCheckoutSession).toHaveBeenCalledWith("token-1");
+    expect(createClientPortalSession).not.toHaveBeenCalled();
+    expect(login).not.toHaveBeenCalled();
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("opens the billing portal for subscribed users", async () => {
+    isSubscribed = true;
+    const { result } = renderHook(() => useSubscribeClick());
+
+    await act(async () => {
+      await result.current.handleClick();
+    });
+
+    expect(createClientPortalSession).toHaveBeenCalledWith("token-1");
+    expect(createClientCheckoutSession).not.toHaveBeenCalled();
+  });
+
+  it("surfaces checkout failures as a toast", async () => {
+    createClientCheckoutSession.mockResolvedValue({
+      error: new Error("HTTP 500"),
+    });
+    const { result } = renderHook(() => useSubscribeClick());
+
+    await act(async () => {
+      await result.current.handleClick();
+    });
+
+    expect(toastError).toHaveBeenCalledWith(
+      "Could not start checkout. Please try again.",
+    );
+  });
+
+  it("surfaces portal failures as a toast", async () => {
+    isSubscribed = true;
+    createClientPortalSession.mockResolvedValue({
+      error: new Error("HTTP 500"),
+    });
+    const { result } = renderHook(() => useSubscribeClick());
+
+    await act(async () => {
+      await result.current.handleClick();
+    });
+
+    expect(toastError).toHaveBeenCalledWith(
+      "Could not open billing. Please try again.",
+    );
+  });
+});

--- a/hooks/useSubscribeClick.ts
+++ b/hooks/useSubscribeClick.ts
@@ -1,26 +1,39 @@
 import { usePrivy } from "@privy-io/react-auth";
+import { toast } from "sonner";
 import { useUserProvider } from "@/providers/UserProvder";
 import { usePaymentProvider } from "@/providers/PaymentProvider";
 import createClientPortalSession from "@/lib/stripe/createClientPortalSession";
 import createClientCheckoutSession from "@/lib/stripe/createClientCheckoutSession";
 
 const useSubscribeClick = () => {
-  const { getAccessToken } = usePrivy();
+  const { getAccessToken, login } = usePrivy();
   const { userData } = useUserProvider();
   const { isSubscribed } = usePaymentProvider();
 
   const handleClick = async () => {
-    if (!userData?.account_id) return;
-
-    const accessToken = await getAccessToken();
-    if (!accessToken) return;
-
-    if (isSubscribed) {
-      await createClientPortalSession(accessToken);
+    if (!userData?.account_id) {
+      login();
       return;
     }
 
-    await createClientCheckoutSession(accessToken);
+    const accessToken = await getAccessToken();
+    if (!accessToken) {
+      login();
+      return;
+    }
+
+    if (isSubscribed) {
+      const result = await createClientPortalSession(accessToken);
+      if (result?.error) {
+        toast.error("Could not open billing. Please try again.");
+      }
+      return;
+    }
+
+    const result = await createClientCheckoutSession(accessToken);
+    if (result?.error) {
+      toast.error("Could not start checkout. Please try again.");
+    }
   };
 
   return {

--- a/lib/stripe/__tests__/createClientCheckoutSession.test.ts
+++ b/lib/stripe/__tests__/createClientCheckoutSession.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import createClientCheckoutSession from "@/lib/stripe/createClientCheckoutSession";
+
+vi.mock("@/lib/api/getClientApiBaseUrl", () => ({
+  getClientApiBaseUrl: () => "https://api.test",
+}));
+
+const fetchMock = vi.fn();
+vi.stubGlobal("fetch", fetchMock);
+
+describe("createClientCheckoutSession", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(window, "location", {
+      value: { href: "https://chat.test/current" },
+      writable: true,
+    });
+  });
+
+  it("navigates same-tab to the checkout URL instead of window.open", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ url: "https://checkout.stripe.com/session-1" }),
+    });
+
+    const result = await createClientCheckoutSession("token-1");
+
+    expect(result).toBeUndefined();
+    expect(window.location.href).toBe("https://checkout.stripe.com/session-1");
+  });
+
+  it("returns an error for non-ok responses", async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500 });
+
+    const result = await createClientCheckoutSession("token-1");
+
+    expect(result?.error).toBeInstanceOf(Error);
+    expect(window.location.href).toBe("https://chat.test/current");
+  });
+
+  it("returns an error when the checkout URL is missing", async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({}) });
+
+    const result = await createClientCheckoutSession("token-1");
+
+    expect(result?.error).toBeInstanceOf(Error);
+  });
+
+  it("returns an error when fetch rejects", async () => {
+    fetchMock.mockRejectedValue(new Error("network down"));
+
+    const result = await createClientCheckoutSession("token-1");
+
+    expect(result?.error).toBeInstanceOf(Error);
+  });
+});

--- a/lib/stripe/__tests__/createClientPortalSession.test.ts
+++ b/lib/stripe/__tests__/createClientPortalSession.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import createClientPortalSession from "@/lib/stripe/createClientPortalSession";
+
+vi.mock("@/lib/api/getClientApiBaseUrl", () => ({
+  getClientApiBaseUrl: () => "https://api.test",
+}));
+
+const fetchMock = vi.fn();
+vi.stubGlobal("fetch", fetchMock);
+
+describe("createClientPortalSession", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(window, "location", {
+      value: { href: "https://chat.test/current" },
+      writable: true,
+    });
+  });
+
+  it("navigates same-tab to the portal URL instead of window.open", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ url: "https://billing.stripe.com/portal-1" }),
+    });
+
+    const result = await createClientPortalSession("token-1");
+
+    expect(result).toBeUndefined();
+    expect(window.location.href).toBe("https://billing.stripe.com/portal-1");
+  });
+
+  it("returns an error for non-ok responses", async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500 });
+
+    const result = await createClientPortalSession("token-1");
+
+    expect(result?.error).toBeInstanceOf(Error);
+    expect(window.location.href).toBe("https://chat.test/current");
+  });
+
+  it("returns an error when the portal URL is missing", async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({}) });
+
+    const result = await createClientPortalSession("token-1");
+
+    expect(result?.error).toBeInstanceOf(Error);
+  });
+});

--- a/lib/stripe/createClientCheckoutSession.ts
+++ b/lib/stripe/createClientCheckoutSession.ts
@@ -25,7 +25,7 @@ const createClientCheckoutSession = async (accessToken: string) => {
       return { error: new Error("Checkout URL missing") };
     }
 
-    window.open(data.url, "_blank", "noopener,noreferrer");
+    window.location.href = data.url;
   } catch (error) {
     return { error };
   }

--- a/lib/stripe/createClientPortalSession.ts
+++ b/lib/stripe/createClientPortalSession.ts
@@ -25,7 +25,7 @@ const createClientPortalSession = async (accessToken: string) => {
       return { error: new Error("Portal URL missing") };
     }
 
-    window.open(data.url, "_blank", "noopener,noreferrer");
+    window.location.href = data.url;
   } catch (error) {
     return { error };
   }


### PR DESCRIPTION
## What

Fixes three bugs in the sidebar "Start Free Trial" / "Manage Subscription" click path (`components/Sidebar/UnlockProCard.tsx` and `components/Sidebar/UserProfileDropdown/ManageSubscriptionButton.tsx`, both via `hooks/useSubscribeClick.ts`):

1. **Signed-out clicks silently no-oped.** `hooks/useSubscribeClick.ts:13` returned early on `if (!userData?.account_id) return;`, so a signed-out visitor clicking Start Free Trial saw nothing happen. The hook now opens the Privy login modal via `login()` from `usePrivy`, both when there is no `account_id` and when `getAccessToken()` yields no token.
2. **Popup blockers killed checkout.** `lib/stripe/createClientCheckoutSession.ts:28` and `lib/stripe/createClientPortalSession.ts:28` called `window.open(url, "_blank")` after an async fetch; real-browser popup blockers block window.open outside the synchronous click handler. Both now navigate same-tab with `window.location.href = data.url`.
3. **Errors were returned but ignored.** The session-creation helpers return `{ error }` on failure and the hook discarded it. Failures now surface as a visible `sonner` error toast ("Could not start checkout. Please try again." / "Could not open billing. Please try again."), matching the toast pattern used across the newer hooks (`hooks/useCreateTask.ts`, `hooks/usePulseToggle.ts`, etc.).

Part of recoupable/chat#1902 (item C2).

## Why

Start Free Trial is a primary conversion CTA. A silent no-op for signed-out users and a popup-blocked checkout tab for signed-in users both read as "the button is broken" and drop the user on the floor with no feedback.

## How to test

1. Signed out: click "Start Free Trial" in the sidebar card. Expected: the Privy login modal opens (previously: nothing happened).
2. Signed in, not subscribed: click "Start Free Trial". Expected: the current tab navigates to Stripe checkout (previously: a new tab that popup blockers often killed).
3. Signed in, subscribed: click "Manage Subscription" in the profile dropdown. Expected: same-tab navigation to the Stripe billing portal.
4. Failure path: block `POST /api/subscriptions/sessions` in devtools and click the button. Expected: an error toast appears (previously: silent failure).
5. Unit tests: `pnpm exec vitest run hooks/__tests__/useSubscribeClick.test.tsx lib/stripe/__tests__` (13 tests, all passing; `pnpm exec tsc --noEmit` clean for the changed files).

Preview verification to follow in a PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Start Free Trial / Manage Subscription click path: signed-out users are prompted to log in, Stripe opens in the same tab, and failures show a toast. This removes silent no-ops and popup-blocked windows to improve conversion.

- **Bug Fixes**
  - Prompt login via `login()` from `@privy-io/react-auth` when no account or access token.
  - Navigate to Stripe in the same tab using `window.location.href` instead of `window.open`.
  - Show `sonner` error toasts for failed checkout/portal session creation.

<sup>Written for commit 1209e16d7312f8400159361a29da8d25326f8642. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authentication prompts when starting checkout or accessing billing.
  * Checkout and billing portal pages now open in the current browser tab.
  * Added clear error notifications when checkout or billing access fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->