### PR TITLE
feat: email capture on catalog valuation report

### DIFF
--- a/app/api/catalogs/[catalogId]/email-report/__tests__/route.test.ts
+++ b/app/api/catalogs/[catalogId]/email-report/__tests__/route.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { POST } from "../route";
+import { sendCatalogReportEmail } from "@/lib/catalog/emailReport/sendCatalogReportEmail";
+
+vi.mock("@/lib/catalog/emailReport/sendCatalogReportEmail", () => ({
+  sendCatalogReportEmail: vi.fn(),
+}));
+
+const mockSend = vi.mocked(sendCatalogReportEmail);
+
+const CATALOG_ID = "9f3a2c9c-1b2d-4e5f-8a7b-6c5d4e3f2a1b";
+
+const makeRequest = (body: unknown) =>
+  new Request(
+    `http://localhost/api/catalogs/${CATALOG_ID}/email-report`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: typeof body === "string" ? body : JSON.stringify(body),
+    },
+  );
+
+const params = (catalogId: string) => ({
+  params: Promise.resolve({ catalogId }),
+});
+
+describe("POST /api/catalogs/[catalogId]/email-report", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sends the report email and returns 200", async () => {
+    mockSend.mockResolvedValueOnce(true);
+
+    const response = await POST(
+      makeRequest({ email: "fan@example.com", headline_value: 1400000 }),
+      params(CATALOG_ID),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ success: true });
+    expect(mockSend).toHaveBeenCalledWith({
+      email: "fan@example.com",
+      catalogId: CATALOG_ID,
+      headlineValue: 1400000,
+    });
+  });
+
+  it("returns 400 for an invalid email", async () => {
+    const response = await POST(
+      makeRequest({ email: "nope" }),
+      params(CATALOG_ID),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a non-uuid catalog id", async () => {
+    const response = await POST(
+      makeRequest({ email: "fan@example.com" }),
+      params("not-a-uuid"),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a malformed JSON body", async () => {
+    const response = await POST(makeRequest("{nope"), params(CATALOG_ID));
+
+    expect(response.status).toBe(400);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it("returns 502 when the email send fails", async () => {
+    mockSend.mockResolvedValueOnce(false);
+
+    const response = await POST(
+      makeRequest({ email: "fan@example.com" }),
+      params(CATALOG_ID),
+    );
+
+    expect(response.status).toBe(502);
+  });
+});

--- a/app/api/catalogs/[catalogId]/email-report/route.ts
+++ b/app/api/catalogs/[catalogId]/email-report/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { validateEmailReportBody } from "@/lib/catalog/emailReport/validateEmailReportBody";
+import { sendCatalogReportEmail } from "@/lib/catalog/emailReport/sendCatalogReportEmail";
+
+const catalogIdSchema = z.string().uuid();
+
+/**
+ * POST /api/catalogs/[catalogId]/email-report — "Email me this report"
+ * (chat#1902 item C3). Deliberately unauthenticated: the report page is
+ * publicly viewable and this is the page's capture, so anonymous viewers must
+ * be able to use it. Sends the viewer the report link (plus the headline
+ * value they saw) via the chat repo's Resend path. The viewer's email is
+ * used for the send only, never logged.
+ */
+export async function POST(
+  request: Request,
+  context: { params: Promise<{ catalogId: string }> },
+): Promise<NextResponse> {
+  const { catalogId } = await context.params;
+  if (!catalogIdSchema.safeParse(catalogId).success) {
+    return NextResponse.json({ error: "Invalid catalog id" }, { status: 400 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const validated = validateEmailReportBody(body);
+  if (validated.error !== undefined) {
+    return NextResponse.json({ error: validated.error }, { status: 400 });
+  }
+
+  const sent = await sendCatalogReportEmail({
+    email: validated.data.email,
+    catalogId,
+    headlineValue: validated.data.headline_value,
+  });
+  if (!sent) {
+    return NextResponse.json(
+      { error: "Failed to send the report email" },
+      { status: 502 },
+    );
+  }
+
+  return NextResponse.json({ success: true });
+}
+
+export const dynamic = "force-dynamic";

--- a/components/Catalog/report/CatalogReportContent.tsx
+++ b/components/Catalog/report/CatalogReportContent.tsx
@@ -13,6 +13,7 @@ import CatalogReportInsights from "./CatalogReportInsights";
 import CatalogReportCta from "./CatalogReportCta";
 import CatalogReportSkeleton from "./CatalogReportSkeleton";
 import CatalogReportError from "./CatalogReportError";
+import CatalogReportEmailCapture from "./CatalogReportEmailCapture";
 
 interface CatalogReportContentProps {
   catalogId: string;
@@ -46,7 +47,14 @@ const CatalogReportContent = ({ catalogId }: CatalogReportContentProps) => {
     return <CatalogReportSkeleton />;
   }
   if (!measurements) {
-    return <CatalogReportError error={measurementsQuery.error} />;
+    // Anonymous viewers can land here (the measurements query needs auth), so
+    // the capture must still render: the emailed link brings them back.
+    return (
+      <div className="flex flex-col gap-4 max-w-3xl">
+        <CatalogReportError error={measurementsQuery.error} />
+        <CatalogReportEmailCapture catalogId={catalogId} />
+      </div>
+    );
   }
 
   const totalStreams =
@@ -70,6 +78,10 @@ const CatalogReportContent = ({ catalogId }: CatalogReportContentProps) => {
   return (
     <div className="flex flex-col gap-4 max-w-3xl">
       <CatalogValuationCard valuation={valuation} />
+      <CatalogReportEmailCapture
+        catalogId={catalogId}
+        headlineValue={valuation.valueBand.central}
+      />
       <CatalogReportStats
         totalStreams={totalStreams}
         measuredSongCount={measuredSongCount}

--- a/components/Catalog/report/CatalogReportEmailCapture.tsx
+++ b/components/Catalog/report/CatalogReportEmailCapture.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { FormEvent, useState } from "react";
+
+interface CatalogReportEmailCaptureProps {
+  catalogId: string;
+  headlineValue?: number;
+}
+
+/**
+ * "Email me this report" capture (chat#1902 item C3). Works for anonymous
+ * viewers: the route it posts to is unauthenticated, and the valuation stays
+ * fully visible on the page regardless of what happens here (capture
+ * alongside, never in front). Success replaces the form.
+ */
+const CatalogReportEmailCapture = ({
+  catalogId,
+  headlineValue,
+}: CatalogReportEmailCaptureProps) => {
+  const [email, setEmail] = useState("");
+  const [status, setStatus] = useState<"idle" | "sending" | "sent" | "error">(
+    "idle",
+  );
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setStatus("sending");
+    try {
+      const response = await fetch(
+        `/api/catalogs/${catalogId}/email-report`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email, headline_value: headlineValue }),
+        },
+      );
+      setStatus(response.ok ? "sent" : "error");
+    } catch {
+      setStatus("error");
+    }
+  };
+
+  return (
+    <section
+      aria-label="Email me this report"
+      className="rounded-2xl bg-card p-6 sm:p-8 shadow-[0_0_0_1px_var(--border),0_2px_4px_rgba(0,0,0,0.04)]"
+    >
+      {status === "sent" ? (
+        <p className="font-heading text-sm font-bold text-foreground">
+          Report sent. Check your inbox.
+        </p>
+      ) : (
+        <>
+          <h2 className="font-heading text-sm font-bold text-foreground">
+            Email me this report
+          </h2>
+          <p className="mt-1.5 text-sm leading-relaxed text-muted-foreground">
+            Get the link and the headline number in your inbox so you can come
+            back to it anytime.
+          </p>
+          <form
+            onSubmit={handleSubmit}
+            className="mt-4 flex flex-col gap-2 sm:flex-row"
+          >
+            <input
+              type="email"
+              required
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              placeholder="you@example.com"
+              aria-label="Your email address"
+              className="w-full rounded-xl bg-background px-4 py-2.5 text-sm text-foreground shadow-[0_0_0_1px_var(--border)] placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            />
+            <button
+              type="submit"
+              disabled={status === "sending"}
+              className="inline-flex shrink-0 items-center justify-center rounded-xl bg-primary px-5 py-2.5 font-heading text-sm font-semibold text-primary-foreground transition-colors duration-200 hover:opacity-90 disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            >
+              {status === "sending" ? "Sending..." : "Send it"}
+            </button>
+          </form>
+          {status === "error" && (
+            <p role="alert" className="mt-2 text-sm text-muted-foreground">
+              Could not send the email. Check the address and try again.
+            </p>
+          )}
+        </>
+      )}
+    </section>
+  );
+};
+
+export default CatalogReportEmailCapture;

--- a/lib/catalog/emailReport/__tests__/renderReportEmailHtml.test.ts
+++ b/lib/catalog/emailReport/__tests__/renderReportEmailHtml.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { renderReportEmailHtml } from "../renderReportEmailHtml";
+
+const REPORT_URL =
+  "https://chat.recoupable.dev/catalogs/9f3a2c9c-1b2d-4e5f-8a7b-6c5d4e3f2a1b";
+
+describe("renderReportEmailHtml", () => {
+  it("links to the report", () => {
+    const html = renderReportEmailHtml({ reportUrl: REPORT_URL });
+    expect(html).toContain(`href="${REPORT_URL}"`);
+  });
+
+  it("shows the formatted headline value when provided", () => {
+    const html = renderReportEmailHtml({
+      reportUrl: REPORT_URL,
+      headlineValue: 1400000,
+    });
+    expect(html).toContain("$1.4M");
+  });
+
+  it("omits the value line when no headline value is provided", () => {
+    const html = renderReportEmailHtml({ reportUrl: REPORT_URL });
+    expect(html).not.toContain("Estimated catalog value");
+  });
+
+  it("contains no em or en dashes", () => {
+    const html = renderReportEmailHtml({
+      reportUrl: REPORT_URL,
+      headlineValue: 959000,
+    });
+    expect(html).not.toMatch(/[–—]/);
+  });
+});

--- a/lib/catalog/emailReport/__tests__/sendCatalogReportEmail.test.ts
+++ b/lib/catalog/emailReport/__tests__/sendCatalogReportEmail.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { sendCatalogReportEmail } from "../sendCatalogReportEmail";
+import sendEmail from "@/lib/email/sendEmail";
+import { APP_BASE_URL, RECOUP_FROM_EMAIL } from "@/lib/consts";
+
+vi.mock("@/lib/email/sendEmail", () => ({ default: vi.fn() }));
+
+const mockSendEmail = vi.mocked(sendEmail);
+
+const CATALOG_ID = "9f3a2c9c-1b2d-4e5f-8a7b-6c5d4e3f2a1b";
+
+describe("sendCatalogReportEmail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sends from the Recoup address to the viewer with the report link", async () => {
+    mockSendEmail.mockResolvedValueOnce({ ok: true } as Response);
+
+    const sent = await sendCatalogReportEmail({
+      email: "fan@example.com",
+      catalogId: CATALOG_ID,
+      headlineValue: 1400000,
+    });
+
+    expect(sent).toBe(true);
+    expect(mockSendEmail).toHaveBeenCalledTimes(1);
+    const args = mockSendEmail.mock.calls[0][0];
+    expect(args.from).toBe(RECOUP_FROM_EMAIL);
+    expect(args.to).toBe("fan@example.com");
+    expect(args.subject).toContain("$1.4M");
+    expect(args.html).toContain(`${APP_BASE_URL}/catalogs/${CATALOG_ID}`);
+  });
+
+  it("uses a generic subject when no headline value is provided", async () => {
+    mockSendEmail.mockResolvedValueOnce({ ok: true } as Response);
+
+    await sendCatalogReportEmail({
+      email: "fan@example.com",
+      catalogId: CATALOG_ID,
+    });
+
+    const args = mockSendEmail.mock.calls[0][0];
+    expect(args.subject).toBe("Your catalog valuation report");
+  });
+
+  it("returns false when the send fails", async () => {
+    mockSendEmail.mockResolvedValueOnce({ ok: false } as Response);
+
+    const sent = await sendCatalogReportEmail({
+      email: "fan@example.com",
+      catalogId: CATALOG_ID,
+    });
+
+    expect(sent).toBe(false);
+  });
+
+  it("returns false when the send path returns an empty result", async () => {
+    mockSendEmail.mockResolvedValueOnce("");
+
+    const sent = await sendCatalogReportEmail({
+      email: "fan@example.com",
+      catalogId: CATALOG_ID,
+    });
+
+    expect(sent).toBe(false);
+  });
+});

--- a/lib/catalog/emailReport/__tests__/validateEmailReportBody.test.ts
+++ b/lib/catalog/emailReport/__tests__/validateEmailReportBody.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { validateEmailReportBody } from "../validateEmailReportBody";
+
+describe("validateEmailReportBody", () => {
+  it("accepts a valid email and trims whitespace", () => {
+    const result = validateEmailReportBody({ email: "  fan@example.com " });
+    expect(result.data).toEqual({ email: "fan@example.com" });
+    expect(result.error).toBeUndefined();
+  });
+
+  it("accepts an optional positive headline_value", () => {
+    const result = validateEmailReportBody({
+      email: "fan@example.com",
+      headline_value: 1400000,
+    });
+    expect(result.data).toEqual({
+      email: "fan@example.com",
+      headline_value: 1400000,
+    });
+  });
+
+  it("rejects a missing email", () => {
+    const result = validateEmailReportBody({});
+    expect(result.data).toBeUndefined();
+    expect(result.error).toBeTruthy();
+  });
+
+  it("rejects an invalid email", () => {
+    const result = validateEmailReportBody({ email: "not-an-email" });
+    expect(result.data).toBeUndefined();
+    expect(result.error).toBeTruthy();
+  });
+
+  it("rejects a non-numeric headline_value", () => {
+    const result = validateEmailReportBody({
+      email: "fan@example.com",
+      headline_value: "1.4M",
+    });
+    expect(result.data).toBeUndefined();
+    expect(result.error).toBeTruthy();
+  });
+
+  it("rejects a negative headline_value", () => {
+    const result = validateEmailReportBody({
+      email: "fan@example.com",
+      headline_value: -5,
+    });
+    expect(result.data).toBeUndefined();
+    expect(result.error).toBeTruthy();
+  });
+
+  it("rejects a non-object body", () => {
+    const result = validateEmailReportBody("hello");
+    expect(result.data).toBeUndefined();
+    expect(result.error).toBeTruthy();
+  });
+});

--- a/lib/catalog/emailReport/renderReportEmailHtml.ts
+++ b/lib/catalog/emailReport/renderReportEmailHtml.ts
@@ -1,0 +1,35 @@
+import { formatValuationAmount } from "@/lib/catalog/formatValuationAmount";
+
+/**
+ * Renders the "Email me this report" body: the headline value the viewer just
+ * saw (when the report had one) plus a single button back to the live report.
+ * Achromatic house style; every dynamic value is server-built (uuid-derived
+ * URL, number formatted here), so nothing viewer-typed reaches the HTML.
+ */
+export function renderReportEmailHtml(params: {
+  reportUrl: string;
+  headlineValue?: number;
+}): string {
+  const valueBlock =
+    params.headlineValue !== undefined
+      ? `<p style="margin:0 0 4px;font-size:12px;letter-spacing:0.14em;text-transform:uppercase;color:#6b6b6b;">Estimated catalog value</p>
+        <p style="margin:0 0 24px;font-size:40px;font-weight:700;color:#111111;">${formatValuationAmount(params.headlineValue)}</p>`
+      : "";
+
+  return `
+  <div style="max-width:520px;margin:0 auto;padding:32px 24px;font-family:Helvetica,Arial,sans-serif;color:#111111;">
+    <p style="margin:0 0 24px;font-size:14px;line-height:1.6;color:#444444;">
+      Here is the catalog valuation report you asked for. The live report stays
+      up to date as new play counts are measured.
+    </p>
+    ${valueBlock}
+    <a href="${params.reportUrl}"
+       style="display:inline-block;padding:12px 24px;background:#111111;color:#ffffff;text-decoration:none;border-radius:12px;font-size:14px;font-weight:600;">
+      View your report
+    </a>
+    <p style="margin:24px 0 0;font-size:12px;line-height:1.6;color:#6b6b6b;">
+      Directional model, not an appraisal. Sent by Recoup because you requested
+      this report at chat.recoupable.dev.
+    </p>
+  </div>`;
+}

--- a/lib/catalog/emailReport/sendCatalogReportEmail.ts
+++ b/lib/catalog/emailReport/sendCatalogReportEmail.ts
@@ -1,0 +1,35 @@
+import sendEmail from "@/lib/email/sendEmail";
+import { APP_BASE_URL, RECOUP_FROM_EMAIL } from "@/lib/consts";
+import { formatValuationAmount } from "@/lib/catalog/formatValuationAmount";
+import { renderReportEmailHtml } from "@/lib/catalog/emailReport/renderReportEmailHtml";
+
+/**
+ * Sends the catalog report link (and headline value when the viewer's report
+ * had one) to the address an anonymous viewer typed on /catalogs/[catalogId]
+ * (chat#1902 item C3). Goes out through the chat repo's direct Resend path.
+ *
+ * @returns true when Resend accepted the send
+ */
+export async function sendCatalogReportEmail(params: {
+  email: string;
+  catalogId: string;
+  headlineValue?: number;
+}): Promise<boolean> {
+  const reportUrl = `${APP_BASE_URL}/catalogs/${params.catalogId}`;
+  const subject =
+    params.headlineValue !== undefined
+      ? `Your catalog valuation report: ${formatValuationAmount(params.headlineValue)}`
+      : "Your catalog valuation report";
+
+  const response = await sendEmail({
+    from: RECOUP_FROM_EMAIL,
+    to: params.email,
+    subject,
+    html: renderReportEmailHtml({
+      reportUrl,
+      headlineValue: params.headlineValue,
+    }),
+  });
+
+  return typeof response !== "string" && response.ok;
+}

--- a/lib/catalog/emailReport/validateEmailReportBody.ts
+++ b/lib/catalog/emailReport/validateEmailReportBody.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+const emailReportBodySchema = z.object({
+  email: z.string().trim().email().max(320),
+  headline_value: z.number().finite().positive().optional(),
+});
+
+export type EmailReportBody = z.infer<typeof emailReportBodySchema>;
+
+/**
+ * Validates the anonymous "Email me this report" body (chat#1902 item C3).
+ * The endpoint is unauthenticated, so nothing beyond the viewer's own email
+ * and an optional headline number is accepted.
+ */
+export function validateEmailReportBody(
+  body: unknown,
+): { data: EmailReportBody; error?: undefined } | { data?: undefined; error: string } {
+  const result = emailReportBodySchema.safeParse(body);
+  if (!result.success) {
+    return { error: result.error.issues[0]?.message ?? "Invalid body" };
+  }
+  return { data: result.data };
+}


### PR DESCRIPTION
## What

Adds an "Email me this report" capture to the public catalog valuation report page (`/catalogs/[catalogId]`), which previously captured nothing. Part of recoupable/chat#1902 (item C3).

- **`components/Catalog/report/CatalogReportEmailCapture.tsx`** - email input + submit card in the report house style (shadow-as-border, achromatic). Success state replaces the form: "Report sent. Check your inbox."
- **`app/api/catalogs/[catalogId]/email-report/route.ts`** - new deliberately unauthenticated POST route so ANONYMOUS viewers can use it. Validates the catalog id (uuid) and body (zod: email + optional `headline_value`), then sends via the chat repo's existing Resend path (`lib/email/sendEmail` from `RECOUP_FROM_EMAIL`). The viewer's email is used for the send only and is never logged.
- **`lib/catalog/emailReport/`** - `validateEmailReportBody` (zod), `renderReportEmailHtml` (headline value + report link button), `sendCatalogReportEmail` (subject carries the formatted value, e.g. "Your catalog valuation report: $1.4M"). One exported function per file.
- **`CatalogReportContent.tsx`** - mounts the capture directly under the valuation card (capture alongside the number, never in front - the valuation stays fully ungated per the recorded architecture decision), and also on the no-measurements state, since anonymous viewers currently land there (the measurements query requires Privy auth).

## Why an api-side endpoint was not used

Checked the api submodule first: `POST /api/emails` is account-scoped (x-api-key, recipients restricted to the account's own email without a card on file) and api#773's valuation-report email only sends to the owning account on valuation complete. Neither fits an anonymous viewer typing an arbitrary address, so this ships as a thin chat-side route on the chat repo's own Resend integration.

## How to test

1. Open a preview deployment at `/catalogs/<catalogId>` (works logged out).
2. The "Email me this report" card renders under the valuation card (or under the error card when logged out).
3. Submit a valid email: card flips to "Report sent. Check your inbox." and the email arrives from `agent@recoupable.dev` with the headline value in the subject and a button back to the report.
4. Deliberate 4xx probes: `POST /api/catalogs/not-a-uuid/email-report` returns 400; body `{"email":"nope"}` returns 400; malformed JSON returns 400; a Resend failure returns 502.

Tests: `pnpm exec vitest run lib/catalog/emailReport "app/api/catalogs/[catalogId]/email-report"` - 4 files, 20 tests passing (validation, HTML render, send wiring, route status codes). `pnpm exec tsc --noEmit` clean for all files in this PR (remaining errors are the pre-existing `lib/emails/__tests__` baseline).

Preview verification to follow in a PR comment.

Part of recoupable/chat#1902

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds “Email me this report” to the public catalog valuation page so anonymous viewers can email themselves the report link and headline value. Supports recoupable/chat#1902 (C3) by enabling ungated report sharing without login.

- **New Features**
  - Email capture card under the valuation (and on the no-measurements state); success state shows “Report sent. Check your inbox.”
  - New unauthenticated POST `POST /api/catalogs/[catalogId]/email-report` with `zod` validation (UUID catalog id, email, optional `headline_value`); sends via the repo’s `Resend` path from `RECOUP_FROM_EMAIL` and never logs the viewer’s email.
  - Email subject includes the formatted value when provided; HTML body includes the value and a button back to the report.
  - Tests cover body validation, HTML rendering, send wiring, and route status codes.

<sup>Written for commit dd0a20efe0fc0ff2d37607e3b8614806a8a0157d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

