### PR TITLE
fix(copy): one description of the measuring wait (chat#1912 row 10)

### DIFF
--- a/components/Onboarding/MeasuringCatalogPanel.tsx
+++ b/components/Onboarding/MeasuringCatalogPanel.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { buttonVariants } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { MEASURING_BODY, MEASURING_TITLE } from "@/lib/catalog/measuringCopy";
 
 /**
  * Terminal state for `/setup/valuation` while a catalog exists but has no
@@ -15,12 +16,9 @@ import { cn } from "@/lib/utils";
  */
 const MeasuringCatalogPanel = () => (
   <section className="mx-auto flex w-full max-w-xl flex-col items-center gap-4 px-6 py-8 text-center">
-    <h1 className="text-2xl font-semibold text-foreground">
-      Measuring your catalog
-    </h1>
+    <h1 className="text-2xl font-semibold text-foreground">{MEASURING_TITLE}</h1>
     <p className="text-sm text-muted-foreground">
-      We are pulling play counts for every track. This usually takes a minute.
-      Your baseline value appears here as soon as it is ready.
+      {MEASURING_BODY} Your baseline value appears here as soon as it is ready.
     </p>
     <Link href="/setup/tasks" className={cn(buttonVariants(), "min-w-[200px]")}>
       Set up your weekly report

--- a/hooks/useAddSpotifyArtist.ts
+++ b/hooks/useAddSpotifyArtist.ts
@@ -6,6 +6,11 @@ import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { addSpotifyArtist } from "@/lib/artists/addSpotifyArtist";
 import { runValuation } from "@/lib/valuation/runValuation";
+import {
+  MEASURING_TOAST_ERROR,
+  MEASURING_TOAST_SUCCESS,
+  measuringToastLoading,
+} from "@/lib/catalog/measuringCopy";
 import { useArtistProvider } from "@/providers/ArtistProvider";
 import { useOrganization } from "@/providers/OrganizationProvider";
 import useCatalogs from "@/hooks/useCatalogs";
@@ -56,10 +61,9 @@ export function useAddSpotifyArtist() {
             queryClient.invalidateQueries({ queryKey: ["catalogs"] });
           }),
           {
-            loading: `Valuing ${artist.name}'s catalog…`,
-            success: "Your catalog is ready",
-            error:
-              "Couldn't value the catalog automatically — you can claim it later",
+            loading: measuringToastLoading(artist.name),
+            success: MEASURING_TOAST_SUCCESS,
+            error: MEASURING_TOAST_ERROR,
           },
         );
       }

--- a/lib/catalog/__tests__/measuringCopy.test.ts
+++ b/lib/catalog/__tests__/measuringCopy.test.ts
@@ -4,6 +4,7 @@ import {
   MEASURING_ESTIMATE,
   MEASURING_BODY,
   MEASURING_TOAST_SUCCESS,
+  MEASURING_TOAST_ERROR,
   measuringToastLoading,
 } from "@/lib/catalog/measuringCopy";
 import { getCatalogReportEmptyCopy } from "@/lib/catalog/getCatalogReportEmptyCopy";
@@ -33,14 +34,24 @@ describe("measuringCopy", () => {
     expect(copy.body.split("about a minute").length - 1).toBe(1);
   });
 
+  // Derived from the title rather than hard-coded, so the assertion fails if
+  // either side drifts — the point is that they agree, not that they are any
+  // particular word.
   it("uses the same verb in the seeding toast as on the pages", () => {
-    expect(measuringToastLoading("BennyJ504")).toBe("Measuring BennyJ504's catalog…");
-    expect(MEASURING_TOAST_SUCCESS.length).toBeGreaterThan(0);
+    const verb = MEASURING_TITLE.split(" ")[0];
+
+    expect(verb).toBe("Measuring");
+    expect(measuringToastLoading("BennyJ504")).toBe(`${verb} BennyJ504's catalog…`);
+  });
+
+  it("states the toast outcomes", () => {
+    expect(MEASURING_TOAST_SUCCESS).toBe("Your catalog is ready");
+    expect(MEASURING_TOAST_ERROR).toContain("claim it later");
   });
 
   // House style: em dashes read as machine-written in product copy.
   it("keeps the shared copy free of em dashes", () => {
-    const all = [MEASURING_TITLE, MEASURING_ESTIMATE, MEASURING_BODY, MEASURING_TOAST_SUCCESS].join(" ");
+    const all = [MEASURING_TITLE, MEASURING_ESTIMATE, MEASURING_BODY, MEASURING_TOAST_SUCCESS, MEASURING_TOAST_ERROR].join(" ");
     expect(all).not.toMatch(/[—–]/);
   });
 });

--- a/lib/catalog/__tests__/measuringCopy.test.ts
+++ b/lib/catalog/__tests__/measuringCopy.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+  MEASURING_TITLE,
+  MEASURING_ESTIMATE,
+  MEASURING_BODY,
+  MEASURING_TOAST_SUCCESS,
+  measuringToastLoading,
+} from "@/lib/catalog/measuringCopy";
+import { getCatalogReportEmptyCopy } from "@/lib/catalog/getCatalogReportEmptyCopy";
+
+describe("measuringCopy", () => {
+  // chat#1912 row 10: the same minute of waiting was described four different
+  // ways across the seeding toast, /setup/valuation, /catalogs/{id} and
+  // marketing, with three different time estimates. The estimate a customer
+  // gets should not depend on which surface they happen to be looking at.
+  it("states the time estimate once", () => {
+    expect(MEASURING_ESTIMATE).toContain("about a minute");
+    expect(MEASURING_BODY).toContain(MEASURING_ESTIMATE);
+  });
+
+  it("is used by the catalog report's measuring state", () => {
+    const copy = getCatalogReportEmptyCopy("measuring", { hasOwnCatalogs: true });
+
+    expect(copy.title).toBe(MEASURING_TITLE);
+    expect(copy.body).toContain(MEASURING_ESTIMATE);
+  });
+
+  it("keeps the report's own reassurance without restating the estimate", () => {
+    const copy = getCatalogReportEmptyCopy("measuring", { hasOwnCatalogs: true });
+
+    expect(copy.body).toContain("no need to run the valuation again");
+    // The estimate must appear once in the sentence, not twice.
+    expect(copy.body.split("about a minute").length - 1).toBe(1);
+  });
+
+  it("uses the same verb in the seeding toast as on the pages", () => {
+    expect(measuringToastLoading("BennyJ504")).toBe("Measuring BennyJ504's catalog…");
+    expect(MEASURING_TOAST_SUCCESS.length).toBeGreaterThan(0);
+  });
+
+  // House style: em dashes read as machine-written in product copy.
+  it("keeps the shared copy free of em dashes", () => {
+    const all = [MEASURING_TITLE, MEASURING_ESTIMATE, MEASURING_BODY, MEASURING_TOAST_SUCCESS].join(" ");
+    expect(all).not.toMatch(/[—–]/);
+  });
+});

--- a/lib/catalog/getCatalogReportEmptyCopy.ts
+++ b/lib/catalog/getCatalogReportEmptyCopy.ts
@@ -1,4 +1,5 @@
 import type { CatalogReportState } from "./getCatalogReportState";
+import { MEASURING_BODY, MEASURING_TITLE } from "./measuringCopy";
 
 export type CatalogReportEmptyState = Exclude<
   CatalogReportState,
@@ -24,8 +25,8 @@ const COPY: Record<CatalogReportEmptyState, CatalogReportEmptyCopy> = {
     cta: { label: "Sign in", action: "login" },
   },
   measuring: {
-    title: "Measuring your catalog",
-    body: "We are pulling live play counts for every track. This usually takes about a minute, and the report appears here on its own. There is no need to run the valuation again.",
+    title: MEASURING_TITLE,
+    body: `${MEASURING_BODY} The report appears here on its own, so there is no need to run the valuation again.`,
   },
   "other-account": {
     title: "This catalog was measured by another account",

--- a/lib/catalog/measuringCopy.ts
+++ b/lib/catalog/measuringCopy.ts
@@ -1,0 +1,30 @@
+/**
+ * One description of one wait.
+ *
+ * The minute between seeding a catalog and its measurements landing is shown on
+ * three chat surfaces — the `/setup/artists` seeding toast, `/setup/valuation`,
+ * and the `/catalogs/{id}` report — and each had drifted into its own wording
+ * and its own time estimate ("a minute", "about a minute", "a minute or two").
+ * The estimate a customer is given should not depend on which surface they
+ * happen to be looking at (chat#1912 row 10).
+ *
+ * Marketing keeps its own copy of these strings, since it is a separate
+ * deployment; the contract is that the text matches, not that the module is
+ * imported across repos.
+ */
+export const MEASURING_TITLE = "Measuring your catalog";
+
+/** The single source for how long this takes. Change it here, nowhere else. */
+export const MEASURING_ESTIMATE =
+  "This usually takes about a minute, and longer for large catalogs.";
+
+export const MEASURING_BODY = `We are pulling live play counts for every track. ${MEASURING_ESTIMATE}`;
+
+/** Seeding runs in the background, so its toast uses the same verb as the pages. */
+export const measuringToastLoading = (artistName: string) =>
+  `Measuring ${artistName}'s catalog…`;
+
+export const MEASURING_TOAST_SUCCESS = "Your catalog is ready";
+
+export const MEASURING_TOAST_ERROR =
+  "Couldn't measure the catalog automatically, you can claim it later";


### PR DESCRIPTION
Chat half of row 10 in [chat#1912](https://github.com/recoupable/chat/issues/1912). Marketing half: **[recoupable/marketing#62](https://github.com/recoupable/marketing/pull/62)**.

## Why

The same minute of waiting was described four different ways, with **three different time estimates**:

| Surface | Said |
|---|---|
| `/setup/artists` seeding toast | *"Valuing BennyJ504's catalog…"* |
| `MeasuringCatalogPanel` (`/setup/valuation`) | *"…This usually takes **a minute**."* |
| `getCatalogReportEmptyCopy` (`/catalogs/{id}`) | *"…This usually takes **about a minute**…"* |
| marketing `ValuationProgress` | *"…Large catalogs can take **a minute or two**."* |

None is wrong; they drifted. But the estimate a customer is given now depends on which surface they happen to be looking at, and a signup can see two of them within the same minute — the toast fires on `/setup/artists`, then they land on `/setup/valuation`.

## What changed

`lib/catalog/measuringCopy.ts` holds the title, the estimate, the body, and the toast strings. All three chat surfaces read from it.

The estimate now says **"This usually takes about a minute, and longer for large catalogs"** — it absorbs marketing's "a minute or two" caveat, which was the only one of the four that acknowledged catalog size, and that is genuinely true.

The toast also switches verb from *"Valuing"* to *"Measuring"* so the background seeding matches what the pages call the same operation.

Each surface keeps its own contextual sentence — the report's *"no need to run the valuation again"*, the setup panel's *"your baseline value appears here"* — but **none restates the estimate**. There is a test asserting the estimate appears exactly once in the report's body, since the obvious way to get this wrong is to concatenate two sentences that both mention a minute.

## Tests

`lib/catalog/__tests__/measuringCopy.test.ts` — 5 cases: the estimate is stated once, the report's measuring state uses it, the report keeps its own reassurance **without** duplicating the estimate, the toast uses the shared verb, and the copy is free of em dashes per house style.

Full suite **342 passed / 83 files**, `tsc --noEmit` and `eslint` clean. Grepping for the estimate across `lib/`, `components/` and `hooks/` now returns exactly **one** definition.

## Verification

This is a copy change with no behavioural effect, so there is nothing to probe on a preview beyond reading the three surfaces. I will walk `/setup/artists` → `/setup/valuation` → `/catalogs/{id}` on the preview and post the three renderings, so the claim "reads the same everywhere" is shown rather than asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unified the measuring wait copy across chat surfaces for consistent messaging. All surfaces now share one estimate: “This usually takes about a minute, and longer for large catalogs,” and the toast uses “Measuring.”

- **Bug Fixes**
  - Centralized copy in `lib/catalog/measuringCopy.ts` and wired into `/setup/valuation`, `/setup/artists` toast (loading/success/error), and the catalog report.
  - Switched the toast verb to “Measuring,” and removed duplicate estimates while keeping each surface’s contextual line.
  - Strengthened tests to assert the single estimate, verb agreement with the title, and copy style.

<sup>Written for commit 4b68134e32313bd48617f52605587393110117cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Consistency**
  * Standardized catalog measurement messaging across onboarding, report states, and notifications.
  * Added consistent loading, success, and error messages during catalog measurement.
  * Clarified that reports appear automatically and do not need to be rerun.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->