### PR TITLE
feat(chat): resume a refreshed page from the recent tail, not chunk zero

### DIFF
--- a/hooks/useChatTransport.ts
+++ b/hooks/useChatTransport.ts
@@ -40,6 +40,10 @@ export function useChatTransport({
   // Absolute index of the last stream chunk this client received, maintained
   // by `createChunkCountingFetch`. Drives `startIndex` on reconnect.
   const lastChunkIndexRef = useRef<number | null>(null);
+  // True until this transport has seen any stream of its own. A reconnect
+  // while it is set is a fresh page load resuming a turn it never watched, so
+  // it asks for a bounded tail rather than replaying the whole response.
+  const isFreshLoadRef = useRef(true);
   // Switching chats voids the position: the transport is memoised for the
   // lifetime of the hook, so without this a reconnect for the new chat could
   // resume at an index belonging to the old one.
@@ -74,6 +78,10 @@ export function useChatTransport({
           baseUrl,
           onPosition: (index) => {
             lastChunkIndexRef.current = index;
+            // Once a chunk lands, this transport has watched a turn of its
+            // own — later reconnects resume from the counted position rather
+            // than asking for a blind tail.
+            if (index !== null) isFreshLoadRef.current = false;
           },
         }),
         // Reconnect hits recoup-api's resume route, which is authenticated
@@ -86,11 +94,9 @@ export function useChatTransport({
 
           return {
             headers,
-            api: buildStreamReconnectUrl(
-              api,
-              chatIdRef.current,
-              lastChunkIndexRef.current,
-            ),
+            api: buildStreamReconnectUrl(api, chatIdRef.current, lastChunkIndexRef.current, {
+              isFreshLoad: isFreshLoadRef.current,
+            }),
           };
         },
       }),

--- a/lib/chat/__tests__/buildStreamReconnectUrl.test.ts
+++ b/lib/chat/__tests__/buildStreamReconnectUrl.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { buildStreamReconnectUrl } from "@/lib/chat/buildStreamReconnectUrl";
+import {
+  buildStreamReconnectUrl,
+  REFRESH_RESUME_WINDOW,
+} from "@/lib/chat/buildStreamReconnectUrl";
 
 const API = "https://api.test/api/chat";
 const CHAT = "11111111-2222-4333-8444-555555555555";
@@ -21,5 +24,33 @@ describe("buildStreamReconnectUrl", () => {
 
   it("treats index 0 as a real position, not as absent", () => {
     expect(buildStreamReconnectUrl(API, CHAT, 0)).toBe(`${API}/${CHAT}/stream?startIndex=1`);
+  });
+
+  // A fresh page load has no counted position, so today it resumes from chunk
+  // zero and replays the entire turn — 418 chunks in the verified prod run.
+  // A negative index asks the server for just the recent tail; the route
+  // reports where that landed via `x-workflow-stream-tail-index`, which is
+  // what lets subsequent retries go back to absolute positions.
+  it("requests a bounded window when resuming a turn it never saw", () => {
+    expect(buildStreamReconnectUrl(API, CHAT, null, { isFreshLoad: true })).toBe(
+      `${API}/${CHAT}/stream?startIndex=${REFRESH_RESUME_WINDOW}`,
+    );
+  });
+
+  it("uses a negative window, so the server reads back from the end", () => {
+    expect(REFRESH_RESUME_WINDOW).toBeLessThan(0);
+  });
+
+  // A counted position always beats a guess.
+  it("prefers a known position over the refresh window", () => {
+    expect(buildStreamReconnectUrl(API, CHAT, 347, { isFreshLoad: true })).toBe(
+      `${API}/${CHAT}/stream?startIndex=348`,
+    );
+  });
+
+  it("still reads from the beginning for a non-fresh reconnect with no position", () => {
+    expect(buildStreamReconnectUrl(API, CHAT, null, { isFreshLoad: false })).toBe(
+      `${API}/${CHAT}/stream`,
+    );
   });
 });

--- a/lib/chat/buildStreamReconnectUrl.ts
+++ b/lib/chat/buildStreamReconnectUrl.ts
@@ -1,4 +1,27 @@
 /**
+ * How much of a turn a fresh page load asks for, as a negative (relative to
+ * the end of the stream) index.
+ *
+ * A reload mid-turn has no counted position, so without this it resumes from
+ * chunk zero and replays the whole response — 418 chunks in the verified prod
+ * run, all of it already persisted and rendered from the database anyway.
+ * Asking for the recent tail instead keeps the reconnect cheap.
+ *
+ * Negative indices are resolved by the server, which reports where the read
+ * landed via `x-workflow-stream-tail-index`; that is what lets subsequent
+ * retries in the same session go back to exact absolute positions.
+ */
+export const REFRESH_RESUME_WINDOW = -50;
+
+interface ReconnectUrlOptions {
+  /**
+   * True when this is the first reconnect of a freshly loaded page, i.e. the
+   * client has no counted position because it never saw any of this turn.
+   */
+  isFreshLoad?: boolean;
+}
+
+/**
  * Build the URL for reconnecting to a chat's in-progress response stream.
  *
  * `api` is the transport's BASE (`…/api/chat`), not the reconnect URL: the AI
@@ -12,14 +35,21 @@
  * @param chatId - The api-minted chat id. NOT the `useChat` instance id, which
  *   for a new chat is still a client placeholder and 404s.
  * @param lastChunkIndex - Absolute index of the last chunk received, or `null`
- *   to read the response from the beginning.
+ *   when the client has no counted position.
+ * @param options - `isFreshLoad` requests a bounded tail instead of the whole
+ *   turn when there is no counted position.
  * @returns The absolute resume URL.
  */
 export function buildStreamReconnectUrl(
   api: string,
   chatId: string,
   lastChunkIndex: number | null,
+  options: ReconnectUrlOptions = {},
 ): string {
   const base = `${api}/${chatId}/stream`;
-  return lastChunkIndex === null ? base : `${base}?startIndex=${lastChunkIndex + 1}`;
+
+  // A counted position is always better than a guess.
+  if (lastChunkIndex !== null) return `${base}?startIndex=${lastChunkIndex + 1}`;
+
+  return options.isFreshLoad ? `${base}?startIndex=${REFRESH_RESUME_WINDOW}` : base;
 }


### PR DESCRIPTION
Row 6 of [chat#1923](https://github.com/recoupable/chat/issues/1923). **Blocked by [api#810](https://github.com/recoupable/api/pull/810)** — see below.

## The problem

A reload mid-turn has no counted position, so `resume: true` reconnects with no `startIndex` and the server replays the **entire** response — 418 chunks in the verified prod run. All of that content is already persisted and rendered from the database on load, so the replay is pure waste.

## The fix

Ask for a bounded tail instead: `REFRESH_RESUME_WINDOW = -50`. The server resolves negative indices relative to the end of the stream and reports where the read landed via `x-workflow-stream-tail-index`, which is what lets later retries in the same session return to exact absolute positions.

**A counted position always wins over the window.** The fresh-load flag is cleared the moment any chunk arrives, so only the *first* reconnect of a freshly loaded page uses it — every subsequent one resumes from what the client actually received.

## Hard dependency on api#810

The tail header is **invisible to browser JS** until `Access-Control-Expose-Headers` ships. Per the SDK docs, without that header a negative `startIndex` is *"assumed to be 0, replaying the entire stream"* — so merging this first would be a no-op at best. **api#810 must land first.**

## Why this doesn't remove the frame counting

Worth restating, because it is the thing most likely to be misread: headers are sent **before** the body, so `x-workflow-stream-tail-index` reports the tail at the moment the read was *opened*, never where it ended. A read advertising `tail: 9` went on to deliver 22 chunks. Counting frames off the wire remains the only way to know how far a long-lived read actually got; this header is an anchor for *relative* indices and nothing more.

## Tests

4 new cases, RED before GREEN: a fresh load requests the bounded window; the window is negative; a counted position is preferred over it; a non-fresh reconnect with no position still reads from the beginning.

**88 chat test files passing**; `tsc --noEmit` clean in touched files; `eslint` clean.

## Merge order

[api#810](https://github.com/recoupable/api/pull/810) → this. Note it also touches `hooks/useChatTransport.ts`, as does [chat#1925](https://github.com/recoupable/chat/pull/1925); whichever lands second will want a rebase.

Refs [chat#1923](https://github.com/recoupable/chat/issues/1923)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resume a refreshed chat page from the recent tail instead of chunk 0 to avoid replaying entire responses and speed up reloads. Applies only to the first reconnect when there’s no counted position; counted positions still win.

- **New Features**
  - On fresh reloads with no position, request `startIndex=-50` to fetch only the recent tail.
  - If a counted position exists, resume from `lastChunkIndex + 1`.
  - Use `x-workflow-stream-tail-index` to anchor subsequent retries; frame counting stays for progress.
  - Clear the fresh-load flag once any chunk arrives so later reconnects use the counted position.

- **Dependencies**
  - Blocked by `api#810` to expose `x-workflow-stream-tail-index` via `Access-Control-Expose-Headers`.
  - Merge order: `api#810` → this.

<sup>Written for commit 8000640805413cd056314b51903003bfa218f2ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

