### PR TITLE
feat: honor pro-trial checkout intent param on homepage

### DIFF
--- a/__tests__/shouldTriggerCheckoutIntent.test.ts
+++ b/__tests__/shouldTriggerCheckoutIntent.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import shouldTriggerCheckoutIntent from "@/lib/checkout/shouldTriggerCheckoutIntent";
+
+const readyState = {
+  intent: "pro-trial",
+  ready: true,
+  authenticated: true,
+  hasAccount: true,
+  alreadyTriggered: false,
+};
+
+describe("shouldTriggerCheckoutIntent", () => {
+  it("returns checkout when a signed-in user lands with the pro-trial intent", () => {
+    expect(shouldTriggerCheckoutIntent(readyState)).toBe("checkout");
+  });
+
+  it("returns login when the visitor is signed out", () => {
+    expect(
+      shouldTriggerCheckoutIntent({
+        ...readyState,
+        authenticated: false,
+        hasAccount: false,
+      }),
+    ).toBe("login");
+  });
+
+  it("returns none when the intent param is absent", () => {
+    expect(shouldTriggerCheckoutIntent({ ...readyState, intent: null })).toBe(
+      "none",
+    );
+  });
+
+  it("returns none for unknown intent values", () => {
+    expect(
+      shouldTriggerCheckoutIntent({ ...readyState, intent: "free-hats" }),
+    ).toBe("none");
+  });
+
+  it("returns none while Privy is not ready", () => {
+    expect(shouldTriggerCheckoutIntent({ ...readyState, ready: false })).toBe(
+      "none",
+    );
+  });
+
+  it("waits (none) when authenticated but the account has not loaded yet", () => {
+    expect(
+      shouldTriggerCheckoutIntent({ ...readyState, hasAccount: false }),
+    ).toBe("none");
+  });
+
+  it("returns none once the intent was already handled", () => {
+    expect(
+      shouldTriggerCheckoutIntent({ ...readyState, alreadyTriggered: true }),
+    ).toBe("none");
+  });
+
+  it("does not reprompt login after the intent was handled", () => {
+    expect(
+      shouldTriggerCheckoutIntent({
+        ...readyState,
+        authenticated: false,
+        hasAccount: false,
+        alreadyTriggered: true,
+      }),
+    ).toBe("none");
+  });
+});

--- a/components/Home/HomePage.tsx
+++ b/components/Home/HomePage.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import NewChatBootstrap from "../VercelChat/NewChatBootstrap";
 import OnboardingChecklist from "@/components/Onboarding/OnboardingChecklist";
 import { useOnboardingGate } from "@/hooks/useOnboardingGate";
+import useCheckoutIntent from "@/hooks/useCheckoutIntent";
 import { useEffect } from "react";
 import { UIMessage } from "ai";
 
@@ -12,6 +13,7 @@ const HomePage = ({ initialMessages }: { initialMessages?: UIMessage[] }) => {
   const { setFrameReady, isFrameReady } = useMiniKit();
   const router = useRouter();
   const onboarding = useOnboardingGate();
+  useCheckoutIntent();
 
   useEffect(() => {
     if (!isFrameReady) {

--- a/components/Home/__tests__/HomePage.onboarding.test.tsx
+++ b/components/Home/__tests__/HomePage.onboarding.test.tsx
@@ -23,6 +23,12 @@ vi.mock("@/providers/UserProvder", () => ({
   useUserProvider: () => ({ userData: { account_id: "acct-test" } }),
 }));
 
+// Checkout-intent handling is covered by __tests__/shouldTriggerCheckoutIntent.test.ts;
+// this suite only exercises the onboarding gate.
+vi.mock("@/hooks/useCheckoutIntent", () => ({
+  default: () => {},
+}));
+
 vi.mock("@/hooks/useOnboardingState", () => ({
   useOnboardingState: () => ({
     isReady: true,

--- a/hooks/useCheckoutIntent.ts
+++ b/hooks/useCheckoutIntent.ts
@@ -1,0 +1,73 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useSearchParams } from "next/navigation";
+import { usePrivy } from "@privy-io/react-auth";
+import { useUserProvider } from "@/providers/UserProvder";
+import shouldTriggerCheckoutIntent from "@/lib/checkout/shouldTriggerCheckoutIntent";
+import requestCheckoutSessionUrl from "@/lib/stripe/requestCheckoutSessionUrl";
+
+const HANDLED_STORAGE_KEY = "recoup_checkout_intent_handled";
+
+const wasHandled = () => {
+  try {
+    return window.sessionStorage.getItem(HANDLED_STORAGE_KEY) === "true";
+  } catch {
+    return false;
+  }
+};
+
+const markHandled = () => {
+  try {
+    window.sessionStorage.setItem(HANDLED_STORAGE_KEY, "true");
+  } catch {
+    // Storage unavailable; the ref guard still prevents double-firing.
+  }
+};
+
+/**
+ * Carries a `?intent=pro-trial` landing into the Stripe Pro trial checkout.
+ * Signed-in visitors go straight to checkout in the same tab; signed-out
+ * visitors get the Privy login modal and continue automatically after auth.
+ */
+const useCheckoutIntent = () => {
+  const searchParams = useSearchParams();
+  const intent = searchParams.get("intent");
+  const { ready, authenticated, login, getAccessToken } = usePrivy();
+  const { userData } = useUserProvider();
+  const hasAccount = Boolean(userData?.account_id);
+  const hasPromptedLogin = useRef(false);
+  const hasStartedCheckout = useRef(false);
+
+  useEffect(() => {
+    const action = shouldTriggerCheckoutIntent({
+      intent,
+      ready,
+      authenticated,
+      hasAccount,
+      alreadyTriggered: hasStartedCheckout.current || wasHandled(),
+    });
+
+    if (action === "login") {
+      if (hasPromptedLogin.current) return;
+      hasPromptedLogin.current = true;
+      login();
+      return;
+    }
+
+    if (action !== "checkout") return;
+    hasStartedCheckout.current = true;
+    markHandled();
+
+    const startCheckout = async () => {
+      const accessToken = await getAccessToken();
+      if (!accessToken) return;
+      const url = await requestCheckoutSessionUrl(accessToken);
+      if (!url) return;
+      window.location.href = url;
+    };
+    void startCheckout();
+  }, [intent, ready, authenticated, hasAccount, login, getAccessToken]);
+};
+
+export default useCheckoutIntent;

--- a/lib/checkout/shouldTriggerCheckoutIntent.ts
+++ b/lib/checkout/shouldTriggerCheckoutIntent.ts
@@ -1,0 +1,29 @@
+export const PRO_TRIAL_INTENT = "pro-trial";
+
+export type CheckoutIntentAction = "checkout" | "login" | "none";
+
+export interface CheckoutIntentState {
+  intent: string | null;
+  ready: boolean;
+  authenticated: boolean;
+  hasAccount: boolean;
+  alreadyTriggered: boolean;
+}
+
+/**
+ * Decides what the `?intent=pro-trial` landing flow should do next.
+ * Pure so the ordering rules (unknown intent, Privy readiness, auth,
+ * account hydration, double-fire guard) stay unit-testable.
+ */
+const shouldTriggerCheckoutIntent = (
+  state: CheckoutIntentState,
+): CheckoutIntentAction => {
+  if (state.intent !== PRO_TRIAL_INTENT) return "none";
+  if (state.alreadyTriggered) return "none";
+  if (!state.ready) return "none";
+  if (!state.authenticated) return "login";
+  if (!state.hasAccount) return "none";
+  return "checkout";
+};
+
+export default shouldTriggerCheckoutIntent;

--- a/lib/stripe/requestCheckoutSessionUrl.ts
+++ b/lib/stripe/requestCheckoutSessionUrl.ts
@@ -1,0 +1,34 @@
+import { getClientApiBaseUrl } from "@/lib/api/getClientApiBaseUrl";
+
+/**
+ * Creates a Stripe checkout session and returns its URL for same-tab
+ * navigation. The success URL drops the query string so a returning
+ * visitor does not re-enter the intent flow.
+ */
+const requestCheckoutSessionUrl = async (
+  accessToken: string,
+): Promise<string | null> => {
+  try {
+    const successUrl = `${window.location.origin}${window.location.pathname}`;
+    const response = await fetch(
+      `${getClientApiBaseUrl()}/api/subscriptions/sessions`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({ successUrl }),
+      },
+    );
+
+    if (!response.ok) return null;
+
+    const data: { url?: string } = await response.json();
+    return data.url ?? null;
+  } catch {
+    return null;
+  }
+};
+
+export default requestCheckoutSessionUrl;


### PR DESCRIPTION
## What

Visitors landing on `chat.recoupable.dev/?intent=pro-trial` are now carried into the Stripe Pro trial checkout instead of being dropped on the homepage.

- **Signed in**: a checkout session is created (`POST /api/subscriptions/sessions` with the Privy bearer token) and the browser navigates to it same-tab via `window.location.href`.
- **Signed out**: the Privy login modal opens; once auth completes and the account hydrates, the flow continues into checkout automatically.
- **Unknown or absent intent values**: nothing happens.

## Why

Part of recoupable/chat#1902 (web UX conversion audit, item C1). Marketing links can now deep-link straight into the Pro trial purchase instead of losing the visitor on the homepage.

## How

- `lib/checkout/shouldTriggerCheckoutIntent.ts`: pure decision helper encoding the ordering rules (unknown intent, Privy readiness, auth state, account hydration, double-fire guard). Test-driven: the vitest suite was written first and run RED before implementation.
- `lib/stripe/requestCheckoutSessionUrl.ts`: creates the checkout session and returns the URL. The success URL strips the query string so returning from Stripe does not re-enter the intent flow.
- `hooks/useCheckoutIntent.ts`: composed hook reading the `intent` search param, `usePrivy` (`ready`, `authenticated`, `login`, `getAccessToken`), and `useUserProvider`. Double-firing is guarded by refs plus a sessionStorage flag that survives the Stripe round trip. Built alongside (not on top of) `useSubscribeClick`, which a sibling PR is reworking.
- `components/Home/HomePage.tsx`: mounts the hook.

## How to test

1. Open the preview deployment at `/?intent=pro-trial` while signed in: you should be redirected same-tab to a Stripe checkout page for the Pro trial.
2. Open the same URL in a fresh incognito session: the Privy login modal opens; complete sign-in and you should land on the Stripe checkout automatically.
3. Open `/?intent=something-else` and plain `/`: no checkout or login side effects beyond the existing auto-login behavior.
4. Cancel out of Stripe checkout and return: the flow does not re-fire in the same tab session.
5. `pnpm exec vitest run`: 75 files / 284 tests pass, including the 8 new `shouldTriggerCheckoutIntent` cases.

Preview verification to follow in a PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honors the `?intent=pro-trial` param on the homepage to carry visitors straight into the Stripe Pro trial checkout. Supports deep links for marketing and reduces drop-offs. Part of recoupable/chat#1902 (conversion audit, C1).

- **New Features**
  - Added `useCheckoutIntent` to read the `intent` param and `@privy-io/react-auth` state, then trigger login or create a checkout session and same-tab redirect.
  - Introduced a pure, tested `shouldTriggerCheckoutIntent` to handle ordering rules and double-fire guards (ref + sessionStorage).
  - Created checkout sessions via `POST /api/subscriptions/sessions`; success URL strips the query to avoid re-entering the flow.
  - Mounted the hook on `HomePage`. Added focused tests for the decision helper.

<sup>Written for commit 8cd2dac35e2bc88740b77ef1c7f3d1b9c30b954b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1904?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

