### PR TITLE
fix(nav): the side menu stops contradicting its own auth state (chat#1912 row 2)

### DIFF
--- a/components/Sidebar/SignInSlotButton.tsx
+++ b/components/Sidebar/SignInSlotButton.tsx
@@ -1,0 +1,24 @@
+import { LogIn } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+/**
+ * The sidebar's account slot for a visitor who is not signed in. The slot is
+ * where account state lives, so it offers the way in rather than rendering a
+ * profile skeleton that can never resolve (chat#1912 row 2).
+ */
+const SignInSlotButton = ({ onClick }: { onClick: () => void }) => (
+  <Button
+    variant="ghost"
+    type="button"
+    onClick={onClick}
+    aria-label="Sign in"
+    className="w-full justify-start items-center gap-2 h-9 px-1 rounded-xl border border-transparent hover:border-muted-foreground/20 dark:hover:border-[#444] cursor-pointer"
+  >
+    <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted">
+      <LogIn className="h-3.5 w-3.5" />
+    </div>
+    <span className="text-xs font-medium">Sign in</span>
+  </Button>
+);
+
+export default SignInSlotButton;

--- a/components/Sidebar/UserProfileButton.tsx
+++ b/components/Sidebar/UserProfileButton.tsx
@@ -1,6 +1,8 @@
+import { usePrivy } from "@privy-io/react-auth";
 import { useUserProvider } from "@/providers/UserProvder";
 import { useOrganization } from "@/providers/OrganizationProvider";
 import useAccountOrganizations from "@/hooks/useAccountOrganizations";
+import { getUserProfileState } from "@/lib/auth/getUserProfileState";
 import UserProfileDropdown from "./UserProfileDropdown";
 import UserProfileButtonSkeleton from "./UserProfileButtonSkeleton";
 import {
@@ -13,10 +15,21 @@ import { cn } from "@/lib/utils";
 
 const UserProfileButton = ({ isExpanded = true }: { isExpanded?: boolean }) => {
   const { email, userData } = useUserProvider();
+  const { ready, authenticated } = usePrivy();
   const { selectedOrgId } = useOrganization();
   const { data: organizations } = useAccountOrganizations();
 
-  if (!userData) return <UserProfileButtonSkeleton />;
+  const profileState = getUserProfileState({
+    isPrivyReady: ready,
+    isAuthenticated: authenticated,
+    hasUserData: !!userData,
+  });
+
+  // A signed-out visitor has no profile to load, so the slot stays empty
+  // rather than showing a skeleton that never resolves next to a Sign In
+  // button (chat#1912 row 2).
+  if (profileState === "signed-out") return null;
+  if (profileState === "loading") return <UserProfileButtonSkeleton />;
 
   const userName = userData?.name || email || userData?.wallet || "";
   const userImage = userData?.image;

--- a/components/Sidebar/UserProfileButton.tsx
+++ b/components/Sidebar/UserProfileButton.tsx
@@ -5,6 +5,7 @@ import useAccountOrganizations from "@/hooks/useAccountOrganizations";
 import { getUserProfileState } from "@/lib/auth/getUserProfileState";
 import UserProfileDropdown from "./UserProfileDropdown";
 import UserProfileButtonSkeleton from "./UserProfileButtonSkeleton";
+import SignInSlotButton from "./SignInSlotButton";
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -14,7 +15,7 @@ import { ChevronDown } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const UserProfileButton = ({ isExpanded = true }: { isExpanded?: boolean }) => {
-  const { email, userData } = useUserProvider();
+  const { email, userData, address, login } = useUserProvider();
   const { ready, authenticated } = usePrivy();
   const { selectedOrgId } = useOrganization();
   const { data: organizations } = useAccountOrganizations();
@@ -22,13 +23,13 @@ const UserProfileButton = ({ isExpanded = true }: { isExpanded?: boolean }) => {
   const profileState = getUserProfileState({
     isPrivyReady: ready,
     isAuthenticated: authenticated,
+    hasWallet: !!address,
     hasUserData: !!userData,
   });
 
-  // A signed-out visitor has no profile to load, so the slot stays empty
-  // rather than showing a skeleton that never resolves next to a Sign In
-  // button (chat#1912 row 2).
-  if (profileState === "signed-out") return null;
+  // A signed-out visitor has no profile to load, so the slot offers the way in
+  // rather than a skeleton that can never resolve (chat#1912 row 2).
+  if (profileState === "signed-out") return <SignInSlotButton onClick={login} />;
   if (profileState === "loading") return <UserProfileButtonSkeleton />;
 
   const userName = userData?.name || email || userData?.wallet || "";
@@ -46,8 +47,6 @@ const UserProfileButton = ({ isExpanded = true }: { isExpanded?: boolean }) => {
   const primaryName = isOrgSelected
     ? selectedOrg.organization_name || "Organization"
     : userName;
-
-  const secondaryName = isOrgSelected ? userName : "Personal";
 
   const avatarImage = isOrgSelected
     ? selectedOrg.organization_image

--- a/components/Sidebar/__tests__/UserProfileButton.test.tsx
+++ b/components/Sidebar/__tests__/UserProfileButton.test.tsx
@@ -1,12 +1,17 @@
 // @vitest-environment jsdom
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import UserProfileButton from "@/components/Sidebar/UserProfileButton";
 
+const login = vi.hoisted(() => vi.fn());
 const privy = { ready: true, authenticated: false };
-const user: { userData: { name?: string; account_id?: string } | null; email?: string } =
-  { userData: null, email: undefined };
+const user: {
+  userData: { name?: string; account_id?: string } | null;
+  email?: string;
+  address?: string;
+  login: () => void;
+} = { userData: null, email: undefined, address: undefined, login };
 
 vi.mock("@privy-io/react-auth", () => ({
   usePrivy: () => privy,
@@ -30,15 +35,25 @@ describe("UserProfileButton", () => {
     privy.authenticated = false;
     user.userData = null;
     user.email = undefined;
+    user.address = undefined;
+    login.mockClear();
   });
 
-  // chat#1912 row 2 — the defect a referred first-time visitor hit on 2026-07-29.
-  it("renders nothing for a signed-out visitor", () => {
-    const { container } = render(<UserProfileButton />);
+  // chat#1912 row 2 — the defect a referred first-time visitor hit on 2026-07-29:
+  // a profile skeleton that could never resolve, pinned under a Sign In button.
+  it("offers a sign-in button to a signed-out visitor, never a skeleton", () => {
+    render(<UserProfileButton />);
 
     expect(screen.queryByLabelText(/loading user profile/i)).toBeNull();
-    expect(screen.queryByRole("button")).toBeNull();
-    expect(container.innerHTML).toBe("");
+    expect(screen.getByRole("button", { name: /sign in/i })).toBeDefined();
+  });
+
+  it("opens the login prompt when the signed-out slot is clicked", () => {
+    render(<UserProfileButton />);
+
+    fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
+
+    expect(login).toHaveBeenCalled();
   });
 
   it("shows the skeleton only while an authenticated session is still loading", () => {

--- a/components/Sidebar/__tests__/UserProfileButton.test.tsx
+++ b/components/Sidebar/__tests__/UserProfileButton.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import UserProfileButton from "@/components/Sidebar/UserProfileButton";
+
+const privy = { ready: true, authenticated: false };
+const user: { userData: { name?: string; account_id?: string } | null; email?: string } =
+  { userData: null, email: undefined };
+
+vi.mock("@privy-io/react-auth", () => ({
+  usePrivy: () => privy,
+}));
+vi.mock("@/providers/UserProvder", () => ({
+  useUserProvider: () => user,
+}));
+vi.mock("@/providers/OrganizationProvider", () => ({
+  useOrganization: () => ({ selectedOrgId: null }),
+}));
+vi.mock("@/hooks/useAccountOrganizations", () => ({
+  default: () => ({ data: [] }),
+}));
+vi.mock("@/components/Sidebar/UserProfileDropdown", () => ({
+  default: () => null,
+}));
+
+describe("UserProfileButton", () => {
+  beforeEach(() => {
+    privy.ready = true;
+    privy.authenticated = false;
+    user.userData = null;
+    user.email = undefined;
+  });
+
+  // chat#1912 row 2 — the defect a referred first-time visitor hit on 2026-07-29.
+  it("renders nothing for a signed-out visitor", () => {
+    const { container } = render(<UserProfileButton />);
+
+    expect(screen.queryByLabelText(/loading user profile/i)).toBeNull();
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("shows the skeleton only while an authenticated session is still loading", () => {
+    privy.authenticated = true;
+
+    render(<UserProfileButton />);
+
+    expect(screen.getByLabelText(/loading user profile/i)).toBeDefined();
+  });
+
+  it("shows the skeleton before Privy resolves", () => {
+    privy.ready = false;
+
+    render(<UserProfileButton />);
+
+    expect(screen.getByLabelText(/loading user profile/i)).toBeDefined();
+  });
+
+  it("renders the account chip once the session and account have loaded", () => {
+    privy.authenticated = true;
+    user.userData = { name: "Ben", account_id: "acc_1" };
+
+    render(<UserProfileButton />);
+
+    expect(screen.getByRole("button", { name: /open user menu/i })).toBeDefined();
+    expect(screen.queryByLabelText(/loading user profile/i)).toBeNull();
+  });
+});

--- a/lib/auth/__tests__/getUserProfileState.test.ts
+++ b/lib/auth/__tests__/getUserProfileState.test.ts
@@ -11,9 +11,39 @@ describe("getUserProfileState", () => {
       getUserProfileState({
         isPrivyReady: true,
         isAuthenticated: false,
+        hasWallet: false,
         hasUserData: false,
       }),
     ).toBe("signed-out");
+  });
+
+  /**
+   * Review finding (codex P2 / cubic P2, 2026-07-30). A Farcaster mini-app
+   * visitor is a real signed-in user with no Privy session: useAutoLogin skips
+   * Privy login when isMiniApp, while useUser still bootstraps the account from
+   * the wagmi address. Gating on Privy's flag alone would have hidden their
+   * profile chip entirely — a regression, not the bug this PR set out to fix.
+   */
+  it("treats a wallet-only session as signed in", () => {
+    expect(
+      getUserProfileState({
+        isPrivyReady: true,
+        isAuthenticated: false,
+        hasWallet: true,
+        hasUserData: true,
+      }),
+    ).toBe("ready");
+  });
+
+  it("is loading for a wallet-only session whose account is still fetching", () => {
+    expect(
+      getUserProfileState({
+        isPrivyReady: true,
+        isAuthenticated: false,
+        hasWallet: true,
+        hasUserData: false,
+      }),
+    ).toBe("loading");
   });
 
   it("stays signed-out even if stale account data lingers", () => {
@@ -23,6 +53,7 @@ describe("getUserProfileState", () => {
       getUserProfileState({
         isPrivyReady: true,
         isAuthenticated: false,
+        hasWallet: false,
         hasUserData: true,
       }),
     ).toBe("signed-out");
@@ -33,6 +64,7 @@ describe("getUserProfileState", () => {
       getUserProfileState({
         isPrivyReady: false,
         isAuthenticated: false,
+        hasWallet: false,
         hasUserData: false,
       }),
     ).toBe("loading");
@@ -43,6 +75,7 @@ describe("getUserProfileState", () => {
       getUserProfileState({
         isPrivyReady: true,
         isAuthenticated: true,
+        hasWallet: false,
         hasUserData: false,
       }),
     ).toBe("loading");
@@ -53,6 +86,7 @@ describe("getUserProfileState", () => {
       getUserProfileState({
         isPrivyReady: true,
         isAuthenticated: true,
+        hasWallet: false,
         hasUserData: true,
       }),
     ).toBe("ready");

--- a/lib/auth/__tests__/getUserProfileState.test.ts
+++ b/lib/auth/__tests__/getUserProfileState.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { getUserProfileState } from "@/lib/auth/getUserProfileState";
+
+describe("getUserProfileState", () => {
+  // chat#1912 row 2. A signed-out visitor saw "Sign In" at the top of the side
+  // menu AND a user-profile skeleton pinned at the bottom, still both present
+  // 12s later — the skeleton can never resolve because there is no account to
+  // load. Reported by a referred first-time visitor 2026-07-29.
+  it("is signed-out when Privy has resolved with no session", () => {
+    expect(
+      getUserProfileState({
+        isPrivyReady: true,
+        isAuthenticated: false,
+        hasUserData: false,
+      }),
+    ).toBe("signed-out");
+  });
+
+  it("stays signed-out even if stale account data lingers", () => {
+    // Guards the logout path: the chip must disappear the moment the session
+    // goes, not linger until React Query evicts the account.
+    expect(
+      getUserProfileState({
+        isPrivyReady: true,
+        isAuthenticated: false,
+        hasUserData: true,
+      }),
+    ).toBe("signed-out");
+  });
+
+  it("is loading while Privy has not resolved yet", () => {
+    expect(
+      getUserProfileState({
+        isPrivyReady: false,
+        isAuthenticated: false,
+        hasUserData: false,
+      }),
+    ).toBe("loading");
+  });
+
+  it("is loading for an authenticated session whose account is still fetching", () => {
+    expect(
+      getUserProfileState({
+        isPrivyReady: true,
+        isAuthenticated: true,
+        hasUserData: false,
+      }),
+    ).toBe("loading");
+  });
+
+  it("is ready once the authenticated account has loaded", () => {
+    expect(
+      getUserProfileState({
+        isPrivyReady: true,
+        isAuthenticated: true,
+        hasUserData: true,
+      }),
+    ).toBe("ready");
+  });
+});

--- a/lib/auth/getUserProfileState.ts
+++ b/lib/auth/getUserProfileState.ts
@@ -3,6 +3,13 @@ export type UserProfileState = "loading" | "signed-out" | "ready";
 interface UserProfileStateInput {
   isPrivyReady: boolean;
   isAuthenticated: boolean;
+  /**
+   * A connected wallet counts as a session on its own. Farcaster mini-app
+   * visitors never get a Privy session — `useAutoLogin` skips login when
+   * `isMiniApp` — yet `useUser` bootstraps their account from the wagmi
+   * address, so gating on Privy alone would hide a real user's profile.
+   */
+  hasWallet: boolean;
   hasUserData: boolean;
 }
 
@@ -18,9 +25,10 @@ interface UserProfileStateInput {
 export function getUserProfileState({
   isPrivyReady,
   isAuthenticated,
+  hasWallet,
   hasUserData,
 }: UserProfileStateInput): UserProfileState {
   if (!isPrivyReady) return "loading";
-  if (!isAuthenticated) return "signed-out";
+  if (!isAuthenticated && !hasWallet) return "signed-out";
   return hasUserData ? "ready" : "loading";
 }

--- a/lib/auth/getUserProfileState.ts
+++ b/lib/auth/getUserProfileState.ts
@@ -1,0 +1,26 @@
+export type UserProfileState = "loading" | "signed-out" | "ready";
+
+interface UserProfileStateInput {
+  isPrivyReady: boolean;
+  isAuthenticated: boolean;
+  hasUserData: boolean;
+}
+
+/**
+ * Decides what the sidebar's user slot should render.
+ *
+ * "signed-out" exists as a distinct state because rendering a loading skeleton
+ * for a visitor with no session produces a menu that contradicts itself — a
+ * Sign In button above a profile chip that can never resolve (chat#1912 row 2).
+ * Authentication is the gate, not the presence of account data, so a session
+ * that has just been torn down reads as signed-out immediately.
+ */
+export function getUserProfileState({
+  isPrivyReady,
+  isAuthenticated,
+  hasUserData,
+}: UserProfileStateInput): UserProfileState {
+  if (!isPrivyReady) return "loading";
+  if (!isAuthenticated) return "signed-out";
+  return hasUserData ? "ready" : "loading";
+}


### PR DESCRIPTION
Closes row 2 of [chat#1912](https://github.com/recoupable/chat/issues/1912).

## Why

Reproduced on prod 2026-07-30 at 390px, **signed out**: the opened side menu shows a **Sign In** button at the top and, at the bottom of the same panel, the user-chip slot rendering a **permanently loading skeleton** (accessible name `Loading user profile`, `disabled`). Still both present **12 seconds later** — a first-time visitor is told to sign in and simultaneously shown a profile chip loading forever for an account that does not exist.

Root cause, [`UserProfileButton.tsx`](https://github.com/recoupable/chat/blob/main/components/Sidebar/UserProfileButton.tsx):

```ts
if (!userData) return <UserProfileButtonSkeleton />;
```

`userData` is absent in two very different situations — "authenticated, account still fetching" and "nobody is signed in" — and both rendered the skeleton. For the signed-out case nothing ever arrives to resolve it.

Originally reported by a referred first-time visitor, relayed by a live outreach customer on 2026-07-29 ("I put someone else into your site and they had issues with the side menu").

## What changed

- New `lib/auth/getUserProfileState.ts` — a pure `loading | signed-out | ready` decision, gated on Privy's `authenticated` flag rather than on the presence of account data.
- `UserProfileButton` renders **nothing** when signed out, the skeleton only while genuinely loading, the chip when ready.

Gating on `authenticated` rather than `!!userData` also fixes the logout path: the chip disappears the moment the session goes, instead of lingering until the account query is evicted. There is a test for that.

## Scope note

The issue also recorded a **signed-in** variant of this bug (Sign In alongside the authenticated avatar chip, plus a Privy `already logged in` warning). That state **did not reproduce** across normal load, Slow 3G + 4x CPU throttling, and force-opening the menu on first paint — details in the issue. This PR fixes the variant that does reproduce. The original sighting is un-reproduced, not disproven, so row 2 should be re-checked against the preview before it is closed.

## Tests

TDD red→green, two files:

- `lib/auth/__tests__/getUserProfileState.test.ts` — 5 cases (RED: module not found), including the stale-data-after-logout guard.
- `components/Sidebar/__tests__/UserProfileButton.test.tsx` — 4 cases. The signed-out case was **RED against the real defect** (`expected <button …> to be null`), the other three green throughout, proving the loading and ready paths are unchanged.

Full suite **291 passed / 77 files**, `tsc --noEmit` clean.

## Verification

Preview verification against the issue's **Works when** script (390px signed-out, the 15s re-check, signed-in, console) will be posted as a PR comment once the preview builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the side menu so signed-out users no longer see a stuck profile skeleton next to Sign In, the profile chip disappears immediately on logout, and the account slot now offers Sign in. Wallet-only users (e.g. mini-app) keep their profile chip. Addresses chat#1912 row 2.

- **Bug Fixes**
  - Updated `lib/auth/getUserProfileState` to decide `loading | signed-out | ready` using `@privy-io/react-auth` readiness/auth plus wallet presence, not `userData`. Treats wallet-only sessions as signed in and marks logout as signed-out immediately.
  - Updated `UserProfileButton` to render `SignInSlotButton` when signed out, show a skeleton only while loading, and keep the chip for wallet-only users.
  - Added tests for the helper and component covering signed-out, loading, ready, logout, wallet-only, and click-to-login.

<sup>Written for commit f140e5d15f0986a54b66295c4b78f3e7f75bc559. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1914?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

