### PR TITLE
fix(onboarding): show the schedule instead of "No runs yet"

### DIFF
--- a/components/Onboarding/ExistingWeeklyReportPanel.tsx
+++ b/components/Onboarding/ExistingWeeklyReportPanel.tsx
@@ -5,6 +5,7 @@ import { CalendarClock } from "lucide-react";
 import { buttonVariants } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import type { Task } from "@/lib/tasks/getTasks";
+import { describeNextRun } from "@/lib/tasks/describeNextRun";
 
 /**
  * Shown at `/setup/tasks` when the account already has an enabled schedule
@@ -14,7 +15,7 @@ import type { Task } from "@/lib/tasks/getTasks";
  */
 const ExistingWeeklyReportPanel = ({ task }: { task: Task }) => {
   const latestRun = task.recent_runs?.[0];
-  const nextRun = task.upcoming?.[0];
+  const nextRun = describeNextRun({ schedule: task.schedule, upcoming: task.upcoming });
 
   return (
     <section className="flex flex-col items-center gap-4 py-8 text-center">
@@ -24,12 +25,14 @@ const ExistingWeeklyReportPanel = ({ task }: { task: Task }) => {
           Your weekly report is already set up
         </h1>
         <p className="mt-1 text-sm text-muted-foreground">
-          {nextRun
-            ? `Next run ${new Date(nextRun).toLocaleString()}.`
-            : "It runs on its schedule and emails you the result."}
+          {nextRun.kind === "timestamp"
+            ? `Next run ${nextRun.value}.`
+            : nextRun.kind === "cron"
+              ? `Runs ${nextRun.value.toLowerCase()}, emailed to you.`
+              : "It runs on its schedule and emails you the result."}
           {latestRun?.createdAt
             ? ` Last run ${new Date(latestRun.createdAt).toLocaleString()}.`
-            : " No runs yet."}
+            : " It has not run yet."}
         </p>
       </div>
       <Link

--- a/lib/tasks/__tests__/describeNextRun.test.ts
+++ b/lib/tasks/__tests__/describeNextRun.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { describeNextRun } from "@/lib/tasks/describeNextRun";
+
+describe("describeNextRun", () => {
+  it("prefers a concrete upcoming timestamp when Trigger supplied one", () => {
+    const result = describeNextRun({
+      schedule: "0 10 * * 1",
+      upcoming: ["2026-08-03T14:00:00.000Z"],
+    });
+    expect(result.kind).toBe("timestamp");
+    expect(result.value).toContain("2026");
+  });
+
+  // The regression this exists for (chat#1918): an empty `upcoming` is common on a
+  // perfectly live schedule, and "No runs yet" read as though nothing was set up.
+  it("falls back to the cron description when upcoming is empty", () => {
+    const result = describeNextRun({ schedule: "0 10 * * 1", upcoming: [] });
+    expect(result.kind).toBe("cron");
+    expect(result.value).toMatch(/Monday/i);
+  });
+
+  it("falls back to the cron description when upcoming is undefined", () => {
+    const result = describeNextRun({ schedule: "0 9 * * *" });
+    expect(result.kind).toBe("cron");
+    expect(result.value).toMatch(/09:00|9:00/);
+  });
+
+  it("returns kind 'unknown' when the cron cannot be parsed and there is no upcoming", () => {
+    const result = describeNextRun({ schedule: "not-a-cron", upcoming: [] });
+    expect(result.kind).toBe("unknown");
+    expect(result.value).toBeNull();
+  });
+
+  it("returns kind 'unknown' when there is no schedule at all", () => {
+    const result = describeNextRun({ schedule: null, upcoming: [] });
+    expect(result.kind).toBe("unknown");
+  });
+
+  it("ignores a malformed upcoming entry and falls back to the cron", () => {
+    const result = describeNextRun({ schedule: "0 10 * * 1", upcoming: ["not-a-date"] });
+    expect(result.kind).toBe("cron");
+  });
+});

--- a/lib/tasks/describeNextRun.ts
+++ b/lib/tasks/describeNextRun.ts
@@ -1,0 +1,36 @@
+import { getCronHumanPreview } from "@/lib/tasks/getCronHumanPreview";
+
+export type NextRunDescription =
+  | { kind: "timestamp"; value: string }
+  | { kind: "cron"; value: string }
+  | { kind: "unknown"; value: null };
+
+/**
+ * Describes when a task will next run, degrading gracefully.
+ *
+ * `upcoming` comes from the latest Trigger.dev run payload, so it is empty for
+ * any schedule that has not run yet — and empty just as often when the Trigger
+ * lookup failed (api-side `trigger_lookup_failed`, chat#1918). Treating that as
+ * "nothing is scheduled" under-sold a live schedule to every cold-start signup.
+ * The cron on the task is always present and always true, so it is the fallback.
+ */
+export function describeNextRun({
+  schedule,
+  upcoming,
+}: {
+  schedule: string | null;
+  upcoming?: string[];
+}): NextRunDescription {
+  const first = upcoming?.[0];
+  if (first) {
+    const parsed = new Date(first);
+    if (!Number.isNaN(parsed.getTime())) {
+      return { kind: "timestamp", value: parsed.toLocaleString() };
+    }
+  }
+
+  const humanCron = schedule ? getCronHumanPreview(schedule) : null;
+  if (humanCron) return { kind: "cron", value: humanCron };
+
+  return { kind: "unknown", value: null };
+}


### PR DESCRIPTION
Closes the "show upcoming run times" row of [chat#1918](https://github.com/recoupable/chat/issues/1918). Unblocked — [chat#1898](https://github.com/recoupable/chat/pull/1898) is merged.

## The problem

`ExistingWeeklyReportPanel` keyed entirely on `task.upcoming`:

```jsx
{nextRun ? `Next run …` : "It runs on its schedule and emails you the result."}
{latestRun?.createdAt ? ` Last run …` : " No runs yet."}
```

`upcoming` is sourced from the **latest Trigger.dev run payload**, so it is empty for any schedule that has not run yet — and empty just as often when the Trigger lookup failed (the api-side false-negative fixed in [api#806](https://github.com/recoupable/api/pull/806)). Every cold-start signup lands on this panel post-chat#1900, and "No runs yet" read as though nothing had been set up at all.

## The fix

New `describeNextRun` (one exported function, own file, per repo SRP) that degrades in three steps:

1. a concrete `upcoming` timestamp when Trigger supplied one → *"Next run 8/3/2026, 10:00:00 AM."*
2. otherwise the task's **cron**, rendered by the existing `getCronHumanPreview` → *"Runs at 10:00 am, only on monday, emailed to you."*
3. only then the generic fallback

`" No runs yet."` becomes `" It has not run yet."` — accurate without implying the setup is missing.

The cron lives on the task, is always present, and is always true, so step 2 is correct even while Trigger is unreachable.

## On the issue's suggested fix

The issue proposed rendering *"the next ~3 occurrences computed from the task's cron as a small table"*. I did not do that, deliberately: computing occurrences needs a cron **evaluator** (`cron-parser`/`croner`), and the repo only carries `cronstrue`, which describes but does not iterate. Adding a dependency to render three timestamps in a one-line panel did not seem worth it, and the human-readable form sidesteps the user-local-vs-UTC ambiguity the issue itself flagged as undecided.

Happy to swap to literal occurrences if you'd rather take the dependency — say the word and it is a small follow-up.

## Tests

6 tests in `lib/tasks/__tests__/describeNextRun.test.ts`, RED first (module not found), covering: concrete timestamp preferred; empty `upcoming` falls back to cron; `undefined` `upcoming` falls back to cron; unparseable cron with no upcoming → `unknown`; no schedule at all → `unknown`; malformed upcoming entry ignored in favour of the cron.

- `pnpm exec vitest run lib/tasks` → **8 files, 25 tests**, all pass
- `pnpm exec tsc --noEmit` → no errors in either touched file
- `pnpm exec eslint` → clean

## Remaining verification

This is a visual change and per house rules wants a screenshot of the panel in both states (with and without `upcoming`) from a preview deployment before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the next run or the schedule in onboarding instead of “No runs yet” to avoid confusion when `upcoming` is empty or lookup fails. This makes the weekly report panel accurate for new signups and cold starts.

- **Bug Fixes**
  - Use `describeNextRun({ schedule, upcoming })` in `ExistingWeeklyReportPanel` instead of keying solely on `task.upcoming`.
  - Fallback order: upcoming timestamp → cron via `getCronHumanPreview` → unknown.
  - Copy updates: “Runs … emailed to you.” and “It has not run yet.” for clarity.
  - Added tests for timestamp preference, empty/undefined `upcoming`, bad cron, no schedule, and malformed dates.

<sup>Written for commit 914633f054b3a47cf2952ccffbe2a0c4f383078c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

