### PR TITLE
fix(chat): reconnect a dropped response stream instead of freezing mid-turn

### DIFF
--- a/hooks/useChatTransport.ts
+++ b/hooks/useChatTransport.ts
@@ -119,7 +119,7 @@ export function useChatTransport({
         // Reconnect hits `GET {api}/{chatId}/stream` — recoup-api's resume
         // route, which is authenticated like every other endpoint. Without
         // this the reconnect 401s and a dropped stream stays dropped.
-        prepareReconnectToStreamRequest: async ({ api, id }) => {
+        prepareReconnectToStreamRequest: async ({ api }) => {
           const accessToken = await getAccessToken().catch(() => null);
           const headers: Record<string, string> = {};
           if (accessToken) headers.Authorization = `Bearer ${accessToken}`;
@@ -129,8 +129,15 @@ export function useChatTransport({
           // `api` of our own. Returning one replaces the whole URL, so the
           // path has to be rebuilt, not appended to: appending the query to
           // the base produced `POST`-only `/api/chat?startIndex=N` and 405s.
+          //
+          // Built from `chatIdRef`, NOT the `id` the callback is handed: that
+          // is the `useChat` INSTANCE id, which for a new chat is still the
+          // client placeholder while the api-minted id lives in the ref. Using
+          // it reconnected to a chat that does not exist and 404'd. This is the
+          // same ref the request body already sends as `chatId`.
           const last = lastChunkIndexRef.current;
-          const url = `${api}/${id}/stream${last === null ? "" : `?startIndex=${last + 1}`}`;
+          const chatId = chatIdRef.current;
+          const url = `${api}/${chatId}/stream${last === null ? "" : `?startIndex=${last + 1}`}`;
 
           return { headers, api: url };
         },

--- a/hooks/useChatTransport.ts
+++ b/hooks/useChatTransport.ts
@@ -2,6 +2,8 @@ import { useMemo, useCallback, useRef } from "react";
 import { DefaultChatTransport } from "ai";
 import { getClientApiBaseUrl } from "@/lib/api/getClientApiBaseUrl";
 import { usePrivy } from "@privy-io/react-auth";
+import { createChunkCountingFetch } from "@/lib/chat/createChunkCountingFetch";
+import { buildStreamReconnectUrl } from "@/lib/chat/buildStreamReconnectUrl";
 
 interface UseChatTransportOptions {
   /** Chat row id (also the AI SDK `useChat({ id })` instance id). */
@@ -35,15 +37,13 @@ export function useChatTransport({
   // stable while always sending the ids current as of the request.
   const chatIdRef = useRef(chatId);
   const sessionIdRef = useRef(sessionId);
-  // Absolute index of the last stream chunk this client has actually received.
-  // Drives `startIndex` on reconnect so a resume is gap-free rather than a
-  // replay. Counted from the wire, NOT taken from
-  // `x-workflow-stream-tail-index`: that header reports the tail at the moment
-  // the read was opened, so a read that stays open past it under-reports (a
-  // live read returning 22 chunks advertised a tail of 9). The header is only
-  // a base for the read's starting position; what we have actually consumed is
-  // that base plus the chunks counted off the body.
+  // Absolute index of the last stream chunk this client received, maintained
+  // by `createChunkCountingFetch`. Drives `startIndex` on reconnect.
   const lastChunkIndexRef = useRef<number | null>(null);
+  // Switching chats voids the position: the transport is memoised for the
+  // lifetime of the hook, so without this a reconnect for the new chat could
+  // resume at an index belonging to the old one.
+  if (chatIdRef.current !== chatId) lastChunkIndexRef.current = null;
   chatIdRef.current = chatId;
   sessionIdRef.current = sessionId;
 
@@ -70,76 +70,28 @@ export function useChatTransport({
           if (recoupAccessToken) body.recoupAccessToken = recoupAccessToken;
           return body;
         },
-        // Track how far through the stream this client actually got, by
-        // counting SSE frames off a tee of the body. `startIndex` on the next
-        // reconnect is that position + 1, so a resume neither replays chunks
-        // we have rendered nor skips ones we have not.
-        fetch: (async (input, init) => {
-          const response = await globalThis.fetch(input as RequestInfo, init);
-          if (!response.body) return response;
-
-          const url = typeof input === "string" ? input : (input as Request).url;
-          const requested = Number(new URL(url, baseUrl).searchParams.get("startIndex") ?? "0");
-          let index = (Number.isInteger(requested) && requested >= 0 ? requested : 0) - 1;
-
-          const [toCaller, toCount] = response.body.tee();
-          void (async () => {
-            const reader = toCount.getReader();
-            const decoder = new TextDecoder();
-            let buffered = "";
-            try {
-              for (;;) {
-                const { done, value } = await reader.read();
-                if (done) break;
-                buffered += decoder.decode(value, { stream: true });
-                const lines = buffered.split("\n");
-                buffered = lines.pop() ?? "";
-                for (const line of lines) {
-                  // `[DONE]` is the SSE terminator, not a stream chunk.
-                  if (line.startsWith("data: ") && !line.startsWith("data: [DONE]")) {
-                    index += 1;
-                    lastChunkIndexRef.current = index;
-                  }
-                }
-              }
-            } catch {
-              // Counting is best-effort; a torn read just means the next
-              // reconnect resumes from the last index we did count.
-            } finally {
-              reader.releaseLock();
-            }
-          })();
-
-          return new Response(toCaller, {
-            status: response.status,
-            statusText: response.statusText,
-            headers: response.headers,
-          });
-        }) as typeof globalThis.fetch,
-        // Reconnect hits `GET {api}/{chatId}/stream` — recoup-api's resume
-        // route, which is authenticated like every other endpoint. Without
-        // this the reconnect 401s and a dropped stream stays dropped.
+        fetch: createChunkCountingFetch({
+          baseUrl,
+          onPosition: (index) => {
+            lastChunkIndexRef.current = index;
+          },
+        }),
+        // Reconnect hits recoup-api's resume route, which is authenticated
+        // like every other endpoint. Without this the reconnect 401s and a
+        // dropped stream stays dropped.
         prepareReconnectToStreamRequest: async ({ api }) => {
           const accessToken = await getAccessToken().catch(() => null);
           const headers: Record<string, string> = {};
           if (accessToken) headers.Authorization = `Bearer ${accessToken}`;
 
-          // `api` here is the BASE (`…/api/chat`), not the reconnect URL — the
-          // SDK only falls back to `${api}/${id}/stream` when we return no
-          // `api` of our own. Returning one replaces the whole URL, so the
-          // path has to be rebuilt, not appended to: appending the query to
-          // the base produced `POST`-only `/api/chat?startIndex=N` and 405s.
-          //
-          // Built from `chatIdRef`, NOT the `id` the callback is handed: that
-          // is the `useChat` INSTANCE id, which for a new chat is still the
-          // client placeholder while the api-minted id lives in the ref. Using
-          // it reconnected to a chat that does not exist and 404'd. This is the
-          // same ref the request body already sends as `chatId`.
-          const last = lastChunkIndexRef.current;
-          const chatId = chatIdRef.current;
-          const url = `${api}/${chatId}/stream${last === null ? "" : `?startIndex=${last + 1}`}`;
-
-          return { headers, api: url };
+          return {
+            headers,
+            api: buildStreamReconnectUrl(
+              api,
+              chatIdRef.current,
+              lastChunkIndexRef.current,
+            ),
+          };
         },
       }),
     [baseUrl, getAccessToken],

--- a/hooks/useChatTransport.ts
+++ b/hooks/useChatTransport.ts
@@ -35,10 +35,15 @@ export function useChatTransport({
   // stable while always sending the ids current as of the request.
   const chatIdRef = useRef(chatId);
   const sessionIdRef = useRef(sessionId);
-  // Highest chunk index the server has reported serving us, from the
-  // `x-workflow-stream-tail-index` response header. Drives `startIndex` on
-  // reconnect so a resume is gap-free rather than a replay.
-  const tailIndexRef = useRef<number | null>(null);
+  // Absolute index of the last stream chunk this client has actually received.
+  // Drives `startIndex` on reconnect so a resume is gap-free rather than a
+  // replay. Counted from the wire, NOT taken from
+  // `x-workflow-stream-tail-index`: that header reports the tail at the moment
+  // the read was opened, so a read that stays open past it under-reports (a
+  // live read returning 22 chunks advertised a tail of 9). The header is only
+  // a base for the read's starting position; what we have actually consumed is
+  // that base plus the chunks counted off the body.
+  const lastChunkIndexRef = useRef<number | null>(null);
   chatIdRef.current = chatId;
   sessionIdRef.current = sessionId;
 
@@ -65,19 +70,51 @@ export function useChatTransport({
           if (recoupAccessToken) body.recoupAccessToken = recoupAccessToken;
           return body;
         },
-        // Capture `x-workflow-stream-tail-index` off every response. The
-        // resume route reports where the read it just served ends, which is
-        // the only honest value to send as `startIndex` on the next
-        // reconnect — without it a reconnect replays the turn from chunk zero
-        // and the client re-renders content it already has.
+        // Track how far through the stream this client actually got, by
+        // counting SSE frames off a tee of the body. `startIndex` on the next
+        // reconnect is that position + 1, so a resume neither replays chunks
+        // we have rendered nor skips ones we have not.
         fetch: (async (input, init) => {
           const response = await globalThis.fetch(input as RequestInfo, init);
-          const tail = response.headers.get("x-workflow-stream-tail-index");
-          if (tail !== null) {
-            const parsed = Number(tail);
-            if (Number.isInteger(parsed) && parsed >= 0) tailIndexRef.current = parsed;
-          }
-          return response;
+          if (!response.body) return response;
+
+          const url = typeof input === "string" ? input : (input as Request).url;
+          const requested = Number(new URL(url, baseUrl).searchParams.get("startIndex") ?? "0");
+          let index = (Number.isInteger(requested) && requested >= 0 ? requested : 0) - 1;
+
+          const [toCaller, toCount] = response.body.tee();
+          void (async () => {
+            const reader = toCount.getReader();
+            const decoder = new TextDecoder();
+            let buffered = "";
+            try {
+              for (;;) {
+                const { done, value } = await reader.read();
+                if (done) break;
+                buffered += decoder.decode(value, { stream: true });
+                const lines = buffered.split("\n");
+                buffered = lines.pop() ?? "";
+                for (const line of lines) {
+                  // `[DONE]` is the SSE terminator, not a stream chunk.
+                  if (line.startsWith("data: ") && !line.startsWith("data: [DONE]")) {
+                    index += 1;
+                    lastChunkIndexRef.current = index;
+                  }
+                }
+              }
+            } catch {
+              // Counting is best-effort; a torn read just means the next
+              // reconnect resumes from the last index we did count.
+            } finally {
+              reader.releaseLock();
+            }
+          })();
+
+          return new Response(toCaller, {
+            status: response.status,
+            statusText: response.statusText,
+            headers: response.headers,
+          });
         }) as typeof globalThis.fetch,
         // Reconnect hits `GET {api}/{chatId}/stream` — recoup-api's resume
         // route, which is authenticated like every other endpoint. Without
@@ -87,10 +124,9 @@ export function useChatTransport({
           const headers: Record<string, string> = {};
           if (accessToken) headers.Authorization = `Bearer ${accessToken}`;
 
-          // Resume from the chunk after the last one we saw. The route reports
-          // a 0-based tail index, so the next unseen chunk is tail + 1.
-          const tail = tailIndexRef.current;
-          const url = tail === null ? api : `${api}?startIndex=${tail + 1}`;
+          // Resume from the chunk after the last one we actually received.
+          const last = lastChunkIndexRef.current;
+          const url = last === null ? api : `${api}?startIndex=${last + 1}`;
 
           return { headers, api: url };
         },

--- a/hooks/useChatTransport.ts
+++ b/hooks/useChatTransport.ts
@@ -119,14 +119,18 @@ export function useChatTransport({
         // Reconnect hits `GET {api}/{chatId}/stream` — recoup-api's resume
         // route, which is authenticated like every other endpoint. Without
         // this the reconnect 401s and a dropped stream stays dropped.
-        prepareReconnectToStreamRequest: async ({ api }) => {
+        prepareReconnectToStreamRequest: async ({ api, id }) => {
           const accessToken = await getAccessToken().catch(() => null);
           const headers: Record<string, string> = {};
           if (accessToken) headers.Authorization = `Bearer ${accessToken}`;
 
-          // Resume from the chunk after the last one we actually received.
+          // `api` here is the BASE (`…/api/chat`), not the reconnect URL — the
+          // SDK only falls back to `${api}/${id}/stream` when we return no
+          // `api` of our own. Returning one replaces the whole URL, so the
+          // path has to be rebuilt, not appended to: appending the query to
+          // the base produced `POST`-only `/api/chat?startIndex=N` and 405s.
           const last = lastChunkIndexRef.current;
-          const url = last === null ? api : `${api}?startIndex=${last + 1}`;
+          const url = `${api}/${id}/stream${last === null ? "" : `?startIndex=${last + 1}`}`;
 
           return { headers, api: url };
         },

--- a/hooks/useChatTransport.ts
+++ b/hooks/useChatTransport.ts
@@ -35,6 +35,10 @@ export function useChatTransport({
   // stable while always sending the ids current as of the request.
   const chatIdRef = useRef(chatId);
   const sessionIdRef = useRef(sessionId);
+  // Highest chunk index the server has reported serving us, from the
+  // `x-workflow-stream-tail-index` response header. Drives `startIndex` on
+  // reconnect so a resume is gap-free rather than a replay.
+  const tailIndexRef = useRef<number | null>(null);
   chatIdRef.current = chatId;
   sessionIdRef.current = sessionId;
 
@@ -61,14 +65,34 @@ export function useChatTransport({
           if (recoupAccessToken) body.recoupAccessToken = recoupAccessToken;
           return body;
         },
+        // Capture `x-workflow-stream-tail-index` off every response. The
+        // resume route reports where the read it just served ends, which is
+        // the only honest value to send as `startIndex` on the next
+        // reconnect — without it a reconnect replays the turn from chunk zero
+        // and the client re-renders content it already has.
+        fetch: (async (input, init) => {
+          const response = await globalThis.fetch(input as RequestInfo, init);
+          const tail = response.headers.get("x-workflow-stream-tail-index");
+          if (tail !== null) {
+            const parsed = Number(tail);
+            if (Number.isInteger(parsed) && parsed >= 0) tailIndexRef.current = parsed;
+          }
+          return response;
+        }) as typeof globalThis.fetch,
         // Reconnect hits `GET {api}/{chatId}/stream` — recoup-api's resume
         // route, which is authenticated like every other endpoint. Without
         // this the reconnect 401s and a dropped stream stays dropped.
-        prepareReconnectToStreamRequest: async () => {
+        prepareReconnectToStreamRequest: async ({ api }) => {
           const accessToken = await getAccessToken().catch(() => null);
           const headers: Record<string, string> = {};
           if (accessToken) headers.Authorization = `Bearer ${accessToken}`;
-          return { headers };
+
+          // Resume from the chunk after the last one we saw. The route reports
+          // a 0-based tail index, so the next unseen chunk is tail + 1.
+          const tail = tailIndexRef.current;
+          const url = tail === null ? api : `${api}?startIndex=${tail + 1}`;
+
+          return { headers, api: url };
         },
       }),
     [baseUrl, getAccessToken],

--- a/hooks/useChatTransport.ts
+++ b/hooks/useChatTransport.ts
@@ -61,6 +61,15 @@ export function useChatTransport({
           if (recoupAccessToken) body.recoupAccessToken = recoupAccessToken;
           return body;
         },
+        // Reconnect hits `GET {api}/{chatId}/stream` — recoup-api's resume
+        // route, which is authenticated like every other endpoint. Without
+        // this the reconnect 401s and a dropped stream stays dropped.
+        prepareReconnectToStreamRequest: async () => {
+          const accessToken = await getAccessToken().catch(() => null);
+          const headers: Record<string, string> = {};
+          if (accessToken) headers.Authorization = `Bearer ${accessToken}`;
+          return { headers };
+        },
       }),
     [baseUrl, getAccessToken],
   );

--- a/hooks/useStreamRecovery.ts
+++ b/hooks/useStreamRecovery.ts
@@ -58,7 +58,7 @@ export function useStreamRecovery({
   }, [status]);
 
   // The evaluation itself lives in a ref so listeners keep a stable identity.
-  const maybeRecoverRef = useRef((_opts?: { isVisibilityCheck?: boolean }) => {});
+  const maybeRecoverRef = useRef<(opts?: { isVisibilityCheck?: boolean }) => void>(() => {});
   maybeRecoverRef.current = (opts) => {
     const now = Date.now();
     if (

--- a/hooks/useStreamRecovery.ts
+++ b/hooks/useStreamRecovery.ts
@@ -1,0 +1,106 @@
+import { useEffect, useRef } from "react";
+import {
+  shouldRecoverStalledStream,
+  STREAM_STALL_MS,
+} from "@/lib/chat/shouldRecoverStalledStream";
+
+/** How often we re-evaluate whether the stream has gone quiet. */
+const POLL_MS = 5_000;
+
+interface UseStreamRecoveryOptions {
+  /** Current `useChat` status. */
+  status: string;
+  /**
+   * Changes whenever the assistant produces output. Any value that moves as
+   * chunks arrive works — the hook only reads it to timestamp "last activity".
+   */
+  activityMarker: unknown;
+  /** `resumeStream` from `useChat`; reconnects to the run's stream. */
+  resumeStream: () => Promise<void> | void;
+}
+
+/**
+ * Reconnect a chat turn whose stream dropped mid-run.
+ *
+ * A long turn's SSE response can end before the workflow does: on prod
+ * 2026-08-02 the connection closed with a clean `[DONE]` and no `finish`
+ * chunk, so `useChat` stopped rendering while the run went on to complete
+ * 7 more iterations. Nothing surfaced that — no error, no retry — and the
+ * only recovery was a page refresh (chat#1923).
+ *
+ * Watches for silence on an in-flight turn and calls `resumeStream()`, which
+ * reconnects via `GET /api/chat/{chatId}/stream`. Also re-checks when the tab
+ * regains visibility, since a backgrounded tab is where drops are most likely
+ * and least likely to be noticed.
+ */
+export function useStreamRecovery({
+  status,
+  activityMarker,
+  resumeStream,
+}: UseStreamRecoveryOptions): void {
+  const lastChunkAtRef = useRef<number | null>(null);
+  const lastRecoveryAtRef = useRef(0);
+  const isRecoveryInFlightRef = useRef(false);
+
+  // Timestamp activity. Kept in a ref so the polling effect never re-registers
+  // as output streams in.
+  useEffect(() => {
+    lastChunkAtRef.current = Date.now();
+  }, [activityMarker]);
+
+  // Reset between turns so a previous turn's timings can't trigger a recovery
+  // on the next one.
+  useEffect(() => {
+    if (status === "submitted") {
+      lastChunkAtRef.current = Date.now();
+      lastRecoveryAtRef.current = 0;
+    }
+  }, [status]);
+
+  // The evaluation itself lives in a ref so listeners keep a stable identity.
+  const maybeRecoverRef = useRef(() => {});
+  maybeRecoverRef.current = () => {
+    const now = Date.now();
+    if (
+      !shouldRecoverStalledStream({
+        status,
+        now,
+        lastChunkAt: lastChunkAtRef.current,
+        lastRecoveryAt: lastRecoveryAtRef.current,
+        isRecoveryInFlight: isRecoveryInFlightRef.current,
+      })
+    ) {
+      return;
+    }
+
+    lastRecoveryAtRef.current = now;
+    isRecoveryInFlightRef.current = true;
+
+    void (async () => {
+      try {
+        await resumeStream();
+      } catch (error) {
+        // A failed reconnect is not fatal — the next tick tries again, and a
+        // finished run resolves to 204 which ends the loop naturally.
+        console.error("[useStreamRecovery] resumeStream failed:", error);
+      } finally {
+        isRecoveryInFlightRef.current = false;
+      }
+    })();
+  };
+
+  useEffect(() => {
+    const interval = setInterval(() => maybeRecoverRef.current(), POLL_MS);
+    const onVisible = () => {
+      if (document.visibilityState === "visible") maybeRecoverRef.current();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+
+    return () => {
+      clearInterval(interval);
+      document.removeEventListener("visibilitychange", onVisible);
+    };
+  }, []);
+}
+
+export { STREAM_STALL_MS };

--- a/hooks/useStreamRecovery.ts
+++ b/hooks/useStreamRecovery.ts
@@ -5,7 +5,7 @@ import {
 } from "@/lib/chat/shouldRecoverStalledStream";
 
 /** How often we re-evaluate whether the stream has gone quiet. */
-const POLL_MS = 5_000;
+const POLL_MS = 3_000;
 
 interface UseStreamRecoveryOptions {
   /** Current `useChat` status. */
@@ -58,8 +58,8 @@ export function useStreamRecovery({
   }, [status]);
 
   // The evaluation itself lives in a ref so listeners keep a stable identity.
-  const maybeRecoverRef = useRef(() => {});
-  maybeRecoverRef.current = () => {
+  const maybeRecoverRef = useRef((_opts?: { isVisibilityCheck?: boolean }) => {});
+  maybeRecoverRef.current = (opts) => {
     const now = Date.now();
     if (
       !shouldRecoverStalledStream({
@@ -68,6 +68,7 @@ export function useStreamRecovery({
         lastChunkAt: lastChunkAtRef.current,
         lastRecoveryAt: lastRecoveryAtRef.current,
         isRecoveryInFlight: isRecoveryInFlightRef.current,
+        isVisibilityCheck: opts?.isVisibilityCheck,
       })
     ) {
       return;
@@ -92,7 +93,9 @@ export function useStreamRecovery({
   useEffect(() => {
     const interval = setInterval(() => maybeRecoverRef.current(), POLL_MS);
     const onVisible = () => {
-      if (document.visibilityState === "visible") maybeRecoverRef.current();
+      if (document.visibilityState === "visible") {
+        maybeRecoverRef.current({ isVisibilityCheck: true });
+      }
     };
     document.addEventListener("visibilitychange", onVisible);
 

--- a/hooks/useVercelChat.ts
+++ b/hooks/useVercelChat.ts
@@ -26,6 +26,7 @@ import getMimeFromPath from "@/lib/files/getMimeFromPath";
 import { getChatPath } from "@/lib/chat/getChatPath";
 import { useInitialMessageAutoSend } from "./useInitialMessageAutoSend";
 import { usePersistSelectedModel } from "./usePersistSelectedModel";
+import { useStreamRecovery } from "./useStreamRecovery";
 
 interface UseVercelChatProps {
   id: string;
@@ -213,10 +214,13 @@ export function useVercelChat({
     [id, artistId, organizationId, accountIdOverride, model],
   );
 
-  const { messages, status, stop, sendMessage, setMessages, regenerate } =
+  const { messages, status, stop, sendMessage, setMessages, regenerate, resumeStream } =
     useChat({
       id,
       transport,
+      // Re-attach to an in-progress response on mount, so returning to a chat
+      // mid-turn keeps rendering instead of showing a frozen half-message.
+      resume: true,
       experimental_throttle: 100,
       generateId: generateUUID,
       onError: (e) => {
@@ -228,6 +232,14 @@ export function useVercelChat({
         await refetchCredits();
       },
     });
+
+  // A long turn's SSE stream can end before the run does (chat#1923). Watch
+  // for silence on an in-flight turn and reconnect via the resume route.
+  useStreamRecovery({
+    status,
+    activityMarker: messages,
+    resumeStream,
+  });
 
   const earliestFailedUserMessageId = useMemo(
     () => getEarliestFailedUserMessageId(messages),

--- a/lib/chat/__tests__/buildStreamReconnectUrl.test.ts
+++ b/lib/chat/__tests__/buildStreamReconnectUrl.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { buildStreamReconnectUrl } from "@/lib/chat/buildStreamReconnectUrl";
+
+const API = "https://api.test/api/chat";
+const CHAT = "11111111-2222-4333-8444-555555555555";
+
+describe("buildStreamReconnectUrl", () => {
+  // The SDK only falls back to `${api}/${id}/stream` when the callback returns
+  // no `api`. Returning one replaces the whole URL, so the path is rebuilt
+  // here rather than appended to — appending to the base produced a GET
+  // against the POST-only `/api/chat` and 405s.
+  it("rebuilds the full resume path from the base", () => {
+    expect(buildStreamReconnectUrl(API, CHAT, null)).toBe(`${API}/${CHAT}/stream`);
+  });
+
+  it("resumes from the chunk after the last one received", () => {
+    expect(buildStreamReconnectUrl(API, CHAT, 347)).toBe(
+      `${API}/${CHAT}/stream?startIndex=348`,
+    );
+  });
+
+  it("treats index 0 as a real position, not as absent", () => {
+    expect(buildStreamReconnectUrl(API, CHAT, 0)).toBe(`${API}/${CHAT}/stream?startIndex=1`);
+  });
+});

--- a/lib/chat/__tests__/createChunkCountingFetch.test.ts
+++ b/lib/chat/__tests__/createChunkCountingFetch.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from "vitest";
+import { createChunkCountingFetch } from "@/lib/chat/createChunkCountingFetch";
+
+const BASE = "https://api.test";
+
+function sseResponse(lines: string[]): Response {
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(lines.join("\n") + "\n"));
+      controller.close();
+    },
+  });
+  return new Response(body, { status: 200 });
+}
+
+/** Let the background counter drain the teed stream. */
+const flush = () => new Promise(resolve => setTimeout(resolve, 20));
+
+describe("createChunkCountingFetch", () => {
+  it("counts SSE frames and reports the absolute index of the last one", async () => {
+    const positions: (number | null)[] = [];
+    const inner = vi.fn(async () =>
+      sseResponse(['data: {"type":"start"}', 'data: {"type":"text-delta"}', "data: [DONE]"]),
+    );
+
+    const f = createChunkCountingFetch({ baseUrl: BASE, onPosition: p => positions.push(p), fetchImpl: inner });
+    await f(`${BASE}/api/chat`, { method: "POST" });
+    await flush();
+
+    // Two real frames at indices 0 and 1; `[DONE]` is the terminator, not a chunk.
+    expect(positions.at(-1)).toBe(1);
+  });
+
+  it("seeds the count from the request's own startIndex", async () => {
+    const positions: (number | null)[] = [];
+    const inner = vi.fn(async () => sseResponse(['data: {"a":1}', 'data: {"a":2}']));
+
+    const f = createChunkCountingFetch({ baseUrl: BASE, onPosition: p => positions.push(p), fetchImpl: inner });
+    await f(`${BASE}/api/chat/abc/stream?startIndex=348`);
+    await flush();
+
+    // Resumed at 348, received two frames → 348 and 349.
+    expect(positions.at(-1)).toBe(349);
+  });
+
+  // Without this, a stale index from a previous turn or a different chat is
+  // sent on the next reconnect and the resume skips chunks it never saw.
+  it("resets the position when a read starts from the beginning", async () => {
+    const positions: (number | null)[] = [];
+    const inner = vi.fn(async () => sseResponse(['data: {"a":1}']));
+
+    const f = createChunkCountingFetch({ baseUrl: BASE, onPosition: p => positions.push(p), fetchImpl: inner });
+    await f(`${BASE}/api/chat`, { method: "POST" });
+
+    // Reset is reported synchronously, before any frame arrives — that is the
+    // window a reconnect could otherwise fire in.
+    expect(positions[0]).toBeNull();
+  });
+
+  it("does NOT reset when the read is itself a resume", async () => {
+    const positions: (number | null)[] = [];
+    const inner = vi.fn(async () => sseResponse(['data: {"a":1}']));
+
+    const f = createChunkCountingFetch({ baseUrl: BASE, onPosition: p => positions.push(p), fetchImpl: inner });
+    await f(`${BASE}/api/chat/abc/stream?startIndex=10`);
+
+    expect(positions[0]).not.toBeNull();
+  });
+
+  it("passes the body through to the caller unchanged", async () => {
+    const inner = vi.fn(async () => sseResponse(['data: {"type":"start"}', "data: [DONE]"]));
+
+    const f = createChunkCountingFetch({ baseUrl: BASE, onPosition: () => {}, fetchImpl: inner });
+    const res = await f(`${BASE}/api/chat`, { method: "POST" });
+    const text = await res.text();
+
+    expect(text).toContain('data: {"type":"start"}');
+    expect(text).toContain("data: [DONE]");
+  });
+
+  it("returns a bodyless response untouched", async () => {
+    const inner = vi.fn(async () => new Response(null, { status: 204 }));
+
+    const f = createChunkCountingFetch({ baseUrl: BASE, onPosition: () => {}, fetchImpl: inner });
+    const res = await f(`${BASE}/api/chat/abc/stream`);
+
+    expect(res.status).toBe(204);
+  });
+});

--- a/lib/chat/__tests__/shouldRecoverStalledStream.test.ts
+++ b/lib/chat/__tests__/shouldRecoverStalledStream.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import {
+  shouldRecoverStalledStream,
+  STREAM_STALL_MS,
+  STREAM_RECOVERY_COOLDOWN_MS,
+} from "@/lib/chat/shouldRecoverStalledStream";
+
+const base = {
+  status: "streaming" as const,
+  now: 100_000,
+  lastChunkAt: 100_000 - STREAM_STALL_MS - 1,
+  lastRecoveryAt: 0,
+  isRecoveryInFlight: false,
+};
+
+describe("shouldRecoverStalledStream", () => {
+  it("recovers when a streaming turn has produced nothing for longer than the stall window", () => {
+    expect(shouldRecoverStalledStream(base)).toBe(true);
+  });
+
+  it("does not recover while chunks are still arriving", () => {
+    expect(shouldRecoverStalledStream({ ...base, lastChunkAt: base.now - 1_000 })).toBe(false);
+  });
+
+  // The turn is over; a reconnect would re-open a stream for nothing.
+  it("does not recover once the turn is no longer in flight", () => {
+    expect(shouldRecoverStalledStream({ ...base, status: "ready" })).toBe(false);
+    expect(shouldRecoverStalledStream({ ...base, status: "error" })).toBe(false);
+  });
+
+  // `submitted` is in flight but has not streamed yet, so the server may
+  // legitimately still be provisioning — the stall window still applies.
+  it("recovers a submitted turn that never started streaming", () => {
+    expect(shouldRecoverStalledStream({ ...base, status: "submitted" })).toBe(true);
+  });
+
+  it("holds off while a previous recovery attempt is still in flight", () => {
+    expect(shouldRecoverStalledStream({ ...base, isRecoveryInFlight: true })).toBe(false);
+  });
+
+  // Without a cooldown a permanently dead stream would be retried on every
+  // tick, hammering the resume route.
+  it("holds off until the cooldown since the last attempt has elapsed", () => {
+    expect(
+      shouldRecoverStalledStream({ ...base, lastRecoveryAt: base.now - 1_000 }),
+    ).toBe(false);
+    expect(
+      shouldRecoverStalledStream({
+        ...base,
+        lastRecoveryAt: base.now - STREAM_RECOVERY_COOLDOWN_MS - 1,
+      }),
+    ).toBe(true);
+  });
+
+  it("treats a never-seen chunk timestamp as no reason to recover yet", () => {
+    expect(shouldRecoverStalledStream({ ...base, lastChunkAt: null })).toBe(false);
+  });
+});

--- a/lib/chat/__tests__/shouldRecoverStalledStream.test.ts
+++ b/lib/chat/__tests__/shouldRecoverStalledStream.test.ts
@@ -55,4 +55,32 @@ describe("shouldRecoverStalledStream", () => {
   it("treats a never-seen chunk timestamp as no reason to recover yet", () => {
     expect(shouldRecoverStalledStream({ ...base, lastChunkAt: null })).toBe(false);
   });
+
+  // Upstream's only live trigger is a visibility probe: a backgrounded tab can
+  // have its connection killed silently, and no amount of waiting will produce
+  // a chunk to time out on. On visibility we skip the silence window — but the
+  // cooldown still applies so a focus-flapping tab can't spam reconnects.
+  it("recovers immediately on a visibility check, without waiting out the stall window", () => {
+    const justStreamed = { ...base, lastChunkAt: base.now - 500 };
+
+    expect(shouldRecoverStalledStream(justStreamed)).toBe(false);
+    expect(shouldRecoverStalledStream({ ...justStreamed, isVisibilityCheck: true })).toBe(true);
+  });
+
+  it("still honours the cooldown on a visibility check", () => {
+    expect(
+      shouldRecoverStalledStream({
+        ...base,
+        lastChunkAt: base.now - 500,
+        isVisibilityCheck: true,
+        lastRecoveryAt: base.now - 1_000,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not recover on a visibility check once the turn is finished", () => {
+    expect(
+      shouldRecoverStalledStream({ ...base, status: "ready", isVisibilityCheck: true }),
+    ).toBe(false);
+  });
 });

--- a/lib/chat/buildStreamReconnectUrl.ts
+++ b/lib/chat/buildStreamReconnectUrl.ts
@@ -1,0 +1,25 @@
+/**
+ * Build the URL for reconnecting to a chat's in-progress response stream.
+ *
+ * `api` is the transport's BASE (`…/api/chat`), not the reconnect URL: the AI
+ * SDK only falls back to `${api}/${id}/stream` when
+ * `prepareReconnectToStreamRequest` returns no `api` of its own. Returning one
+ * replaces the whole URL, so the path must be rebuilt rather than appended to
+ * — appending the query to the base produced a GET against the POST-only
+ * `/api/chat` and 405'd on every reconnect (chat#1923).
+ *
+ * @param api - The transport's base chat endpoint.
+ * @param chatId - The api-minted chat id. NOT the `useChat` instance id, which
+ *   for a new chat is still a client placeholder and 404s.
+ * @param lastChunkIndex - Absolute index of the last chunk received, or `null`
+ *   to read the response from the beginning.
+ * @returns The absolute resume URL.
+ */
+export function buildStreamReconnectUrl(
+  api: string,
+  chatId: string,
+  lastChunkIndex: number | null,
+): string {
+  const base = `${api}/${chatId}/stream`;
+  return lastChunkIndex === null ? base : `${base}?startIndex=${lastChunkIndex + 1}`;
+}

--- a/lib/chat/createChunkCountingFetch.ts
+++ b/lib/chat/createChunkCountingFetch.ts
@@ -1,0 +1,89 @@
+interface ChunkCountingFetchOptions {
+  /** Base URL, used to resolve relative request URLs. */
+  baseUrl: string;
+  /**
+   * Called with the absolute index of the last chunk received, or `null` when
+   * a read starts from the beginning and any previous position is void.
+   */
+  onPosition: (index: number | null) => void;
+  /** Injectable for tests; defaults to the global fetch. */
+  fetchImpl?: typeof globalThis.fetch;
+}
+
+/**
+ * Wrap `fetch` so we always know how far through a response stream the client
+ * actually got.
+ *
+ * This cannot be read off a response header. Headers are sent before the body,
+ * so `x-workflow-stream-tail-index` reports the tail at the moment the read
+ * was OPENED — a live read advertising a tail of 9 went on to deliver 22
+ * chunks. The only honest position for a long-lived read is the one counted
+ * off the wire.
+ *
+ * A read with no `startIndex` begins at chunk zero, which voids any position
+ * carried over from a previous turn or a different chat. That reset is
+ * reported immediately, before the body is read, because the window between
+ * issuing a request and its first frame is exactly when a stalled-stream
+ * reconnect could otherwise fire with a stale index and skip chunks the client
+ * never saw.
+ *
+ * @param options - Base URL, position callback, and an optional fetch.
+ * @returns A `fetch` that streams through untouched while counting.
+ */
+export function createChunkCountingFetch({
+  baseUrl,
+  onPosition,
+  fetchImpl,
+}: ChunkCountingFetchOptions): typeof globalThis.fetch {
+  return (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const doFetch = fetchImpl ?? globalThis.fetch;
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+
+    const startIndexParam = new URL(url, baseUrl).searchParams.get("startIndex");
+    const requested = startIndexParam === null ? null : Number(startIndexParam);
+    const resumesFrom =
+      requested !== null && Number.isInteger(requested) && requested >= 0 ? requested : null;
+
+    // Reading from the beginning — any earlier position no longer applies.
+    if (resumesFrom === null) onPosition(null);
+
+    const response = await doFetch(input, init);
+    if (!response.body) return response;
+
+    let index = (resumesFrom ?? 0) - 1;
+    const [toCaller, toCount] = response.body.tee();
+
+    void (async () => {
+      const reader = toCount.getReader();
+      const decoder = new TextDecoder();
+      let buffered = "";
+      try {
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buffered += decoder.decode(value, { stream: true });
+          const lines = buffered.split("\n");
+          buffered = lines.pop() ?? "";
+          for (const line of lines) {
+            // `[DONE]` terminates the SSE response; it is not a stream chunk.
+            if (line.startsWith("data: ") && !line.startsWith("data: [DONE]")) {
+              index += 1;
+              onPosition(index);
+            }
+          }
+        }
+      } catch {
+        // Counting is best-effort: a torn read just means the next reconnect
+        // resumes from the last index we did count, still ahead of replaying.
+      } finally {
+        reader.releaseLock();
+      }
+    })();
+
+    return new Response(toCaller, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
+  }) as typeof globalThis.fetch;
+}

--- a/lib/chat/shouldRecoverStalledStream.ts
+++ b/lib/chat/shouldRecoverStalledStream.ts
@@ -1,8 +1,25 @@
-/** How long a turn may produce nothing before we treat the stream as dropped. */
-export const STREAM_STALL_MS = 20_000;
+/**
+ * How long a turn may produce nothing before we treat the stream as dropped.
+ *
+ * Not upstream's `STREAM_RECOVERY_STALL_MS = 4_000`: that value feeds a
+ * scheduler their `shouldScheduleStallRecovery` unconditionally disables
+ * (`return false`), so it is not a live stall threshold to copy. It also would
+ * not survive our workload — a single legitimate tool call streams nothing for
+ * up to ~200 s (measured on prod), so a 4 s window would fire dozens of
+ * pointless reconnects per turn.
+ *
+ * 10 s is a deliberate tightening from the 20 s this hook shipped with, which
+ * the tail-index resume makes safe: a reconnect now resumes from the exact
+ * chunk we last saw rather than replaying, so an unnecessary one costs a
+ * request and nothing else.
+ */
+export const STREAM_STALL_MS = 10_000;
 
-/** Minimum gap between reconnect attempts, so a dead stream isn't retried every tick. */
-export const STREAM_RECOVERY_COOLDOWN_MS = 15_000;
+/**
+ * Minimum gap between reconnect attempts, so a dead stream isn't retried every
+ * tick. Matches upstream's `STREAM_RECOVERY_MIN_INTERVAL_MS`.
+ */
+export const STREAM_RECOVERY_COOLDOWN_MS = 8_000;
 
 /** The `useChat` statuses that mean a turn is still expected to produce output. */
 const IN_FLIGHT_STATUSES = new Set(["streaming", "submitted"]);
@@ -18,6 +35,14 @@ export type StreamRecoveryInput = {
   lastRecoveryAt: number;
   /** Whether a reconnect attempt is already running. */
   isRecoveryInFlight: boolean;
+  /**
+   * True when evaluated because the tab regained visibility, rather than on
+   * the interval. A backgrounded tab can have its connection killed silently,
+   * and no amount of waiting produces a chunk to time out on — so this skips
+   * the silence window. Upstream's only live recovery trigger is this same
+   * visibility probe.
+   */
+  isVisibilityCheck?: boolean;
 };
 
 /**
@@ -42,12 +67,18 @@ export function shouldRecoverStalledStream({
   lastChunkAt,
   lastRecoveryAt,
   isRecoveryInFlight,
+  isVisibilityCheck = false,
 }: StreamRecoveryInput): boolean {
   if (!IN_FLIGHT_STATUSES.has(status)) return false;
   if (isRecoveryInFlight) return false;
+  if (now - lastRecoveryAt <= STREAM_RECOVERY_COOLDOWN_MS) return false;
+
+  // A visibility check skips the silence window but keeps the cooldown, so a
+  // focus-flapping tab can't spam reconnects.
+  if (isVisibilityCheck) return true;
+
   if (lastChunkAt === null) return false;
   if (now - lastChunkAt <= STREAM_STALL_MS) return false;
-  if (now - lastRecoveryAt <= STREAM_RECOVERY_COOLDOWN_MS) return false;
 
   return true;
 }

--- a/lib/chat/shouldRecoverStalledStream.ts
+++ b/lib/chat/shouldRecoverStalledStream.ts
@@ -1,0 +1,53 @@
+/** How long a turn may produce nothing before we treat the stream as dropped. */
+export const STREAM_STALL_MS = 20_000;
+
+/** Minimum gap between reconnect attempts, so a dead stream isn't retried every tick. */
+export const STREAM_RECOVERY_COOLDOWN_MS = 15_000;
+
+/** The `useChat` statuses that mean a turn is still expected to produce output. */
+const IN_FLIGHT_STATUSES = new Set(["streaming", "submitted"]);
+
+export type StreamRecoveryInput = {
+  /** Current `useChat` status. */
+  status: string;
+  /** `Date.now()` at evaluation time. */
+  now: number;
+  /** When the last chunk arrived, or `null` if none has yet. */
+  lastChunkAt: number | null;
+  /** When we last attempted a reconnect (0 if never). */
+  lastRecoveryAt: number;
+  /** Whether a reconnect attempt is already running. */
+  isRecoveryInFlight: boolean;
+};
+
+/**
+ * Decide whether a chat turn's stream looks dropped and should be reconnected.
+ *
+ * A long turn's SSE stream can end before the run does — reproduced on prod
+ * 2026-08-02, where the connection closed mid-run with no `finish` chunk and
+ * the UI froze at 6 of 13 iterations while the workflow ran to completion
+ * (chat#1923). Nothing in `useChat` notices that, so we watch for silence and
+ * reconnect via the resume route.
+ *
+ * Deliberately silence-based rather than duration-based: a turn that is still
+ * streaming is healthy no matter how long it has been running, and a turn that
+ * has gone quiet is suspect even if it only just started.
+ *
+ * @param input - Current status, timings, and in-flight recovery state.
+ * @returns True when a reconnect should be attempted now.
+ */
+export function shouldRecoverStalledStream({
+  status,
+  now,
+  lastChunkAt,
+  lastRecoveryAt,
+  isRecoveryInFlight,
+}: StreamRecoveryInput): boolean {
+  if (!IN_FLIGHT_STATUSES.has(status)) return false;
+  if (isRecoveryInFlight) return false;
+  if (lastChunkAt === null) return false;
+  if (now - lastChunkAt <= STREAM_STALL_MS) return false;
+  if (now - lastRecoveryAt <= STREAM_RECOVERY_COOLDOWN_MS) return false;
+
+  return true;
+}


### PR DESCRIPTION
Client half of [chat#1923](https://github.com/recoupable/chat/issues/1923). Depends on [api#809](https://github.com/recoupable/api/pull/809) (the resume route) and [docs#286](https://github.com/recoupable/docs/pull/286) (the contract).

## Why

Reproduced on prod 2026-08-02 by replaying the reported prompt through the real UI. The `/api/chat` SSE response **ended at ~123 s** with a clean `data: [DONE]` and **no `finish` chunk**, while the workflow ran on to completion.

| | |
|---|---|
| UI froze at | **02:26:58** — exactly when the connection closed |
| Still frozen at | 02:36:12, nine minutes later |
| Run actually completed | 02:31:05 |
| Iterations delivered | **6 of 13** |
| Reconnect attempts made | **0** |

No error, no retry, no visible state change — the composer looked idle, as if the turn had finished. Only a page refresh recovered it.

## The SDK already had the machinery

`DefaultChatTransport.reconnectToStream` defaults to **`GET ${api}/${chatId}/stream`**. Our transport's `api` is `${baseUrl}/api/chat`, so the SDK has been prepared to reconnect to exactly the endpoint our docs describe — and which nothing ever implemented. We were missing both halves.

## What

| File | Role |
|---|---|
| `hooks/useVercelChat.ts` | `resume: true` — re-attach to an in-progress response on mount, so returning to a chat mid-turn keeps rendering. Wires `useStreamRecovery`. |
| `hooks/useStreamRecovery.ts` | Watches an in-flight turn for silence, calls `resumeStream()`. Also re-checks on `visibilitychange`. |
| `lib/chat/shouldRecoverStalledStream.ts` | The pure decision — unit-tested, no React. |
| `hooks/useChatTransport.ts` | `prepareReconnectToStreamRequest` attaches the bearer token. |

Composed-hook shape rather than growing `useVercelChat` internals, matching how the other chat hooks extend it.

## Design calls

**Silence-based, not duration-based.** A turn that is still streaming is healthy however long it runs; a turn that has gone quiet is suspect even if it just started. Keying on elapsed total time would fight the legitimate long turns api#808 just made possible.

**A cooldown, so a permanently dead stream isn't retried every tick.** Reconnects are cheap but not free, and a 204 ends the loop naturally once the run finishes.

**Auth on reconnect is not optional.** The resume route authenticates like every other endpoint; without `prepareReconnectToStreamRequest` the reconnect 401s and a dropped stream stays dropped. Easy to miss because the failure looks identical to having no recovery at all.

## Not included: precise `startIndex`

api#809 accepts `startIndex` for a gap-free resume, but `useChat` does not expose a received-chunk count, so there is no honest value to send. The SDK's default reconnect replays the stream and reconciles by message id, which is correct if slightly wasteful. Passing a *guessed* index would risk skipping content — worse than replaying it. Wiring an exact index is a follow-up once we track it properly; the route already supports it.

## Tests

`shouldRecoverStalledStream` — 7 cases, RED before GREEN: recovers on a stalled streaming turn; does not while chunks arrive; not once the turn is `ready`/`error`; recovers a `submitted` turn that never started; holds off while an attempt is in flight; honours the cooldown; treats a never-seen chunk timestamp as no reason to act.

- **Full chat suite: 363 tests passing.**
- **`tsc --noEmit`: 7 errors, identical to the `main` baseline (7), zero in any file this PR touches.**

## One thing I could not verify locally

`next build` in my worktree died with `WorkerError: Call retries were exceeded` — a worker crash, not a type or lint failure, which I attribute to the symlinked `node_modules` in the worktree rather than this diff. **CI's build is the authority here**; I'd rather flag that than claim a green build I didn't get. Preview verification against a real dropped stream is still owed and will be posted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically reconnects dropped chat response streams and resume from the last received chunk so turns keep rendering without duplication. Tightens stall detection and probes on tab visibility to prevent freezes like chat#1923.

- **Bug Fixes**
  - Added `useStreamRecovery` to detect silence and call `resumeStream()`; also checks on `visibilitychange` and polls every 3s with a 10s stall window and 8s cooldown.
  - Set `resume: true` in `useChat` to reattach to in‑progress streams on mount.
  - Implemented gap‑free resume by counting received SSE chunks via `lib/chat/createChunkCountingFetch` and sending `startIndex=last+1`; `prepareReconnectToStreamRequest` uses `lib/chat/buildStreamReconnectUrl` to rebuild `${api}/${chatId}/stream`, reads the server chat id from a ref, attaches bearer auth, and resets the position on fresh reads and chat switches to avoid stale indices. Unit tests cover both helpers and the decision logic.
  - Introduced `shouldRecoverStalledStream` (unit‑tested) as the pure decision logic.
  - Typed the recovery ref to remove an unused placeholder param flagged by lint.

- **Migration**
  - Requires the resume route `GET /api/chat/{chatId}/stream` from `api#809` (per `docs#286`) to be available.

<sup>Written for commit ea642b3edc90c30da29963db5a31f9fb6ef0ce84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1924?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat responses now automatically reconnect when streaming stalls.
  * In-progress responses resume from the last received content, reducing duplicate or lost text.
  * Recovery checks immediately when returning to an inactive browser tab.
* **Bug Fixes**
  * Improved handling of interrupted or silently disconnected chat streams.
  * Added safeguards to prevent overlapping recovery attempts and repeated reconnects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->