### PR TITLE
fix(hydration): stop the mobile media query running during hydration (chat#1912 row 5)

### DIFF
--- a/hooks/__tests__/useIsMobile.test.tsx
+++ b/hooks/__tests__/useIsMobile.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import useIsMobile from "@/hooks/useIsMobile";
+
+const useMediaQuery = vi.hoisted(() => vi.fn(() => false));
+
+vi.mock("usehooks-ts", () => ({ useMediaQuery }));
+
+describe("useIsMobile", () => {
+  /**
+   * chat#1912 row 5. usehooks-ts defaults `initializeWithValue` to true, which
+   * evaluates window.matchMedia during the very first render — including the
+   * hydration render. The server has no matchMedia and renders the desktop
+   * branch, so on a narrow viewport the client's first render disagreed and
+   * Header emitted an extra "Add Your Artist" button the server never sent.
+   * React threw #418 and regenerated the whole tree on every page load.
+   */
+  it("does not evaluate the media query during the hydration render", () => {
+    renderHook(() => useIsMobile());
+
+    expect(useMediaQuery).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ initializeWithValue: false }),
+    );
+  });
+
+  it("keeps the 768px breakpoint", () => {
+    renderHook(() => useIsMobile());
+
+    expect(useMediaQuery).toHaveBeenCalledWith(
+      "(max-width: 768px)",
+      expect.anything(),
+    );
+  });
+
+  it("returns what the media query reports", () => {
+    useMediaQuery.mockReturnValue(true);
+
+    const { result } = renderHook(() => useIsMobile());
+
+    expect(result.current).toBe(true);
+  });
+});

--- a/hooks/useIsMobile.tsx
+++ b/hooks/useIsMobile.tsx
@@ -1,7 +1,21 @@
 import { useMediaQuery } from "usehooks-ts";
 
+/**
+ * Viewport check for the mobile breakpoint.
+ *
+ * `initializeWithValue: false` is required, not cosmetic. usehooks-ts defaults
+ * it to true, which evaluates `window.matchMedia` during the first render —
+ * including the hydration render. The server has no matchMedia and renders the
+ * desktop branch, so on a narrow viewport the client's first render disagreed
+ * and `Header` emitted an "Add Your Artist" button the server never sent.
+ * React treated that as a hydration mismatch (#418) and regenerated the entire
+ * tree on every page load (chat#1912 row 5). With this off the first render
+ * matches the server, and the real value arrives in an effect.
+ */
 const useIsMobile = () => {
-  const isMobile = useMediaQuery("(max-width: 768px)");
+  const isMobile = useMediaQuery("(max-width: 768px)", {
+    initializeWithValue: false,
+  });
 
   return isMobile;
 };


### PR DESCRIPTION
Closes row 5 of [chat#1912](https://github.com/recoupable/chat/issues/1912).

## Why

`Uncaught Error: Minified React error #418` fires on **every cold load**, signed out and signed in, on `/` and `/catalogs/{id}`. React regenerates the entire tree on the client each time, so the whole app pays a full re-render on first paint.

The error's args are `["HTML", ""]`, which in React 19's [`throwOnHydrationMismatch`](https://github.com/facebook/react/blob/main/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js) is `fromText ? "text" : "HTML"` — an **element** mismatch, not a text one. That ruled out the usual suspects (`Date` formatting, locale, `Math.random()`), and SSR output was confirmed byte-identical across fetches, so the server was not the variable side.

Reproducing against a **dev build** made React name the node:

```
<Header>
  <div className="z-[50] fix...">
    <button>
+   <button
+     type="button"
+     onClick={function handleAddArtist}
+     aria-label="Add a new artist"
+   >
```

The `+` is client-only output. [`Header.tsx`](https://github.com/recoupable/chat/blob/main/components/Header/Header.tsx#L52) renders that button behind `isMobile && !isArtistSelected`, and `useIsMobile` wraps usehooks-ts `useMediaQuery`, whose `initializeWithValue` **defaults to `true`**:

```js
const [matches, setMatches] = useState(() => {
  if (initializeWithValue) return getMatches(query); // window.matchMedia, during the first render
  return defaultValue;
});
```

On the server `getMatches` returns `defaultValue` (`false`); on the client the *hydration* render already evaluates `matchMedia`, so at any viewport under 768px the two renders disagree and an extra `<button>` appears. Nothing about this is mobile-only in consequence: the mismatch regenerates the whole tree for that visitor.

## What changed

One option on `hooks/useIsMobile.tsx`: `initializeWithValue: false`. The first render now matches the server, and the real viewport value arrives via the hook's existing layout effect — so the mobile UI still appears immediately, it just no longer contradicts the server's HTML.

`components/Sidebar/RecentChats/useRecentChats.ts` uses a different hook (`useMobileDetection`) which is already effect-based and correct, so it needed no change.

## Verification

Reproduced and fixed against a local dev build at a 500px viewport:

| | Before | After |
|---|---|---|
| `/` cold load | `Hydration failed because the server rendered HTML didn't match the client` + the `<Header>` diff above | **no hydration error** |
| `/catalogs` cold load | same | **no hydration error** |

The only console error remaining on localhost is Privy's `frame-ancestors` CSP rejection, which is expected off-domain and unrelated.

## Tests

`hooks/__tests__/useIsMobile.test.tsx` — 3 cases, TDD red→green. The first two were RED against the real defect (the hook called `useMediaQuery` with no options object). They assert the hook does not evaluate the query during the hydration render, keeps the 768px breakpoint, and returns what the query reports.

Full suite **285 passed / 76 files**, `tsc --noEmit` clean.

## Verification on preview

The issue's **Works when** script (cold, signed-out loads of `/`, `/catalogs`, `/catalogs/{id}`, console clean of #418 / #423 / #425) will be re-run against the preview and posted as a PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent the mobile media query from running during hydration to stop React hydration mismatches (#418). Fixes chat#1912 row 5 and removes the full re-render on cold loads of `/` and `/catalogs`.

- **Bug Fixes**
  - Use `useMediaQuery("(max-width: 768px)", { initializeWithValue: false })` from `usehooks-ts` in `useIsMobile` so the first client render matches SSR and no extra Header button appears on narrow viewports.
  - Add tests for `useIsMobile` to assert no query during hydration, the 768px breakpoint, and that the return mirrors the query.

<sup>Written for commit c702c1034f89f5f3d9ba9c088bb785edb2642b69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile and desktop layout detection during initial page loading.
  * Prevented hydration mismatches and visual differences between server-rendered and client-rendered content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->