### PR TITLE
feat: custom analytics events for signup, checkout, and report views

### DIFF
--- a/components/Catalog/report/CatalogReportPage.tsx
+++ b/components/Catalog/report/CatalogReportPage.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { ArrowLeft } from "lucide-react";
+import trackEvent from "@/lib/analytics/trackEvent";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import CatalogSongsPageContent from "@/components/Catalog/CatalogSongsPageContent";
 import CatalogReportContent from "./CatalogReportContent";
@@ -17,6 +19,10 @@ interface CatalogReportPageProps {
  */
 const CatalogReportPage = ({ catalogId }: CatalogReportPageProps) => {
   const router = useRouter();
+
+  useEffect(() => {
+    trackEvent("valuation_report_viewed", { catalog_id: catalogId });
+  }, [catalogId]);
 
   return (
     <div className="min-h-screen p-4">

--- a/components/SignInPage/SignInPage.tsx
+++ b/components/SignInPage/SignInPage.tsx
@@ -4,6 +4,7 @@ import { usePrivy } from "@privy-io/react-auth";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
 import Loading from "@/components/Loading";
+import trackSignupStarted from "@/lib/analytics/trackSignupStarted";
 
 export default function SignInPage() {
   const { login, authenticated } = usePrivy();
@@ -15,6 +16,7 @@ export default function SignInPage() {
       return;
     }
 
+    trackSignupStarted("signin_page");
     login();
     // eslint-disable-next-line
   }, [authenticated]);

--- a/components/shared/StartButton.tsx
+++ b/components/shared/StartButton.tsx
@@ -3,6 +3,7 @@
 import { Button } from "@/components/ui/button";
 import { usePrivy } from "@privy-io/react-auth";
 import { useState } from "react";
+import trackSignupStarted from "@/lib/analytics/trackSignupStarted";
 
 export function StartButton() {
   const [isLoading, setIsLoading] = useState(false);
@@ -11,6 +12,7 @@ export function StartButton() {
 
   const handleClick = async () => {
     if (!authenticated) {
+      trackSignupStarted("start_button");
       login();
       return;
     }

--- a/hooks/useAutoLogin.tsx
+++ b/hooks/useAutoLogin.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef } from "react";
 import { usePrivy } from "@privy-io/react-auth";
 import { useUserProvider } from "@/providers/UserProvder";
 import { useMiniAppContext } from "@/providers/MiniAppProvider";
+import trackSignupStarted from "@/lib/analytics/trackSignupStarted";
 
 /** Prompts anonymous visitors to sign in via Privy. Must run under `UserProvider`. */
 export function useAutoLogin() {
@@ -17,6 +18,7 @@ export function useAutoLogin() {
       !email && !hasTriedLogin.current && !isMiniApp && !isMiniAppLoading;
     if (!shouldTryLogin) return;
     hasTriedLogin.current = true;
+    trackSignupStarted("modal_auto");
     login();
   }, [email, login, isMiniApp, isMiniAppLoading]);
 }

--- a/hooks/useTrackSignupCompleted.tsx
+++ b/hooks/useTrackSignupCompleted.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useLogin } from "@privy-io/react-auth";
+import trackEvent from "@/lib/analytics/trackEvent";
+
+/**
+ * Fires the `signup_completed` funnel event when a Privy login flow finishes.
+ * Skips users who entered the app already authenticated (session restore).
+ * No PII in props (chat#1902 C5).
+ */
+export function useTrackSignupCompleted() {
+  useLogin({
+    onComplete: ({ isNewUser, wasAlreadyAuthenticated, loginMethod }) => {
+      if (wasAlreadyAuthenticated) return;
+      trackEvent("signup_completed", {
+        is_new_user: isNewUser,
+        login_method: loginMethod,
+      });
+    },
+  });
+}
+
+export default useTrackSignupCompleted;

--- a/hooks/useUser.tsx
+++ b/hooks/useUser.tsx
@@ -8,6 +8,7 @@ import { toast } from "sonner";
 import { AccountWithDetails } from "@/lib/supabase/accounts/getAccountWithDetails";
 import { ensureAccount } from "@/lib/accounts/ensureAccount";
 import { updateAccountProfile } from "@/lib/accounts/updateAccountProfile";
+import trackSignupStarted from "@/lib/analytics/trackSignupStarted";
 
 const useUser = () => {
   const { login, user, logout, getAccessToken, ready } = usePrivy();
@@ -90,6 +91,7 @@ const useUser = () => {
 
   const isPrepared = () => {
     if (!address) {
+      trackSignupStarted("menu");
       login();
       return false;
     }

--- a/lib/analytics/__tests__/trackEvent.test.ts
+++ b/lib/analytics/__tests__/trackEvent.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { track } from "@vercel/analytics";
+import trackEvent from "@/lib/analytics/trackEvent";
+
+vi.mock("@vercel/analytics", () => ({
+  track: vi.fn(),
+}));
+
+describe("trackEvent", () => {
+  beforeEach(() => {
+    vi.mocked(track).mockReset();
+  });
+
+  it("forwards the event name and props to @vercel/analytics track", () => {
+    trackEvent("signup_started", { source: "menu" });
+
+    expect(track).toHaveBeenCalledTimes(1);
+    expect(track).toHaveBeenCalledWith("signup_started", { source: "menu" });
+  });
+
+  it("forwards the event name alone when no props are given", () => {
+    trackEvent("checkout_opened");
+
+    expect(track).toHaveBeenCalledTimes(1);
+    expect(track).toHaveBeenCalledWith("checkout_opened", undefined);
+  });
+
+  it("never throws when track throws", () => {
+    vi.mocked(track).mockImplementation(() => {
+      throw new Error("analytics unavailable");
+    });
+
+    expect(() => trackEvent("signup_completed", { is_new_user: true })).not.toThrow();
+  });
+});

--- a/lib/analytics/trackEvent.ts
+++ b/lib/analytics/trackEvent.ts
@@ -1,0 +1,18 @@
+import { track } from "@vercel/analytics";
+
+type EventProps = Parameters<typeof track>[1];
+
+/**
+ * Single door for custom Vercel Web Analytics events (chat#1902 C5).
+ * Never include PII (emails, names, wallet addresses) in props.
+ * Swallows analytics failures so tracking can never break product flows.
+ */
+const trackEvent = (name: string, props?: EventProps): void => {
+  try {
+    track(name, props);
+  } catch {
+    // Analytics must never break the product.
+  }
+};
+
+export default trackEvent;

--- a/lib/analytics/trackSignupStarted.ts
+++ b/lib/analytics/trackSignupStarted.ts
@@ -1,0 +1,17 @@
+import trackEvent from "@/lib/analytics/trackEvent";
+
+export type SignupStartedSource =
+  | "menu"
+  | "modal_auto"
+  | "signin_page"
+  | "start_button";
+
+/**
+ * Fires the `signup_started` funnel event. Call immediately before every
+ * programmatic Privy `login()` so each entry point is attributed by source.
+ */
+const trackSignupStarted = (source: SignupStartedSource): void => {
+  trackEvent("signup_started", { source });
+};
+
+export default trackSignupStarted;

--- a/lib/stripe/createClientCheckoutSession.ts
+++ b/lib/stripe/createClientCheckoutSession.ts
@@ -1,4 +1,5 @@
 import { getClientApiBaseUrl } from "@/lib/api/getClientApiBaseUrl";
+import trackEvent from "@/lib/analytics/trackEvent";
 
 const createClientCheckoutSession = async (accessToken: string) => {
   try {
@@ -25,6 +26,7 @@ const createClientCheckoutSession = async (accessToken: string) => {
       return { error: new Error("Checkout URL missing") };
     }
 
+    trackEvent("checkout_opened");
     window.open(data.url, "_blank", "noopener,noreferrer");
   } catch (error) {
     return { error };

--- a/providers/UserProvder.tsx
+++ b/providers/UserProvder.tsx
@@ -2,6 +2,7 @@
 
 import useUser from "@/hooks/useUser";
 import { useAutoLogin } from "@/hooks/useAutoLogin";
+import { useTrackSignupCompleted } from "@/hooks/useTrackSignupCompleted";
 import React, { createContext, useContext, useMemo } from "react";
 
 const UserContext = createContext<ReturnType<typeof useUser>>(
@@ -24,6 +25,7 @@ const UserProvider = ({ children }: { children: React.ReactNode }) => {
 /** Runs auto-login under the provider so `useUserProvider` sees real user state. */
 function UserAutoLogin() {
   useAutoLogin();
+  useTrackSignupCompleted();
   return null;
 }
 


### PR DESCRIPTION
Part of recoupable/chat#1902 (C5 — web UX conversion audit).

chat.recoupable.dev has `@vercel/analytics` installed (`<Analytics/>` in `app/layout.tsx`) but emitted zero custom events, so the signup/checkout funnel was unmeasurable. This PR adds a thin `lib/analytics/trackEvent.ts` wrapper (single door for all future events; forwards name + props to `@vercel/analytics` `track`; never throws; no PII in props) and instruments four funnel events.

## Events

| Event | Trigger | Props |
|-------|---------|-------|
| `signup_started` | Immediately before every programmatic Privy `login()` call, via the `trackSignupStarted(source)` helper | `source`: `menu` (sidebar/menu action gate in `useUser.isPrepared`), `modal_auto` (`useAutoLogin` auto-prompt), `signin_page` (`/signin`), `start_button` (shared StartButton) |
| `signup_completed` | Privy `useLogin` `onComplete` (mounted under `UserProvider`); skipped when `wasAlreadyAuthenticated` (session restore) | `is_new_user` (boolean), `login_method` (string) |
| `checkout_opened` | Stripe checkout session URL received in `lib/stripe/createClientCheckoutSession.ts`, just before the checkout tab opens | none |
| `valuation_report_viewed` | Catalog report page mount (`components/Catalog/report/CatalogReportPage.tsx`, serving `/catalogs/[catalogId]`) | `catalog_id` |

No PII (emails, names, wallet addresses) is included in any event props.

## Files

- `lib/analytics/trackEvent.ts` — new thin wrapper (one exported function)
- `lib/analytics/trackSignupStarted.ts` — new `signup_started` helper with typed `source`
- `lib/analytics/__tests__/trackEvent.test.ts` — new unit tests (TDD, red then green)
- `hooks/useTrackSignupCompleted.tsx` — new hook on Privy `useLogin` `onComplete`
- `providers/UserProvder.tsx` — mounts the completion hook next to auto-login
- `hooks/useAutoLogin.tsx`, `components/SignInPage/SignInPage.tsx`, `components/shared/StartButton.tsx`, `hooks/useUser.tsx` — one `trackSignupStarted(...)` line before each `login()`
- `lib/stripe/createClientCheckoutSession.ts` — one additive `trackEvent("checkout_opened")` line (kept minimal; sibling PRs touch this file)
- `components/Catalog/report/CatalogReportPage.tsx` — mount effect firing `valuation_report_viewed`

## Testing

- `pnpm exec vitest run` — 75 files / 279 tests pass (includes the 3 new `trackEvent` tests: forwards name+props, forwards name alone, never throws when `track` throws)
- `pnpm exec tsc --noEmit` — no errors in changed files (8 pre-existing baseline errors in `SpotifyDeepResearchResult.tsx` / `extractSendEmailResults.test.ts`, untouched by this PR)

## How to verify in the Vercel Web Analytics dashboard

1. Open the Vercel dashboard → `chat` project → **Analytics** → **Events** tab (custom events).
2. On the preview deployment, walk the funnel: land signed-out (fires `signup_started` with `source=modal_auto`), complete the Privy email login (`signup_completed`), open a catalog report at `/catalogs/[catalogId]` (`valuation_report_viewed` with the `catalog_id` prop), and click Subscribe as a non-subscribed user (`checkout_opened`).
3. Each event should appear in the Events panel within a few minutes; use the property filters to break `signup_started` down by `source`.

Note: custom events require the Web Analytics Plus/Pro events feature to be enabled on the project; events fired from preview deployments show under that deployment's environment filter.

Preview verification to follow in a PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds custom analytics events using `@vercel/analytics` to track signup, checkout, and report views. Supports #1902 conversion audit by making the funnel measurable.

- **New Features**
  - Wrapper `trackEvent` for `@vercel/analytics` (single entry point, never throws, no PII).
  - Events: `signup_started` (sources: `menu`, `modal_auto`, `signin_page`, `start_button`), `signup_completed` (props: `is_new_user`, `login_method`), `checkout_opened`, `valuation_report_viewed` (prop: `catalog_id`).

<sup>Written for commit bcc854b9b98d360749d35e6f8aadabc9b418ab13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

