### PR TITLE
fix: composer send attempt while signed out reopens login instead of dead-ending

### DIFF
--- a/components/VercelChat/ChatInput.tsx
+++ b/components/VercelChat/ChatInput.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import cn from "classnames";
+import { usePrivy } from "@privy-io/react-auth";
 import { useVercelChatContext } from "@/providers/VercelChatProvider";
+import { getComposerSubmitAction } from "@/lib/chat/getComposerSubmitAction";
 import AttachmentsPreview from "./AttachmentsPreview";
 import PureAttachmentsButton from "./PureAttachmentsButton";
 import { motion } from "framer-motion";
@@ -29,15 +31,29 @@ export function ChatInput() {
     input,
     textAttachments,
   } = useVercelChatContext();
+  const { ready: authReady, authenticated, login } = usePrivy();
   // Allow typing regardless of artist selection
   const isDisabled = false;
   // Block sending until the workspace (session + sandbox) is ready; the
   // input stays typeable so users aren't stuck on a spinner meanwhile.
-  const isSendDisabled =
+  const isSendBlocked =
     isDisabled ||
     hasPendingUploads ||
     isLoadingSignedUrls ||
     workspaceStatus !== "ready";
+  // Allow sending if there are text attachments even without typed input
+  const hasContent = input !== "" || textAttachments.length > 0;
+  const submitAction = getComposerSubmitAction({
+    authReady,
+    authenticated,
+    hasContent,
+    isSendBlocked,
+  });
+  // The workspace never provisions for signed-out visitors, so Send must
+  // stay clickable for them once they have a draft: the attempt reopens
+  // the Privy login modal instead of dead-ending (chat#1902 C4).
+  const isSendDisabled =
+    submitAction === "prompt-login" ? false : isSendBlocked;
 
   const handleSend = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -48,10 +64,14 @@ export function ChatInput() {
       return;
     }
 
-    // Only check input requirements for sending new messages
-    // Allow sending if there are text attachments even without typed input
-    const hasContent = input !== "" || textAttachments.length > 0;
-    if (!hasContent || isSendDisabled) return;
+    // Signed-out send attempt: reopen the login modal. The draft lives in
+    // `input` state above this overlay, so it survives the auth flow.
+    if (submitAction === "prompt-login") {
+      login();
+      return;
+    }
+
+    if (submitAction !== "send") return;
 
     handleSendMessage(event);
   };
@@ -79,7 +99,7 @@ export function ChatInput() {
           className={cn(
             "overflow-visible",
             "rounded-2xl border border-border bg-background/70 backdrop-blur",
-            "shadow-sm"
+            "shadow-sm",
           )}
         >
           <FileMentionsInput
@@ -95,12 +115,19 @@ export function ChatInput() {
             </PromptInputTools>
             <PromptInputSubmit
               disabled={isSendDisabled}
+              aria-label={
+                isGeneratingResponse
+                  ? "Stop response"
+                  : submitAction === "prompt-login"
+                    ? "Sign in to send"
+                    : "Send message"
+              }
               status={status}
               className={cn(
                 "rounded-full hover:scale-105 active:scale-95 transition-all",
                 {
                   "cursor-not-allowed opacity-50": isSendDisabled,
-                }
+                },
               )}
             />
           </PromptInputToolbar>

--- a/lib/chat/__tests__/getComposerSubmitAction.test.ts
+++ b/lib/chat/__tests__/getComposerSubmitAction.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { getComposerSubmitAction } from "@/lib/chat/getComposerSubmitAction";
+
+const signedInReady = {
+  authReady: true,
+  authenticated: true,
+  hasContent: true,
+  isSendBlocked: false,
+};
+
+describe("getComposerSubmitAction", () => {
+  it("sends when authenticated with content and nothing blocking", () => {
+    expect(getComposerSubmitAction(signedInReady)).toBe("send");
+  });
+
+  it("prompts login when a signed-out visitor tries to send (chat#1902 C4)", () => {
+    expect(
+      getComposerSubmitAction({
+        ...signedInReady,
+        authenticated: false,
+      }),
+    ).toBe("prompt-login");
+  });
+
+  it("prompts login even while the workspace is blocked, since it never provisions for anonymous visitors", () => {
+    expect(
+      getComposerSubmitAction({
+        ...signedInReady,
+        authenticated: false,
+        isSendBlocked: true,
+      }),
+    ).toBe("prompt-login");
+  });
+
+  it("stays disabled with an empty composer, signed in or out", () => {
+    expect(
+      getComposerSubmitAction({ ...signedInReady, hasContent: false }),
+    ).toBe("disabled");
+    expect(
+      getComposerSubmitAction({
+        ...signedInReady,
+        authenticated: false,
+        hasContent: false,
+      }),
+    ).toBe("disabled");
+  });
+
+  it("stays disabled while uploads or the workspace block an authenticated send", () => {
+    expect(
+      getComposerSubmitAction({ ...signedInReady, isSendBlocked: true }),
+    ).toBe("disabled");
+  });
+
+  it("stays disabled until Privy is ready, so login() is never called mid-init", () => {
+    expect(
+      getComposerSubmitAction({
+        ...signedInReady,
+        authReady: false,
+        authenticated: false,
+      }),
+    ).toBe("disabled");
+  });
+});

--- a/lib/chat/getComposerSubmitAction.ts
+++ b/lib/chat/getComposerSubmitAction.ts
@@ -1,0 +1,32 @@
+export type ComposerSubmitAction = "send" | "prompt-login" | "disabled";
+
+interface GetComposerSubmitActionParams {
+  /** Privy has finished initializing — login() must never fire before this. */
+  authReady: boolean;
+  authenticated: boolean;
+  /** Typed input or text attachments present. */
+  hasContent: boolean;
+  /** Pending uploads, signed-url loading, or workspace not ready. */
+  isSendBlocked: boolean;
+}
+
+/**
+ * Decides what a composer send attempt (button click or Enter) should do.
+ * Auth is checked before send blockers because the workspace never
+ * provisions for anonymous visitors — without the auth branch a signed-out
+ * visitor who dismissed the login modal hits a permanently disabled Send
+ * with no way forward (chat#1902 C4). "prompt-login" reopens the Privy
+ * modal; the draft stays in component state through the auth flow.
+ */
+export function getComposerSubmitAction({
+  authReady,
+  authenticated,
+  hasContent,
+  isSendBlocked,
+}: GetComposerSubmitActionParams): ComposerSubmitAction {
+  if (!authReady) return "disabled";
+  if (!hasContent) return "disabled";
+  if (!authenticated) return "prompt-login";
+  if (isSendBlocked) return "disabled";
+  return "send";
+}


### PR DESCRIPTION
## What

On chat.recoupable.dev, a signed-out visitor who dismisses the Privy login modal can type in the composer but can never send: the workspace never provisions without auth, so the send button stays permanently disabled and Enter is a silent no-op (`form.requestSubmit()` bails when the default submit button is disabled). This PR turns that dead end into a login reprompt: any send attempt (button click or Enter) while unauthenticated reopens the Privy login modal via `usePrivy().login()`.

Part of recoupable/chat#1902 (item C4).

## How

- New `lib/chat/getComposerSubmitAction.ts`: pure decision function returning `"send" | "prompt-login" | "disabled"`. Auth is checked before workspace blockers, because the workspace never provisions for anonymous visitors; without that ordering the signed-out state is permanently "disabled".
- `components/VercelChat/ChatInput.tsx`: computes the action from `usePrivy()` (`ready`, `authenticated`, `login`) plus the existing context flags. When the action is `prompt-login` the send button stays enabled and the submit handler calls `login()` instead of `handleSendMessage`. Signed-in behavior (workspace gating, stop-while-generating, empty-input no-op) is unchanged. The button also gains a state-accurate `aria-label` ("Sign in to send" / "Send message" / "Stop response").
- `login()` is never called before Privy finishes initializing (`ready` gate in the decision function).

**Draft persistence:** the composer draft is React state (`useState("")` in `hooks/useVercelChat.ts`) inside the `<Chat>` instance, which `NewChatBootstrap` keeps mounted with a stable ref-based id across the provisioning transition. The Privy modal is an overlay, so nothing unmounts: the drafted text survives dismissing and reopening the modal and the full auth flow, and sends normally once the workspace provisions after login.

## How to test

1. Open the preview signed out and dismiss the auto-opened Privy login modal.
2. Type a message in the composer. The send button is now enabled (previously stuck disabled).
3. Click send or press Enter: the Privy login modal reopens and the typed text stays in the composer.
4. Dismiss again, press Enter again: modal reopens again (repeatable, no dead end).
5. Complete login: the draft is still in the composer; once the workspace dot turns green, send works normally.
6. Signed in: empty-input Enter still does nothing, sends still gate on workspace readiness, and the stop button still works mid-response.

Tests: `pnpm exec vitest run` (282 passed, incl. 6 new for `getComposerSubmitAction`); `pnpm exec tsc --noEmit` clean for the changed files.

Preview verification to follow in a PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the signed-out composer dead end: pressing Send or Enter now reopens the Privy login modal and preserves the draft. Addresses recoupable/chat#1902 (C4).

- **Bug Fixes**
  - Added `getComposerSubmitAction` to decide between "send" | "prompt-login" | "disabled", checking auth before workspace blockers.
  - Updated `VercelChat/ChatInput` to call `usePrivy().login()` from `@privy-io/react-auth` on unauthenticated send, keep Send enabled with correct aria-labels, and guard until Privy is ready; drafts persist and signed-in behavior is unchanged.

<sup>Written for commit 2e99f7faa642e7e37606c8c6e53fa34278d9d02c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1905?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

