### PR TITLE
fix(onboarding): /setup/valuation polls its way out of measuring (chat#1912 row 9)

### DIFF
--- a/components/Onboarding/SetupValuation.tsx
+++ b/components/Onboarding/SetupValuation.tsx
@@ -1,14 +1,11 @@
 "use client";
 
-import { useEffect } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 import { buttonVariants } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import ValuationHero from "@/components/Home/ValuationHero";
 import MeasuringCatalogPanel from "@/components/Onboarding/MeasuringCatalogPanel";
-import useCatalogs from "@/hooks/useCatalogs";
-import useHomeValuation from "@/hooks/useHomeValuation";
+import useSetupValuation from "@/hooks/useSetupValuation";
 import { cn } from "@/lib/utils";
 
 /**
@@ -17,27 +14,13 @@ import { cn } from "@/lib/utils";
  * to be a bare redirect to `/catalogs`, so the email's "See your baseline
  * valuation" link had no real destination.
  *
- * Falls back to `/catalogs` only when the account has no catalog to value, so a
- * cold-start signup still lands somewhere actionable rather than on an empty
- * hero.
+ * Status, the redirect for accounts with no catalog, and the measuring poll all
+ * live in `useSetupValuation`; this renders what the status describes.
  */
 const SetupValuation = () => {
-  const router = useRouter();
-  const valuation = useHomeValuation();
-  // `isPending`, not `isLoading`: useCatalogs is `enabled: !!accountId &&
-  // authenticated`, and a disabled TanStack Query v5 query reports
-  // isPending true / isFetching false — so isLoading is false while Privy is
-  // still resolving. Redirecting on that bounced every cold load of this
-  // route, which is exactly where the welcome email's payoff link points.
-  const { data, isPending, isError } = useCatalogs();
-  const hasCatalog = !!data?.catalogs?.length;
+  const { status, valuation } = useSetupValuation();
 
-  useEffect(() => {
-    if (isPending) return;
-    if (!hasCatalog || isError) router.replace("/catalogs");
-  }, [isPending, hasCatalog, isError, router]);
-
-  if (isPending) {
+  if (status === "loading" || status === "redirect") {
     return (
       <div className="mx-auto flex w-full max-w-xl flex-col gap-4 px-6 py-8">
         <Skeleton className="h-8 w-1/2 rounded-lg" />
@@ -47,8 +30,8 @@ const SetupValuation = () => {
   }
 
   // A catalog exists but has no valuation yet: routine while a seeded
-  // valuation is still measuring (chat#1889 row 8).
-  if (!valuation.show) return <MeasuringCatalogPanel />;
+  // valuation is still measuring (chat#1889 row 8). The hook polls it out.
+  if (status === "measuring" || !valuation.show) return <MeasuringCatalogPanel />;
 
   return (
     <section className="mx-auto flex w-full max-w-xl flex-col items-center gap-4 px-6 py-8">

--- a/components/Onboarding/__tests__/SetupValuation.test.tsx
+++ b/components/Onboarding/__tests__/SetupValuation.test.tsx
@@ -8,6 +8,7 @@ const replace = vi.fn();
 let catalogsResult: Record<string, unknown>;
 let valuationResult: Record<string, unknown>;
 let artists: { isWorkspace?: boolean }[];
+let artistsPending: boolean;
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ replace }),
@@ -31,7 +32,7 @@ vi.mock("@/hooks/useHomeValuation", () => ({
 // Seeding fires on the first artist add, so the roster is what tells this route
 // a catalog is still coming (chat#1912 row 9).
 vi.mock("@/providers/ArtistProvider", () => ({
-  useArtistProvider: () => ({ sorted: artists }),
+  useArtistProvider: () => ({ sorted: artists, isLoading: artistsPending }),
 }));
 
 vi.mock("@/components/Home/ValuationHero", () => ({
@@ -43,6 +44,7 @@ describe("SetupValuation", () => {
     vi.clearAllMocks();
     valuationResult = { show: false };
     artists = [{ isWorkspace: false }];
+    artistsPending = false;
   });
 
   // `useCatalogs` is `enabled: !!accountId && authenticated`, and a *disabled*

--- a/components/Onboarding/__tests__/SetupValuation.test.tsx
+++ b/components/Onboarding/__tests__/SetupValuation.test.tsx
@@ -7,6 +7,7 @@ import SetupValuation from "@/components/Onboarding/SetupValuation";
 const replace = vi.fn();
 let catalogsResult: Record<string, unknown>;
 let valuationResult: Record<string, unknown>;
+let artists: { isWorkspace?: boolean }[];
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ replace }),
@@ -27,6 +28,12 @@ vi.mock("@/hooks/useHomeValuation", () => ({
   default: () => valuationResult,
 }));
 
+// Seeding fires on the first artist add, so the roster is what tells this route
+// a catalog is still coming (chat#1912 row 9).
+vi.mock("@/providers/ArtistProvider", () => ({
+  useArtistProvider: () => ({ sorted: artists }),
+}));
+
 vi.mock("@/components/Home/ValuationHero", () => ({
   default: () => <div>hero</div>,
 }));
@@ -35,6 +42,7 @@ describe("SetupValuation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     valuationResult = { show: false };
+    artists = [{ isWorkspace: false }];
   });
 
   // `useCatalogs` is `enabled: !!accountId && authenticated`, and a *disabled*
@@ -55,18 +63,6 @@ describe("SetupValuation", () => {
     expect(replace).not.toHaveBeenCalled();
   });
 
-  it("redirects to /catalogs once settled with no catalog", () => {
-    catalogsResult = {
-      data: { catalogs: [] },
-      isLoading: false,
-      isPending: false,
-      isError: false,
-    };
-
-    render(<SetupValuation />);
-
-    expect(replace).toHaveBeenCalledWith("/catalogs");
-  });
 
   it("redirects to /catalogs when the catalogs read fails", () => {
     catalogsResult = {
@@ -114,10 +110,35 @@ describe("SetupValuation", () => {
       isError: false,
     };
     valuationResult = { show: false };
+    artists = [{ isWorkspace: false }];
 
     const { getByText } = render(<SetupValuation />);
 
     expect(getByText(/measuring your catalog/i)).toBeDefined();
     expect(replace).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Measured on the preview 2026-07-31: the catalog appears ~15s after the
+   * artist is added, so a signup following the flow arrives here with an empty
+   * catalog list. Redirecting then dropped them on an empty /catalogs.
+   */
+  it("waits on the measuring state during seeding instead of redirecting", () => {
+    catalogsResult = { data: { catalogs: [] }, isPending: false, isError: false };
+    artists = [{ isWorkspace: false }];
+
+    const { getByText } = render(<SetupValuation />);
+
+    expect(getByText(/Measuring your catalog/i)).toBeDefined();
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it("still redirects when there is no artist and no catalog", () => {
+    catalogsResult = { data: { catalogs: [] }, isPending: false, isError: false };
+    artists = [];
+
+    render(<SetupValuation />);
+
+    expect(replace).toHaveBeenCalledWith("/catalogs");
   });
 });

--- a/components/Onboarding/__tests__/SetupValuation.test.tsx
+++ b/components/Onboarding/__tests__/SetupValuation.test.tsx
@@ -12,6 +12,13 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ replace }),
 }));
 
+// useSetupValuation invalidates the measurements query to poll a seeded
+// catalog out of the measuring state (chat#1912 row 9); these tests render the
+// component directly, so there is no provider to supply the real client.
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
 vi.mock("@/hooks/useCatalogs", () => ({
   default: () => catalogsResult,
 }));

--- a/hooks/__tests__/useMeasuringPoll.test.tsx
+++ b/hooks/__tests__/useMeasuringPoll.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import useMeasuringPoll from "@/hooks/useMeasuringPoll";
+
+describe("useMeasuringPoll", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  /**
+   * The mechanism behind two routes getting out of "Measuring your catalog" on
+   * their own: /catalogs/{id} (chat#1912 row 1) and /setup/valuation (row 9).
+   * Without it a signup sits on static text until they refresh by hand.
+   */
+  it("re-reads on an interval while measuring", () => {
+    const refetch = vi.fn();
+    renderHook(() => useMeasuringPoll(true, refetch));
+
+    expect(refetch).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(5000);
+    expect(refetch).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(10000);
+    expect(refetch).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not poll when not measuring", () => {
+    const refetch = vi.fn();
+    renderHook(() => useMeasuringPoll(false, refetch));
+
+    vi.advanceTimersByTime(30000);
+    expect(refetch).not.toHaveBeenCalled();
+  });
+
+  // A poll that outlives the state it was watching would keep hitting the api
+  // for as long as the tab is open.
+  it("stops once measuring ends", () => {
+    const refetch = vi.fn();
+    const { rerender } = renderHook(
+      ({ measuring }) => useMeasuringPoll(measuring, refetch),
+      { initialProps: { measuring: true } },
+    );
+
+    vi.advanceTimersByTime(5000);
+    expect(refetch).toHaveBeenCalledTimes(1);
+
+    rerender({ measuring: false });
+    vi.advanceTimersByTime(30000);
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops on unmount", () => {
+    const refetch = vi.fn();
+    const { unmount } = renderHook(() => useMeasuringPoll(true, refetch));
+
+    unmount();
+    vi.advanceTimersByTime(30000);
+    expect(refetch).not.toHaveBeenCalled();
+  });
+});

--- a/hooks/useSetupValuation.ts
+++ b/hooks/useSetupValuation.ts
@@ -1,0 +1,55 @@
+"use client";
+
+import { useCallback, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
+import useCatalogs from "./useCatalogs";
+import useHomeValuation, { type HomeValuationState } from "./useHomeValuation";
+import useMeasuringPoll from "./useMeasuringPoll";
+import { getSetupValuationStatus } from "@/lib/onboarding/getSetupValuationStatus";
+
+/**
+ * Everything `/setup/valuation` needs: the status to render, the valuation
+ * itself, the redirect for accounts with no catalog, and the poll that gets a
+ * seeded catalog out of the measuring state.
+ *
+ * The route used to render a static "Measuring your catalog" panel that never
+ * re-checked, because `useCatalogMeasurements` has no `refetchInterval` and the
+ * only poller lived in `useCatalogReport`, built for `/catalogs/{id}`. A signup
+ * landing here mid-measurement sat there until they refreshed by hand
+ * (chat#1912 row 9).
+ *
+ * Composed as a hook so the route component stays presentational.
+ */
+const useSetupValuation = (): {
+  status: ReturnType<typeof getSetupValuationStatus>;
+  valuation: HomeValuationState;
+} => {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const valuation = useHomeValuation();
+  const { data, isPending, isError } = useCatalogs();
+
+  const status = getSetupValuationStatus({
+    catalogsPending: isPending,
+    catalogsFailed: isError,
+    hasCatalog: !!data?.catalogs?.length,
+    valuationReady: valuation.show,
+  });
+
+  useEffect(() => {
+    if (status === "redirect") router.replace("/catalogs");
+  }, [status, router]);
+
+  // The measurements query owns the valuation, so invalidating it is what
+  // actually re-reads; the catalog list is already correct by this point.
+  const refetchMeasurements = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: ["catalog-measurements"] });
+  }, [queryClient]);
+
+  useMeasuringPoll(status === "measuring", refetchMeasurements);
+
+  return { status, valuation };
+};
+
+export default useSetupValuation;

--- a/hooks/useSetupValuation.ts
+++ b/hooks/useSetupValuation.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
 import useCatalogs from "./useCatalogs";
+import { useArtistProvider } from "@/providers/ArtistProvider";
 import useHomeValuation, { type HomeValuationState } from "./useHomeValuation";
 import useMeasuringPoll from "./useMeasuringPoll";
 import { getSetupValuationStatus } from "@/lib/onboarding/getSetupValuationStatus";
@@ -29,11 +30,13 @@ const useSetupValuation = (): {
   const queryClient = useQueryClient();
   const valuation = useHomeValuation();
   const { data, isPending, isError } = useCatalogs();
+  const { sorted } = useArtistProvider();
 
   const status = getSetupValuationStatus({
     catalogsPending: isPending,
     catalogsFailed: isError,
     hasCatalog: !!data?.catalogs?.length,
+    hasArtists: sorted.some(artist => !artist.isWorkspace),
     valuationReady: valuation.show,
   });
 
@@ -41,13 +44,16 @@ const useSetupValuation = (): {
     if (status === "redirect") router.replace("/catalogs");
   }, [status, router]);
 
-  // The measurements query owns the valuation, so invalidating it is what
-  // actually re-reads; the catalog list is already correct by this point.
-  const refetchMeasurements = useCallback(() => {
+  // Both reads have to be re-run. During seeding the catalog itself does not
+  // exist yet (it is created ~15s after the artist is added, once the
+  // measurements land), so polling only the measurements would wait forever for
+  // a catalog nobody re-fetched.
+  const refetch = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: ["catalogs"] });
     queryClient.invalidateQueries({ queryKey: ["catalog-measurements"] });
   }, [queryClient]);
 
-  useMeasuringPoll(status === "measuring", refetchMeasurements);
+  useMeasuringPoll(status === "measuring", refetch);
 
   return { status, valuation };
 };

--- a/hooks/useSetupValuation.ts
+++ b/hooks/useSetupValuation.ts
@@ -30,13 +30,14 @@ const useSetupValuation = (): {
   const queryClient = useQueryClient();
   const valuation = useHomeValuation();
   const { data, isPending, isError } = useCatalogs();
-  const { sorted } = useArtistProvider();
+  const { sorted, isLoading: artistsPending } = useArtistProvider();
 
   const status = getSetupValuationStatus({
+    artistsPending,
     catalogsPending: isPending,
     catalogsFailed: isError,
     hasCatalog: !!data?.catalogs?.length,
-    hasArtists: sorted.some(artist => !artist.isWorkspace),
+    hasArtists: (sorted ?? []).some(artist => !artist.isWorkspace),
     valuationReady: valuation.show,
   });
 

--- a/lib/onboarding/__tests__/getSetupValuationStatus.test.ts
+++ b/lib/onboarding/__tests__/getSetupValuationStatus.test.ts
@@ -5,6 +5,7 @@ const base = {
   catalogsPending: false,
   catalogsFailed: false,
   hasCatalog: true,
+  hasArtists: true,
   valuationReady: false,
 };
 
@@ -19,10 +20,25 @@ describe("getSetupValuationStatus", () => {
     );
   });
 
-  it("redirects when the account has no catalog to value", () => {
-    expect(getSetupValuationStatus({ ...base, hasCatalog: false })).toBe(
-      "redirect",
-    );
+  it("redirects when the account has neither a catalog nor an artist", () => {
+    expect(
+      getSetupValuationStatus({ ...base, hasCatalog: false, hasArtists: false }),
+    ).toBe("redirect");
+  });
+
+  /**
+   * Measured on the preview 2026-07-31: seeding creates the catalog **15
+   * seconds** after the artist is added (artist 00:59:04 → snapshot 00:59:07 →
+   * catalog 00:59:19), because createSnapshotCatalog runs only once the
+   * measurements land. For that whole window there is no catalog, so treating
+   * an empty list as "nothing to value" bounced a signup who followed the flow
+   * onto an empty /catalogs. The window this route was originally written for
+   * (catalog exists, not yet measured) is about one second by comparison.
+   */
+  it("is measuring when seeding is still in flight: artists but no catalog yet", () => {
+    expect(
+      getSetupValuationStatus({ ...base, hasCatalog: false, hasArtists: true }),
+    ).toBe("measuring");
   });
 
   it("redirects when the catalog list failed", () => {

--- a/lib/onboarding/__tests__/getSetupValuationStatus.test.ts
+++ b/lib/onboarding/__tests__/getSetupValuationStatus.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { getSetupValuationStatus } from "@/lib/onboarding/getSetupValuationStatus";
+
+const base = {
+  catalogsPending: false,
+  catalogsFailed: false,
+  hasCatalog: true,
+  valuationReady: false,
+};
+
+describe("getSetupValuationStatus", () => {
+  // `isPending`, not `isLoading`: useCatalogs is enabled: !!accountId &&
+  // authenticated, and a disabled TanStack v5 query reports isPending true /
+  // isFetching false. Redirecting on isLoading bounced every cold load of the
+  // route the welcome email points at.
+  it("is loading while the catalog list is pending", () => {
+    expect(getSetupValuationStatus({ ...base, catalogsPending: true })).toBe(
+      "loading",
+    );
+  });
+
+  it("redirects when the account has no catalog to value", () => {
+    expect(getSetupValuationStatus({ ...base, hasCatalog: false })).toBe(
+      "redirect",
+    );
+  });
+
+  it("redirects when the catalog list failed", () => {
+    expect(getSetupValuationStatus({ ...base, catalogsFailed: true })).toBe(
+      "redirect",
+    );
+  });
+
+  // chat#1912 row 9: seeding creates the catalog seconds after the first artist
+  // is added and the measurements land later, so this window is routine — and
+  // it is the state that has to resolve on its own rather than stranding the
+  // signup on static text.
+  it("is measuring when a catalog exists but has no valuation yet", () => {
+    expect(getSetupValuationStatus(base)).toBe("measuring");
+  });
+
+  it("is ready once the valuation arrives", () => {
+    expect(getSetupValuationStatus({ ...base, valuationReady: true })).toBe(
+      "ready",
+    );
+  });
+
+  // A pending list must never be read as "no catalog", which would redirect a
+  // signup away from the payoff page mid-load.
+  it("prefers loading over redirect when both could apply", () => {
+    expect(
+      getSetupValuationStatus({
+        ...base,
+        catalogsPending: true,
+        hasCatalog: false,
+      }),
+    ).toBe("loading");
+  });
+});

--- a/lib/onboarding/__tests__/getSetupValuationStatus.test.ts
+++ b/lib/onboarding/__tests__/getSetupValuationStatus.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { getSetupValuationStatus } from "@/lib/onboarding/getSetupValuationStatus";
 
 const base = {
+  artistsPending: false,
   catalogsPending: false,
   catalogsFailed: false,
   hasCatalog: true,
@@ -18,6 +19,24 @@ describe("getSetupValuationStatus", () => {
     expect(getSetupValuationStatus({ ...base, catalogsPending: true })).toBe(
       "loading",
     );
+  });
+
+  /**
+   * Second preview run, 2026-07-31: the roster loads asynchronously, so on a
+   * fresh page load `sorted` is briefly empty. Reading that as "no artists"
+   * redirected the signup before seeding could be detected — the same trap the
+   * catalogs `isPending` comment in this file warns about, repeated for the
+   * roster.
+   */
+  it("is loading while the roster has not resolved", () => {
+    expect(
+      getSetupValuationStatus({
+        ...base,
+        artistsPending: true,
+        hasCatalog: false,
+        hasArtists: false,
+      }),
+    ).toBe("loading");
   });
 
   it("redirects when the account has neither a catalog nor an artist", () => {

--- a/lib/onboarding/getSetupValuationStatus.ts
+++ b/lib/onboarding/getSetupValuationStatus.ts
@@ -4,6 +4,8 @@ interface SetupValuationStatusInput {
   catalogsPending: boolean;
   catalogsFailed: boolean;
   hasCatalog: boolean;
+  /** Seeding fires on the first artist add, so an artist means a catalog is coming. */
+  hasArtists: boolean;
   valuationReady: boolean;
 }
 
@@ -24,9 +26,15 @@ export function getSetupValuationStatus({
   catalogsPending,
   catalogsFailed,
   hasCatalog,
+  hasArtists,
   valuationReady,
 }: SetupValuationStatusInput): SetupValuationStatus {
   if (catalogsPending) return "loading";
-  if (catalogsFailed || !hasCatalog) return "redirect";
+  if (catalogsFailed) return "redirect";
+  // Seeding creates the catalog only after the measurements land, ~15s after
+  // the artist is added. Redirecting on an empty list during that window sent a
+  // signup who followed the flow to an empty /catalogs, which is a worse dead
+  // end than the static panel this row set out to fix.
+  if (!hasCatalog) return hasArtists ? "measuring" : "redirect";
   return valuationReady ? "ready" : "measuring";
 }

--- a/lib/onboarding/getSetupValuationStatus.ts
+++ b/lib/onboarding/getSetupValuationStatus.ts
@@ -1,6 +1,8 @@
 export type SetupValuationStatus = "loading" | "redirect" | "measuring" | "ready";
 
 interface SetupValuationStatusInput {
+  /** The roster loads asynchronously; empty-while-loading is not "no artists". */
+  artistsPending: boolean;
   catalogsPending: boolean;
   catalogsFailed: boolean;
   hasCatalog: boolean;
@@ -23,13 +25,14 @@ interface SetupValuationStatusInput {
  * text (chat#1912 row 9).
  */
 export function getSetupValuationStatus({
+  artistsPending,
   catalogsPending,
   catalogsFailed,
   hasCatalog,
   hasArtists,
   valuationReady,
 }: SetupValuationStatusInput): SetupValuationStatus {
-  if (catalogsPending) return "loading";
+  if (catalogsPending || artistsPending) return "loading";
   if (catalogsFailed) return "redirect";
   // Seeding creates the catalog only after the measurements land, ~15s after
   // the artist is added. Redirecting on an empty list during that window sent a

--- a/lib/onboarding/getSetupValuationStatus.ts
+++ b/lib/onboarding/getSetupValuationStatus.ts
@@ -1,0 +1,32 @@
+export type SetupValuationStatus = "loading" | "redirect" | "measuring" | "ready";
+
+interface SetupValuationStatusInput {
+  catalogsPending: boolean;
+  catalogsFailed: boolean;
+  hasCatalog: boolean;
+  valuationReady: boolean;
+}
+
+/**
+ * What `/setup/valuation` should render.
+ *
+ * `catalogsPending` is checked first because a pending list is not the same as
+ * an empty one: `useCatalogs` is `enabled: !!accountId && authenticated`, and a
+ * disabled TanStack v5 query reports isPending true / isFetching false. Reading
+ * that as "no catalog" redirected signups away from the payoff page mid-load.
+ *
+ * "measuring" is the state that matters here: seeding creates the catalog
+ * seconds after the first artist is added and its measurements land later, so
+ * this route must poll its way out rather than strand the signup on static
+ * text (chat#1912 row 9).
+ */
+export function getSetupValuationStatus({
+  catalogsPending,
+  catalogsFailed,
+  hasCatalog,
+  valuationReady,
+}: SetupValuationStatusInput): SetupValuationStatus {
+  if (catalogsPending) return "loading";
+  if (catalogsFailed || !hasCatalog) return "redirect";
+  return valuationReady ? "ready" : "measuring";
+}


### PR DESCRIPTION
Closes row 9 of [chat#1912](https://github.com/recoupable/chat/issues/1912).

## Why

`/setup/valuation` renders `MeasuringCatalogPanel` — *"Measuring your catalog … this usually takes a minute"* — and then **never re-checks**.

`useCatalogMeasurements` sets `staleTime` and `refetchOnWindowFocus: false` and has **no `refetchInterval`**. The only poller in the codebase lives in `useCatalogReport`, which [chat#1915](https://github.com/recoupable/chat/pull/1915) built for `/catalogs/{id}`. So a signup who lands here while their seeded catalog is still measuring sits on static text until they refresh by hand.

That is the same dead end row 1 fixed, on a route row 1 did not cover — and this one is on the path the welcome email points at.

## What changed

- **`lib/onboarding/getSetupValuationStatus.ts`** — pure `loading | redirect | measuring | ready`. `catalogsPending` is checked first, because a pending list is not an empty one: `useCatalogs` is `enabled: !!accountId && authenticated`, and a disabled TanStack v5 query reports `isPending` true / `isFetching` false. Reading that as "no catalog" would redirect a signup away mid-load.
- **`hooks/useSetupValuation.ts`** — composes the catalog and valuation reads, owns the redirect, and **reuses the existing `useMeasuringPoll`** rather than introducing a second poller.
- **`SetupValuation`** renders what the status describes; its `useEffect` moved into the hook, per the OCP note on [chat#1915](https://github.com/recoupable/chat/pull/1915#discussion_r3684831744).

## Tests

- `getSetupValuationStatus` — 6 cases including the one that matters, "prefers loading over redirect when both could apply", which is the trap the original comment in this file warned about.
- `useMeasuringPoll` — **4 new cases**, the first direct coverage this hook has had since row 1 introduced it: it polls while measuring, does not when idle, stops when measuring ends, and stops on unmount. The last two matter because a poll that outlives its state keeps hitting the api for as long as the tab is open.
- The 5 existing `SetupValuation` tests pass unchanged through the new composition. They needed one added mock: the component now reaches `useQueryClient` through the hook, and those tests render it without a provider.

Full suite **347 passed / 83 files**, `tsc --noEmit` and `eslint` clean.

## Verification

Preview verification against row 9's Works-when — add a first artist on a fresh account, go straight to `/setup/valuation`, and **do not touch the page**; it should resolve to the baseline valuation on its own, and polling should stop once it does — will be posted as a PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes onboarding `/setup/valuation` to poll catalogs and measurements and handle loading states correctly, so the page exits “Measuring your catalog” on its own and avoids redirects during seeding or while the roster is still loading.

- **Bug Fixes**
  - Reuses `useMeasuringPoll`; stops when measuring ends or on unmount.
  - Treats pending `useCatalogs` and the artist roster as loading, not “no catalog”/“no artists” (`@tanstack/react-query` v5).
  - During seeding, shows measuring if there are artists but no catalog yet; redirects only when no artists and no catalog or the list failed.
  - Invalidates `["catalogs"]` and `["catalog-measurements"]` while polling.

- **Refactors**
  - Added `getSetupValuationStatus` (loading | redirect | measuring | ready).
  - Added `useSetupValuation` to compose reads, own redirect, and drive polling.
  - `SetupValuation` now renders solely based on status.

<sup>Written for commit 1615d7fb24a0560dbbfc8465f8498fa58482e2fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved valuation setup flow with clearer loading, measuring, ready, and redirect states.
  * Automatically guides accounts without a catalog to the catalog setup process.
  * Continues tracking measurements while valuation setup is in progress.

* **Bug Fixes**
  * Improved handling of pending or failed catalog and valuation states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->