### PR TITLE
feat: dedupe model picker and gate premium models behind upgrade prompt

### DIFF
--- a/components/ModelSelect/ModelSelect.tsx
+++ b/components/ModelSelect/ModelSelect.tsx
@@ -5,9 +5,11 @@ import {
 } from "../ai-elements/prompt-input";
 import { PromptInputModelSelectContent } from "../ai-elements/prompt-input";
 import { useVercelChatContext } from "@/providers/VercelChatProvider";
-import { isFreeModel } from "@/lib/ai/isFreeModel";
+import { isPremiumModel } from "@/lib/ai/isPremiumModel";
+import { dedupeModels } from "@/lib/ai/dedupeModels";
 import { toast } from "react-toastify";
 import { usePaymentProvider } from "@/providers/PaymentProvider";
+import useSubscribeClick from "@/hooks/useSubscribeClick";
 import { organizeModels } from "@/lib/ai/organizeModels";
 import { getFeaturedModelConfig } from "@/lib/ai/featuredModels";
 import { useMemo } from "react";
@@ -17,9 +19,10 @@ import ModelSelectMaintenance from "./ModelSelectMaintenance";
 const ModelSelect = () => {
   const { model, setModel, availableModels } = useVercelChatContext();
   const { isSubscribed } = usePaymentProvider();
+  const { handleClick: handleSubscribeClick } = useSubscribeClick();
 
   const organizedModels = useMemo(() => {
-    return organizeModels(availableModels);
+    return organizeModels(dedupeModels(availableModels));
   }, [availableModels]);
 
   const selectedModel = availableModels.find((m) => m.id === model);
@@ -30,11 +33,10 @@ const ModelSelect = () => {
 
   const handleModelChange = (value: string) => {
     const selectedModel = availableModels.find((m) => m.id === value);
-    const isModelFree = selectedModel ? isFreeModel(selectedModel) : false;
-    if (!isModelFree && !isSubscribed) {
-      toast.error(
-        "This model is not free. Please upgrade to a paid plan or select a free model."
-      );
+    const isPremium = selectedModel ? isPremiumModel(selectedModel) : true;
+    if (isPremium && !isSubscribed) {
+      toast.info("Upgrade to Pro to use this model.");
+      handleSubscribeClick();
       return;
     }
     setModel(value);

--- a/components/ModelSelect/ModelSelectItem.tsx
+++ b/components/ModelSelect/ModelSelectItem.tsx
@@ -1,26 +1,29 @@
 import { GatewayLanguageModelEntry } from "@ai-sdk/gateway";
 import { PromptInputModelSelectItem } from "../ai-elements/prompt-input";
-import { isFreeModel } from "@/lib/ai/isFreeModel";
-import { Lock, Crown } from "lucide-react";
+import { isPremiumModel } from "@/lib/ai/isPremiumModel";
 import { usePaymentProvider } from "@/providers/PaymentProvider";
 import { getFeaturedModelConfig } from "@/lib/ai/featuredModels";
 import { Tooltip } from "../common/Tooltip";
 
 const ModelSelectItem = ({ model }: { model: GatewayLanguageModelEntry }) => {
   const { isSubscribed } = usePaymentProvider();
-  const isModelFree = isFreeModel(model);
-  const isLocked = !isModelFree && !isSubscribed;
-  const isUnlockedPro = !isModelFree && isSubscribed;
-  
+  const isPremium = isPremiumModel(model);
+  const isLocked = isPremium && !isSubscribed;
+
   // Get featured model config for pills and descriptions
   const featuredConfig = getFeaturedModelConfig(model.id);
 
   const content = (
     <div className="w-full">
       <div className="flex items-center gap-2.5">
-        <span className="font-semibold text-sm text-foreground dark:text-white">{model.name}</span>
-        {isLocked && <Lock className="h-3 w-3 text-muted-foreground dark:text-muted-foreground" />}
-        {isUnlockedPro && <Crown className="h-3 w-3 text-muted-foreground dark:text-muted-foreground" />}
+        <span className="font-semibold text-sm text-foreground dark:text-white">
+          {model.name}
+        </span>
+        {isPremium && (
+          <span className="px-2 py-0.5 text-[10px] font-medium leading-none text-muted-foreground rounded-full border border-border-light">
+            Pro
+          </span>
+        )}
         {featuredConfig?.pill && (
           <span className="px-2.5 py-0.5 text-xs font-medium bg-transparent text-foreground dark:text-muted-foreground rounded-full border border-border-light">
             {featuredConfig.pill}
@@ -41,9 +44,7 @@ const ModelSelectItem = ({ model }: { model: GatewayLanguageModelEntry }) => {
       className={`py-3 ${isLocked ? "opacity-40" : ""}`}
     >
       {featuredConfig?.tooltip ? (
-        <Tooltip content={featuredConfig.tooltip}>
-          {content}
-        </Tooltip>
+        <Tooltip content={featuredConfig.tooltip}>{content}</Tooltip>
       ) : (
         content
       )}

--- a/lib/ai/__tests__/dedupeModels.test.ts
+++ b/lib/ai/__tests__/dedupeModels.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { dedupeModels } from "../dedupeModels";
+import { GatewayLanguageModelEntry } from "@ai-sdk/gateway";
+
+const makeModel = (id: string, name: string) =>
+  ({
+    id,
+    name,
+    specification: {
+      specificationVersion: "v2",
+      provider: id.split("/")[0],
+      modelId: id,
+    },
+  }) as unknown as GatewayLanguageModelEntry;
+
+describe("dedupeModels", () => {
+  it("returns distinct models unchanged and preserves order", () => {
+    const models = [
+      makeModel("openai/gpt-5.5", "GPT-5.5"),
+      makeModel("anthropic/claude-opus-4.8", "Claude Opus 4.8"),
+    ];
+    expect(dedupeModels(models)).toEqual(models);
+  });
+
+  it("drops later entries with a duplicate id", () => {
+    const first = makeModel("openai/gpt-5.2", "GPT 5.2");
+    const dupe = makeModel("openai/gpt-5.2", "GPT 5.2 (alias)");
+    expect(dedupeModels([first, dupe])).toEqual([first]);
+  });
+
+  it("drops alias entries sharing the same display name", () => {
+    const canonical = makeModel(
+      "alibaba/qwen3-235b-a22b-thinking",
+      "Qwen3 VL 235B A22B Thinking",
+    );
+    const alias = makeModel(
+      "alibaba/qwen3-vl-thinking",
+      "Qwen3 VL 235B A22B Thinking",
+    );
+    expect(dedupeModels([canonical, alias])).toEqual([canonical]);
+  });
+
+  it("normalizes case and whitespace when comparing names", () => {
+    const first = makeModel("a/one", "GPT  5.2");
+    const dupe = makeModel("b/two", "gpt 5.2");
+    expect(dedupeModels([first, dupe])).toEqual([first]);
+  });
+
+  it("returns an empty array for empty input", () => {
+    expect(dedupeModels([])).toEqual([]);
+  });
+});

--- a/lib/ai/__tests__/isPremiumModel.test.ts
+++ b/lib/ai/__tests__/isPremiumModel.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { isPremiumModel } from "../isPremiumModel";
+import { GatewayLanguageModelEntry } from "@ai-sdk/gateway";
+
+const makeModel = (pricing?: { input: string; output: string }) =>
+  ({
+    id: "test/model",
+    name: "Test Model",
+    pricing,
+    specification: {
+      specificationVersion: "v2",
+      provider: "test",
+      modelId: "test/model",
+    },
+  }) as unknown as GatewayLanguageModelEntry;
+
+describe("isPremiumModel", () => {
+  it("returns true for expensive frontier pricing", () => {
+    // $15/M input, $75/M output (Opus class)
+    expect(
+      isPremiumModel(makeModel({ input: "0.000015", output: "0.000075" })),
+    ).toBe(true);
+  });
+
+  it("returns false for cheap pricing within the free tier", () => {
+    // $0.40/M input, $1.60/M output
+    expect(
+      isPremiumModel(makeModel({ input: "0.0000004", output: "0.0000016" })),
+    ).toBe(false);
+  });
+
+  it("treats missing pricing as premium", () => {
+    expect(isPremiumModel(makeModel(undefined))).toBe(true);
+  });
+
+  it("treats unparseable pricing as premium", () => {
+    expect(isPremiumModel(makeModel({ input: "n/a", output: "n/a" }))).toBe(
+      true,
+    );
+  });
+});

--- a/lib/ai/dedupeModels.ts
+++ b/lib/ai/dedupeModels.ts
@@ -1,0 +1,25 @@
+import { GatewayLanguageModelEntry } from "@ai-sdk/gateway";
+
+/**
+ * Removes duplicate models from the AI Gateway list.
+ * The gateway exposes alias ids for some models (e.g. alibaba/qwen3-vl-thinking
+ * aliases alibaba/qwen3-235b-a22b-thinking) so ids alone are not enough;
+ * entries are deduped by id and by normalized display name, keeping the
+ * first occurrence.
+ */
+export const dedupeModels = (
+  models: GatewayLanguageModelEntry[],
+): GatewayLanguageModelEntry[] => {
+  const seenIds = new Set<string>();
+  const seenNames = new Set<string>();
+
+  return models.filter((model) => {
+    const normalizedName = model.name.trim().toLowerCase().replace(/\s+/g, " ");
+    if (seenIds.has(model.id) || seenNames.has(normalizedName)) return false;
+    seenIds.add(model.id);
+    seenNames.add(normalizedName);
+    return true;
+  });
+};
+
+export default dedupeModels;

--- a/lib/ai/isPremiumModel.ts
+++ b/lib/ai/isPremiumModel.ts
@@ -1,0 +1,12 @@
+import { GatewayLanguageModelEntry } from "@ai-sdk/gateway";
+import { isFreeModel } from "./isFreeModel";
+
+/**
+ * A model is premium (Pro) when its gateway pricing metadata puts it above
+ * the free tier. Models with missing or unparseable pricing are treated as
+ * premium, matching the existing lock behavior in the model picker.
+ */
+export const isPremiumModel = (model: GatewayLanguageModelEntry): boolean =>
+  !isFreeModel(model);
+
+export default isPremiumModel;


### PR DESCRIPTION
## What

Cleans up the chat model picker for anonymous and free users (item C6 of the web UX conversion audit):

1. **Dedupe the model list.** The AI Gateway list (~200 entries) contains alias ids that render as duplicate rows (e.g. `alibaba/qwen3-235b-a22b-thinking` and `alibaba/qwen3-vl-thinking` both display as "Qwen3 VL 235B A22B Thinking"). New `lib/ai/dedupeModels.ts` dedupes by id and by normalized display name (trim, lowercase, collapse whitespace), keeping the first occurrence. Ids in the live list are unique; the duplicates differ only by alias id, so normalized name is the effective dedupe key.
2. **"Pro" chip on premium models.** New `lib/ai/isPremiumModel.ts` badges every premium model with a small achromatic pill chip (matches the existing featured-pill styling and the DESIGN.md badge spec). Replaces the previous Lock/Crown icons, so the picker now visibly matches the sidebar's "premium AI models" pitch.
3. **Upgrade flow on gated selection.** When a non-subscribed user picks a premium model, the picker no longer just shows an error toast and dead-ends. It keeps the current model selected, shows a short info toast, and triggers the existing upgrade flow (`useSubscribeClick.handleClick`, the same Stripe checkout the sidebar "Start Free Trial" card uses).

## How premium is derived

Tier metadata already exists on the gateway model objects: `pricing.input` / `pricing.output`. `isPremiumModel` is the negation of the existing `isFreeModel` pricing threshold (input <= $0.50/M and output <= $2.50/M is free), so no curated model-id list was needed. Models with missing or unparseable pricing are treated as premium, matching the previous lock behavior.

## Files changed

- `lib/ai/dedupeModels.ts` (new)
- `lib/ai/isPremiumModel.ts` (new)
- `lib/ai/__tests__/dedupeModels.test.ts` (new, 5 tests)
- `lib/ai/__tests__/isPremiumModel.test.ts` (new, 4 tests)
- `components/ModelSelect/ModelSelect.tsx` (dedupe + gate to upgrade flow)
- `components/ModelSelect/ModelSelectItem.tsx` (Pro chip, drop Lock/Crown icons)

## How to test

1. Open the preview signed out (or as a free account) and open the model picker in the chat prompt bar.
2. Search/scroll for "Qwen3 VL 235B A22B Thinking" and "Qwen3 VL 235B A22B Instruct": each appears exactly once.
3. Premium models (Claude Opus, GPT-5.5, Grok, etc.) show a small "Pro" chip; free models (Kimi K3, Gemini Flash) do not.
4. As a non-subscribed user, click a Pro model: the selection does not change, a toast appears, and the Stripe checkout opens in a new tab (signed-out users see the toast only, same as the sidebar card behavior).
5. As a subscribed user, Pro models select normally.

`pnpm exec vitest run`: 76 files / 285 tests passing. `pnpm exec tsc --noEmit`: no errors in changed files.

Part of recoupable/chat#1902.

Preview verification to follow in a PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dedupes the chat model picker and gates premium models behind an upgrade prompt to improve clarity for anonymous and free users. Adds a "Pro" chip and routes gated selections to the existing upgrade flow; addresses C6 in recoupable/chat#1902.

- New Features
  - Remove alias duplicates in the model list by id and normalized display name.
  - Badge premium models with a "Pro" chip based on pricing via `isPremiumModel` (missing/unparseable pricing is treated as premium).
  - For non‑subscribers selecting a premium model: keep current selection, show an info toast, and trigger `useSubscribeClick` (Stripe checkout).

<sup>Written for commit 710182f53e7e89084cf4bc8cbc4994581bac7a27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

