### PR TITLE
fix(catalog): cross-account copy stops promising the songs tab (chat#1912 row 6)

### DIFF
--- a/components/Catalog/report/CatalogReportContent.tsx
+++ b/components/Catalog/report/CatalogReportContent.tsx
@@ -27,7 +27,7 @@ interface CatalogReportContentProps {
  * this component only renders what that state describes.
  */
 const CatalogReportContent = ({ catalogId }: CatalogReportContentProps) => {
-  const { state, measurements, songs, totalSongs } =
+  const { state, measurements, songs, totalSongs, hasOwnCatalogs } =
     useCatalogReport(catalogId);
 
   const releases = useMemo(
@@ -37,7 +37,12 @@ const CatalogReportContent = ({ catalogId }: CatalogReportContentProps) => {
 
   if (state === "loading") return <CatalogReportSkeleton />;
   if (state !== "ready" || !measurements) {
-    return <CatalogReportEmptyState state={state === "ready" ? "error" : state} />;
+    return (
+      <CatalogReportEmptyState
+        state={state === "ready" ? "error" : state}
+        hasOwnCatalogs={hasOwnCatalogs}
+      />
+    );
   }
 
   const totalStreams =

--- a/components/Catalog/report/CatalogReportEmptyState.tsx
+++ b/components/Catalog/report/CatalogReportEmptyState.tsx
@@ -15,9 +15,15 @@ const CTA_CLASS =
  * point at recoupable.dev, which is how a signed-in customer ended up re-running
  * a valuation that was already running (chat#1912 row 1).
  */
-const CatalogReportEmptyState = ({ state }: { state: EmptyState }) => {
+const CatalogReportEmptyState = ({
+  state,
+  hasOwnCatalogs,
+}: {
+  state: EmptyState;
+  hasOwnCatalogs: boolean;
+}) => {
   const { login } = useUserProvider();
-  const copy = getCatalogReportEmptyCopy(state);
+  const copy = getCatalogReportEmptyCopy(state, { hasOwnCatalogs });
 
   return (
     <div className="max-w-3xl rounded-2xl bg-card p-6 sm:p-8 shadow-[0_0_0_1px_var(--border)]">

--- a/hooks/useCatalogReport.ts
+++ b/hooks/useCatalogReport.ts
@@ -22,7 +22,7 @@ const useCatalogReport = (catalogId: string) => {
     MEASUREMENTS_PAGE_LIMIT,
   );
   const songsQuery = useCatalogReportSongs(catalogId);
-  const { ownsCatalog, isResolved, ownershipUnknown } =
+  const { ownsCatalog, hasOwnCatalogs, isResolved, ownershipUnknown } =
     useOwnsCatalog(catalogId);
 
   const state = getCatalogReportState({
@@ -43,6 +43,7 @@ const useCatalogReport = (catalogId: string) => {
 
   return {
     state,
+    hasOwnCatalogs,
     measurements: measurementsQuery.data,
     songs: songsQuery.data?.songs,
     totalSongs: songsQuery.data?.pagination?.total_count,

--- a/hooks/useOwnsCatalog.ts
+++ b/hooks/useOwnsCatalog.ts
@@ -19,6 +19,8 @@ const useOwnsCatalog = (catalogId?: string) => {
   return {
     ownsCatalog:
       !!catalogId && !!data?.catalogs?.some((c) => c.id === catalogId),
+    /** Drives the cross-account CTA: somewhere to go depends on having one. */
+    hasOwnCatalogs: (data?.catalogs?.length ?? 0) > 0,
     isResolved: isSuccess || isError,
     /** The list failed, so ownership carries no information either way. */
     ownershipUnknown: isError,

--- a/lib/catalog/__tests__/getCatalogReportEmptyCopy.test.ts
+++ b/lib/catalog/__tests__/getCatalogReportEmptyCopy.test.ts
@@ -3,9 +3,12 @@ import { getCatalogReportEmptyCopy } from "@/lib/catalog/getCatalogReportEmptyCo
 
 const states = ["signed-out", "measuring", "other-account", "error"] as const;
 
+const withCatalogs = { hasOwnCatalogs: true };
+const withoutCatalogs = { hasOwnCatalogs: false };
+
 describe("getCatalogReportEmptyCopy", () => {
   it.each(states)("gives %s a title and a body", (state) => {
-    const copy = getCatalogReportEmptyCopy(state);
+    const copy = getCatalogReportEmptyCopy(state, withCatalogs);
 
     expect(copy.title.length).toBeGreaterThan(0);
     expect(copy.body.length).toBeGreaterThan(0);
@@ -15,7 +18,7 @@ describe("getCatalogReportEmptyCopy", () => {
   // customer back to the marketing site. Bouncing them off-app at the moment of
   // peak interest is what produced the duplicate valuation run.
   it.each(states)("never points %s off-app to recoupable.dev", (state) => {
-    const copy = getCatalogReportEmptyCopy(state);
+    const copy = getCatalogReportEmptyCopy(state, withCatalogs);
 
     expect(`${copy.title} ${copy.body}`).not.toContain("recoupable.dev");
     expect(copy.cta?.href ?? "").not.toContain("recoupable.dev");
@@ -23,13 +26,13 @@ describe("getCatalogReportEmptyCopy", () => {
 
   // House style: em dashes read as machine-written in product copy.
   it.each(states)("keeps %s copy free of em dashes", (state) => {
-    const copy = getCatalogReportEmptyCopy(state);
+    const copy = getCatalogReportEmptyCopy(state, withCatalogs);
 
     expect(`${copy.title} ${copy.body}`).not.toMatch(/[—–]/);
   });
 
   it("tells a cross-account viewer the catalog belongs to another account", () => {
-    const copy = getCatalogReportEmptyCopy("other-account");
+    const copy = getCatalogReportEmptyCopy("other-account", withCatalogs);
 
     expect(copy.title.toLowerCase()).toContain("another account");
     // The old copy claimed no valuation existed, which was false: the catalog
@@ -38,19 +41,19 @@ describe("getCatalogReportEmptyCopy", () => {
   });
 
   it("offers a signed-out visitor a way in", () => {
-    const copy = getCatalogReportEmptyCopy("signed-out");
+    const copy = getCatalogReportEmptyCopy("signed-out", withCatalogs);
 
     expect(copy.cta?.action).toBe("login");
   });
 
   it("keeps a cross-account viewer in-app", () => {
-    const copy = getCatalogReportEmptyCopy("other-account");
+    const copy = getCatalogReportEmptyCopy("other-account", withCatalogs);
 
     expect(copy.cta?.href).toBe("/catalogs");
   });
 
   it("offers no CTA while measuring, because there is nothing to do", () => {
-    expect(getCatalogReportEmptyCopy("measuring").cta).toBeUndefined();
+    expect(getCatalogReportEmptyCopy("measuring", withCatalogs).cta).toBeUndefined();
   });
 
   // chat#1912 row 6 chain (recoupable/docs#282 -> recoupable/api#802): catalog
@@ -58,8 +61,36 @@ describe("getCatalogReportEmptyCopy", () => {
   // tab either. Copy that points them at Manage songs would be promising a
   // tab that now fails.
   it("does not promise a cross-account viewer the songs tab", () => {
-    const copy = getCatalogReportEmptyCopy("other-account");
+    const copy = getCatalogReportEmptyCopy("other-account", withCatalogs);
 
     expect(copy.body.toLowerCase()).not.toContain("manage songs");
+  });
+
+  // Review (@sweetmantech): a viewer who cannot see this catalog should get a
+  // way forward, not a paragraph. "Go to your catalogs" is only a happy path
+  // for someone who has catalogs — a stranger following a shared link usually
+  // has none, and would land on an empty page. So the action adapts.
+  it("sends a viewer who has catalogs to their own", () => {
+    const copy = getCatalogReportEmptyCopy("other-account", withCatalogs);
+
+    expect(copy.cta?.href).toBe("/catalogs");
+  });
+
+  it("offers a viewer with no catalogs the way to get one", () => {
+    const copy = getCatalogReportEmptyCopy("other-account", withoutCatalogs);
+
+    expect(copy.cta?.href).toBe("/setup/artists");
+    expect(copy.cta?.label.toLowerCase()).toContain("value");
+  });
+
+  it("always gives the cross-account state something to click", () => {
+    expect(getCatalogReportEmptyCopy("other-account", withCatalogs).cta).toBeDefined();
+    expect(getCatalogReportEmptyCopy("other-account", withoutCatalogs).cta).toBeDefined();
+  });
+
+  // The measuring state resolves on its own, so a button would invite exactly
+  // the redundant re-run this whole issue exists to stop.
+  it("still offers nothing to click while measuring", () => {
+    expect(getCatalogReportEmptyCopy("measuring", withCatalogs).cta).toBeUndefined();
   });
 });

--- a/lib/catalog/__tests__/getCatalogReportEmptyCopy.test.ts
+++ b/lib/catalog/__tests__/getCatalogReportEmptyCopy.test.ts
@@ -52,4 +52,14 @@ describe("getCatalogReportEmptyCopy", () => {
   it("offers no CTA while measuring, because there is nothing to do", () => {
     expect(getCatalogReportEmptyCopy("measuring").cta).toBeUndefined();
   });
+
+  // chat#1912 row 6 chain (recoupable/docs#282 -> recoupable/api#802): catalog
+  // songs become account-scoped, so a non-owner will no longer see the songs
+  // tab either. Copy that points them at Manage songs would be promising a
+  // tab that now fails.
+  it("does not promise a cross-account viewer the songs tab", () => {
+    const copy = getCatalogReportEmptyCopy("other-account");
+
+    expect(copy.body.toLowerCase()).not.toContain("manage songs");
+  });
 });

--- a/lib/catalog/getCatalogReportEmptyCopy.ts
+++ b/lib/catalog/getCatalogReportEmptyCopy.ts
@@ -12,6 +12,11 @@ export interface CatalogReportEmptyCopy {
   cta?: { label: string; href?: string; action?: "login" };
 }
 
+export interface CatalogReportViewer {
+  /** Whether the signed-in viewer has any catalog of their own. */
+  hasOwnCatalogs: boolean;
+}
+
 const COPY: Record<CatalogReportEmptyState, CatalogReportEmptyCopy> = {
   "signed-out": {
     title: "Sign in to see this report",
@@ -24,7 +29,7 @@ const COPY: Record<CatalogReportEmptyState, CatalogReportEmptyCopy> = {
   },
   "other-account": {
     title: "This catalog was measured by another account",
-    body: "Its play counts and valuation belong to the account that measured it. Run a valuation on your own catalog to see this report.",
+    body: "Its play counts and valuation belong to the account that measured it. Here is how to get this report for your own music.",
     cta: { label: "Go to your catalogs", href: "/catalogs" },
   },
   error: {
@@ -40,6 +45,20 @@ const COPY: Record<CatalogReportEmptyState, CatalogReportEmptyCopy> = {
  */
 export function getCatalogReportEmptyCopy(
   state: CatalogReportEmptyState,
+  viewer: CatalogReportViewer,
 ): CatalogReportEmptyCopy {
-  return COPY[state];
+  const copy = COPY[state];
+
+  // A viewer who cannot see this catalog still needs somewhere to go, and
+  // "your catalogs" is only somewhere for people who have one. A stranger
+  // following a shared link usually has none, so point them at the step that
+  // creates one instead of an empty page.
+  if (state === "other-account" && !viewer.hasOwnCatalogs) {
+    return {
+      ...copy,
+      cta: { label: "Value your catalog", href: "/setup/artists" },
+    };
+  }
+
+  return copy;
 }

--- a/lib/catalog/getCatalogReportEmptyCopy.ts
+++ b/lib/catalog/getCatalogReportEmptyCopy.ts
@@ -24,7 +24,7 @@ const COPY: Record<CatalogReportEmptyState, CatalogReportEmptyCopy> = {
   },
   "other-account": {
     title: "This catalog was measured by another account",
-    body: "The songs are listed under Manage songs, but the play counts and valuation belong to the account that measured them.",
+    body: "Its play counts and valuation belong to the account that measured it. Run a valuation on your own catalog to see this report.",
     cta: { label: "Go to your catalogs", href: "/catalogs" },
   },
   error: {


### PR DESCRIPTION
Third and final link of row 6's chain in [chat#1912](https://github.com/recoupable/chat/issues/1912).

**Merge order: [docs#282](https://github.com/recoupable/docs/pull/282) → [api#802](https://github.com/recoupable/api/pull/802) → this.** It is safe to merge at any point (the new wording is true before and after), but it only becomes *necessary* once api#802 lands.

## Why

[chat#1915](https://github.com/recoupable/chat/pull/1915) shipped this copy for a cross-account viewer:

> This catalog was measured by another account.
> **The songs are listed under Manage songs**, but the play counts and valuation belong to the account that measured them.

That sentence was written to be true either way while the access model was undecided — at the time, `GET /api/catalogs/songs` really did return 200 to anyone. [api#802](https://github.com/recoupable/api/pull/802) makes it **403** for a non-owner, so the copy would be pointing a stranger at a tab that now fails.

## What changed

```diff
- The songs are listed under Manage songs, but the play counts and valuation
- belong to the account that measured them.
+ Its play counts and valuation belong to the account that measured it. Run a
+ valuation on your own catalog to see this report.
```

Same title, same `Go to your catalogs` CTA. The replacement states only what remains true and offers a next step instead of a dead reference.

## Tests

TDD red→green: a new case asserts the `other-account` body does not mention "Manage songs", so this cannot silently regress if the copy is edited again later. The existing guards in that file still pass unchanged — no `recoupable.dev` in any state's copy or CTA, and no em dashes.

Full suite **333 passed / 82 files**, `tsc --noEmit` and `eslint` clean.

## Verification

Nothing to verify on a preview until api#802 is merged — before that, the songs tab still returns 200 and both wordings are accurate. Row 6's Works-when step 4 ("re-read the other-account wording and confirm it does not describe behaviour the API no longer has") covers this once the chain is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewords the cross-account catalog report empty state so it no longer points to “Manage songs”. Adds an adaptive CTA that keeps viewers in-app with a clear next step.

- **Bug Fixes**
  - Updated body to: "Its play counts and valuation belong to the account that measured it. Here is how to get this report for your own music." CTA adapts: has catalogs → "Go to your catalogs" (`/catalogs`); none → "Value your catalog" (`/setup/artists`).
  - Added `hasOwnCatalogs` to `useOwnsCatalog` → `useCatalogReport` → `CatalogReportEmptyState`, and tests to guard wording, ensure cross-account always has a CTA, and keep measuring with no CTA.

<sup>Written for commit e781cd6fc89e8812163316e674a882e33fc9cdd1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1917?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the report empty state for another-account views, tailoring the call-to-action based on whether the viewer has their own catalogs.
  * Updated guidance so users are directed to the correct valuation flow to view a report for their own music when applicable.
  * Clarified in the empty-state messaging how play counts and valuation relate to the measuring account.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->