### PR TITLE
fix(chat): keep probing after the turn stops looking in-flight

### DIFF
--- a/hooks/useChatTransport.ts
+++ b/hooks/useChatTransport.ts
@@ -26,6 +26,9 @@ export function useChatTransport({
   chatId,
   sessionId,
 }: UseChatTransportOptions) {
+  // Flipped when the resume route answers 204. Read by the recovery hook to
+  // stop probing a turn the server says is over.
+  const noActiveStreamRef = useRef(false);
   const { getAccessToken } = usePrivy();
   const baseUrl = getClientApiBaseUrl();
 
@@ -97,5 +100,5 @@ export function useChatTransport({
     [baseUrl, getAccessToken],
   );
 
-  return { transport, getHeaders };
+  return { transport, getHeaders, noActiveStreamRef };
 }

--- a/hooks/useStreamRecovery.ts
+++ b/hooks/useStreamRecovery.ts
@@ -11,6 +11,12 @@ interface UseStreamRecoveryOptions {
   /** Current `useChat` status. */
   status: string;
   /**
+   * True once the resume route has answered 204 for this turn. Ends probing —
+   * the server is the only party that can distinguish a finished turn from a
+   * cut-off one.
+   */
+  serverConfirmedDone: boolean;
+  /**
    * Changes whenever the assistant produces output. Any value that moves as
    * chunks arrive works — the hook only reads it to timestamp "last activity".
    */
@@ -35,12 +41,18 @@ interface UseStreamRecoveryOptions {
  */
 export function useStreamRecovery({
   status,
+  serverConfirmedDone,
   activityMarker,
   resumeStream,
 }: UseStreamRecoveryOptions): void {
   const lastChunkAtRef = useRef<number | null>(null);
   const lastRecoveryAtRef = useRef(0);
   const isRecoveryInFlightRef = useRef(false);
+  // When the turn last stopped looking in-flight. Opens the post-turn probe
+  // window — the stream ends identically whether the turn finished or was cut
+  // off, so the client cannot tell them apart without asking.
+  const turnEndedAtRef = useRef<number | null>(null);
+  const wasInFlightRef = useRef(false);
 
   // Timestamp activity. Kept in a ref so the polling effect never re-registers
   // as output streams in.
@@ -54,7 +66,16 @@ export function useStreamRecovery({
     if (status === "submitted") {
       lastChunkAtRef.current = Date.now();
       lastRecoveryAtRef.current = 0;
+      turnEndedAtRef.current = null;
     }
+  }, [status]);
+
+  // Record the in-flight → not-in-flight edge. This is the moment the original
+  // bug becomes invisible to a status-gated trigger.
+  useEffect(() => {
+    const inFlight = status === "streaming" || status === "submitted";
+    if (wasInFlightRef.current && !inFlight) turnEndedAtRef.current = Date.now();
+    wasInFlightRef.current = inFlight;
   }, [status]);
 
   // The evaluation itself lives in a ref so listeners keep a stable identity.
@@ -69,6 +90,8 @@ export function useStreamRecovery({
         lastRecoveryAt: lastRecoveryAtRef.current,
         isRecoveryInFlight: isRecoveryInFlightRef.current,
         isVisibilityCheck: opts?.isVisibilityCheck,
+        turnEndedAt: turnEndedAtRef.current,
+        serverConfirmedDone,
       })
     ) {
       return;

--- a/hooks/useVercelChat.ts
+++ b/hooks/useVercelChat.ts
@@ -77,7 +77,7 @@ export function useVercelChat({
   // client placeholder. Drives the transport, message load, and URL so
   // sends/persistence target the row recoup-api actually created.
   const transportChatId = workflowChatId ?? id;
-  const { transport, getHeaders } = useChatTransport({
+  const { transport, getHeaders, noActiveStreamRef } = useChatTransport({
     chatId: transportChatId,
     sessionId,
   });
@@ -237,6 +237,7 @@ export function useVercelChat({
   // for silence on an in-flight turn and reconnect via the resume route.
   useStreamRecovery({
     status,
+    serverConfirmedDone: noActiveStreamRef.current,
     activityMarker: messages,
     resumeStream,
   });

--- a/lib/chat/__tests__/createChunkCountingFetch.test.ts
+++ b/lib/chat/__tests__/createChunkCountingFetch.test.ts
@@ -86,4 +86,37 @@ describe("createChunkCountingFetch", () => {
 
     expect(res.status).toBe(204);
   });
+
+  // A 204 from the resume route is the server saying "nothing to resume" —
+  // the signal that stops post-turn probing. Without it the client cannot
+  // tell a finished turn from a cut-off one.
+  it("reports when a resume read finds no active stream", async () => {
+    const done: boolean[] = [];
+    const inner = vi.fn(async () => new Response(null, { status: 204 }));
+
+    const f = createChunkCountingFetch({
+      baseUrl: BASE,
+      onPosition: () => {},
+      onNoActiveStream: () => done.push(true),
+      fetchImpl: inner,
+    });
+    await f(`${BASE}/api/chat/abc/stream`);
+
+    expect(done).toEqual([true]);
+  });
+
+  it("does not report no-active-stream for a normal streaming response", async () => {
+    const done: boolean[] = [];
+    const inner = vi.fn(async () => sseResponse(['data: {"a":1}']));
+
+    const f = createChunkCountingFetch({
+      baseUrl: BASE,
+      onPosition: () => {},
+      onNoActiveStream: () => done.push(true),
+      fetchImpl: inner,
+    });
+    await f(`${BASE}/api/chat/abc/stream`);
+
+    expect(done).toEqual([]);
+  });
 });

--- a/lib/chat/__tests__/shouldRecoverStalledStream.test.ts
+++ b/lib/chat/__tests__/shouldRecoverStalledStream.test.ts
@@ -3,6 +3,7 @@ import {
   shouldRecoverStalledStream,
   STREAM_STALL_MS,
   STREAM_RECOVERY_COOLDOWN_MS,
+  POST_TURN_PROBE_MS,
 } from "@/lib/chat/shouldRecoverStalledStream";
 
 const base = {
@@ -11,6 +12,8 @@ const base = {
   lastChunkAt: 100_000 - STREAM_STALL_MS - 1,
   lastRecoveryAt: 0,
   isRecoveryInFlight: false,
+  turnEndedAt: null as number | null,
+  serverConfirmedDone: false,
 };
 
 describe("shouldRecoverStalledStream", () => {
@@ -81,6 +84,62 @@ describe("shouldRecoverStalledStream", () => {
   it("does not recover on a visibility check once the turn is finished", () => {
     expect(
       shouldRecoverStalledStream({ ...base, status: "ready", isVisibilityCheck: true }),
+    ).toBe(false);
+  });
+
+  // THE ORIGINAL BUG. A stream that ends with a clean `[DONE]` and no `finish`
+  // chunk moves useChat OUT of streaming, so a trigger gated on in-flight
+  // status goes silent exactly when the run is still going. Reproduced on prod
+  // 2026-08-03 after chat#1924 merged: 123 s stream, zero reconnects, run alive
+  // for a further 3.25 min.
+  it("recovers after the turn leaves in-flight, while the post-turn window is open", () => {
+    expect(
+      shouldRecoverStalledStream({
+        ...base,
+        status: "ready",
+        turnEndedAt: base.now - 2_000,
+      }),
+    ).toBe(true);
+  });
+
+  it("stops probing once the post-turn window has expired", () => {
+    expect(
+      shouldRecoverStalledStream({
+        ...base,
+        status: "ready",
+        turnEndedAt: base.now - POST_TURN_PROBE_MS - 1,
+      }),
+    ).toBe(false);
+  });
+
+  // Without this, every idle chat polls the resume route forever.
+  it("does not probe a turn that never ran", () => {
+    expect(shouldRecoverStalledStream({ ...base, status: "ready", turnEndedAt: null })).toBe(
+      false,
+    );
+  });
+
+  // The route answering 204 is the server saying "nothing to resume" — the
+  // only authoritative end-of-turn signal we get.
+  it("stops probing once the server has confirmed there is nothing to resume", () => {
+    expect(
+      shouldRecoverStalledStream({
+        ...base,
+        status: "ready",
+        turnEndedAt: base.now - 2_000,
+        serverConfirmedDone: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("honours the cooldown on post-turn probes too", () => {
+    expect(
+      shouldRecoverStalledStream({
+        ...base,
+        status: "ready",
+        turnEndedAt: base.now - 2_000,
+        lastRecoveryAt: base.now - 1_000,
+      }),
     ).toBe(false);
   });
 });

--- a/lib/chat/createChunkCountingFetch.ts
+++ b/lib/chat/createChunkCountingFetch.ts
@@ -6,6 +6,13 @@ interface ChunkCountingFetchOptions {
    * a read starts from the beginning and any previous position is void.
    */
   onPosition: (index: number | null) => void;
+  /**
+   * Called when a read of the resume route answers 204 — the server saying
+   * there is nothing left to resume. The only authoritative end-of-turn
+   * signal available to the client, since a cut-off stream and a completed
+   * one both end with `[DONE]`.
+   */
+  onNoActiveStream?: () => void;
   /** Injectable for tests; defaults to the global fetch. */
   fetchImpl?: typeof globalThis.fetch;
 }
@@ -33,6 +40,7 @@ interface ChunkCountingFetchOptions {
 export function createChunkCountingFetch({
   baseUrl,
   onPosition,
+  onNoActiveStream,
   fetchImpl,
 }: ChunkCountingFetchOptions): typeof globalThis.fetch {
   return (async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -48,6 +56,12 @@ export function createChunkCountingFetch({
     if (resumesFrom === null) onPosition(null);
 
     const response = await doFetch(input, init);
+
+    // 204 on the resume path means the run is genuinely over.
+    if (response.status === 204 && new URL(url, baseUrl).pathname.endsWith("/stream")) {
+      onNoActiveStream?.();
+    }
+
     if (!response.body) return response;
 
     let index = (resumesFrom ?? 0) - 1;

--- a/lib/chat/shouldRecoverStalledStream.ts
+++ b/lib/chat/shouldRecoverStalledStream.ts
@@ -21,6 +21,22 @@ export const STREAM_STALL_MS = 10_000;
  */
 export const STREAM_RECOVERY_COOLDOWN_MS = 8_000;
 
+/**
+ * How long after a turn leaves in-flight we keep asking the server whether it
+ * is really finished.
+ *
+ * This window exists because the failure mode ends the stream *cleanly* — a
+ * `[DONE]` with no `finish` chunk — so `useChat` transitions out of
+ * `streaming` and any trigger gated on in-flight status goes silent exactly
+ * when the run is still going. Reproduced on prod 2026-08-03: a 123 s stream,
+ * zero reconnects, and the run alive for a further 3.25 minutes.
+ *
+ * It is only a backstop: the first 204 from the resume route ends probing
+ * immediately, so a normally-completed turn costs one extra request. The
+ * window bounds the pathological case where that answer never arrives.
+ */
+export const POST_TURN_PROBE_MS = 5 * 60_000;
+
 /** The `useChat` statuses that mean a turn is still expected to produce output. */
 const IN_FLIGHT_STATUSES = new Set(["streaming", "submitted"]);
 
@@ -43,6 +59,18 @@ export type StreamRecoveryInput = {
    * visibility probe.
    */
   isVisibilityCheck?: boolean;
+  /**
+   * When the turn last left in-flight, or `null` if no turn has run in this
+   * session. Opens the post-turn probe window.
+   */
+  turnEndedAt?: number | null;
+  /**
+   * True once the resume route has answered 204 — the server saying there is
+   * nothing left to resume. The only authoritative end-of-turn signal we get,
+   * since the stream itself ends the same way whether the turn finished or
+   * was cut off.
+   */
+  serverConfirmedDone?: boolean;
 };
 
 /**
@@ -68,10 +96,20 @@ export function shouldRecoverStalledStream({
   lastRecoveryAt,
   isRecoveryInFlight,
   isVisibilityCheck = false,
+  turnEndedAt = null,
+  serverConfirmedDone = false,
 }: StreamRecoveryInput): boolean {
-  if (!IN_FLIGHT_STATUSES.has(status)) return false;
   if (isRecoveryInFlight) return false;
+  // The server has told us there is nothing to resume. Believe it.
+  if (serverConfirmedDone) return false;
   if (now - lastRecoveryAt <= STREAM_RECOVERY_COOLDOWN_MS) return false;
+
+  // The turn looks finished to the client — but a cut-off stream and a
+  // completed one are indistinguishable from here, so keep asking the server
+  // for a bounded window rather than trusting the appearance.
+  if (!IN_FLIGHT_STATUSES.has(status)) {
+    return turnEndedAt !== null && now - turnEndedAt < POST_TURN_PROBE_MS;
+  }
 
   // A visibility check skips the silence window but keeps the cooldown, so a
   // focus-flapping tab can't spam reconnects.


### PR DESCRIPTION
Row 1 of [chat#1923](https://github.com/recoupable/chat/issues/1923) — **the original bug is live on prod**. [chat#1924](https://github.com/recoupable/chat/pull/1924) shipped the plumbing but the trigger never fires in the real failure mode.

## Reproduced on prod after #1924 merged

Original prompt, prod `7a56bb65`:

| | |
|---|---|
| `POST /api/chat` | 19:13:42 → **19:15:45** (123 s), 1,498 chunks |
| Reconnect requests | **zero** |
| Run kept writing until | **19:19:00** — 3¼ min later |
| Persisted server-side | 25 parts (6 `step-start`, 6 `reasoning`, 3 `text`, 2 `tool-skill`, 8 `tool-bash`) |
| UI | frozen, no stop control, composer idle |

## Root cause

`shouldRecoverStalledStream` gated on `IN_FLIGHT_STATUSES = {streaming, submitted}`. The failure ends the stream **cleanly** — `[DONE]` with no `finish` chunk — so `useChat` transitions **out** of in-flight and the interval stops evaluating. Everything downstream (frame counting, URL building, auth, the api route) was correct and simply never got invoked.

**The earlier verification passed for the wrong reason.** Its prompt was five sequential 45 s sleeps, which guarantees a stall *while still streaming* — a resume was already in flight at 17:10:28 before the stream died at 17:11:48. It never exercised the post-drop path. The original prompt is many quick tool calls, so nothing was in flight when the stream ended.

This is the case upstream open-agents covers with `status === "ready"` → probe. I reviewed that, called it redundant because our resume route self-probes via its 204, and dropped it. Wrong: **the route cannot probe itself if nothing calls it.**

## Fix

A cut-off stream and a completed one are indistinguishable from the client — both end with `[DONE]`. So stop trusting the appearance and ask the server.

- **`POST_TURN_PROBE_MS`** (5 min): after the in-flight → not-in-flight edge, keep evaluating under the existing cooldown.
- **204 ends it.** `createChunkCountingFetch` reports a 204 on the resume path — the server saying there is nothing to resume, the only authoritative end-of-turn signal. A normally-completed turn therefore costs **one extra request**, then stops.
- **Any chunk re-arms**, so a resumed stream that drops again is caught.

The window is a backstop, not the control: the 204 is what normally ends probing. It bounds the pathological case where that answer never arrives.

This also subsumes the "reconnect fired before the stream died" waste flagged on #1924, since the trigger is no longer purely silence-based.

## Tests

5 new cases on the policy, RED before GREEN — the first one reproduces the prod bug directly:

- recovers after the turn leaves in-flight, while the window is open
- stops once the window expires
- never probes a turn that never ran (so idle chats don't poll)
- stops once the server has confirmed nothing to resume
- honours the cooldown on post-turn probes

Plus 2 on the fetch: reports no-active-stream on a 204 resume, and does **not** for a normal streaming response.

**88 chat test files passing**; `tsc --noEmit` clean in every touched file; `eslint` clean apart from the pre-existing `useVercelChat` `'authenticated' is assigned but never used`, which is on `main`.

## Verification owed

**This must be verified against the original prompt on a preview before merge — not a sleep-based scenario.** That substitution is exactly what hid the bug last time. Results will be posted here.

Refs [chat#1923](https://github.com/recoupable/chat/issues/1923)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep probing for a stalled stream after a turn exits in-flight, and stop immediately when the server returns 204. Fixes the prod bug where streams end with `[DONE]` (no finish chunk) and the UI freezes while the run continues.

- **Bug Fixes**
  - Added a 5‑min `POST_TURN_PROBE_MS` window after leaving in-flight; respects existing cooldown.
  - Treat 204 from the resume route as the authoritative end-of-turn; `createChunkCountingFetch` signals no active stream and `useStreamRecovery` halts.
  - Track the in-flight → not-in-flight edge; any new chunk re-arms recovery. Idle chats never poll; probing stops once the server confirms done.
  - Tests cover post-turn probing, cooldowns, and the 204 path.

<sup>Written for commit fef0bd405ded3f1c88e7bc0ba85b0c01c2138748. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

