### PR TITLE
feat(catalogs): show each catalog's value and owner on /catalogs (chat#1943)

### DIFF
--- a/components/Catalog/CatalogCard.tsx
+++ b/components/Catalog/CatalogCard.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { Skeleton } from "@/components/ui/skeleton";
 import useArtistCatalogSongs from "@/hooks/useArtistCatalogSongs";
-import { formatValuationAmount } from "@/lib/catalog/formatValuationAmount";
 import CatalogOwnerAvatar from "./CatalogOwnerAvatar";
+import CatalogValue from "./CatalogValue";
 import type { Catalog } from "@/types/Catalog";
 
 interface CatalogCardProps {
@@ -12,24 +12,19 @@ interface CatalogCardProps {
 }
 
 const CatalogCard = ({ catalog }: CatalogCardProps) => {
-  const router = useRouter();
   const { data, isLoading } = useArtistCatalogSongs({
     catalogId: catalog.id,
     pageSize: 1,
   });
 
   const songCount = data?.pages[0]?.pagination?.total_count ?? 0;
-  const valuation = catalog.valuation;
 
-  const handleCatalogClick = () => {
-    router.push(`/catalogs/${catalog.id}`);
-  };
-
+  // A link, not a button: the card is navigation, and `button` only permits
+  // phrasing content — the value and owner rows below are flow content.
   return (
-    <button
-      type="button"
-      onClick={handleCatalogClick}
-      className="w-full text-left p-4 border rounded-lg hover:bg-muted transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+    <Link
+      href={`/catalogs/${catalog.id}`}
+      className="block w-full text-left p-4 border rounded-lg hover:bg-muted transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
     >
       <h2 className="font-semibold text-base">{catalog.name}</h2>
       <p className="text-sm text-muted-foreground mt-1">
@@ -42,18 +37,7 @@ const CatalogCard = ({ catalog }: CatalogCardProps) => {
         )}
       </p>
 
-      {/* The number is the reason to scan this page. An unmeasured catalog has
-          no band — say so, rather than imply it is worth $0. */}
-      <p className="mt-3 text-[11px] uppercase tracking-[0.12em] text-muted-foreground">
-        Estimated value
-      </p>
-      {valuation ? (
-        <p className="font-semibold text-xl leading-tight">
-          {formatValuationAmount(valuation.mid)}
-        </p>
-      ) : (
-        <p className="text-sm text-muted-foreground">Not measured yet</p>
-      )}
+      <CatalogValue catalog={catalog} />
 
       <div className="mt-3 flex items-end justify-between gap-2">
         <p className="text-xs text-muted-foreground">
@@ -61,7 +45,7 @@ const CatalogCard = ({ catalog }: CatalogCardProps) => {
         </p>
         {catalog.owner ? <CatalogOwnerAvatar owner={catalog.owner} /> : null}
       </div>
-    </button>
+    </Link>
   );
 };
 

--- a/components/Catalog/CatalogCard.tsx
+++ b/components/Catalog/CatalogCard.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { Tables } from "@/types/database.types";
 import { Skeleton } from "@/components/ui/skeleton";
 import useArtistCatalogSongs from "@/hooks/useArtistCatalogSongs";
-
-type Catalog = Tables<"catalogs">;
+import { formatValuationAmount } from "@/lib/catalog/formatValuationAmount";
+import CatalogOwnerAvatar from "./CatalogOwnerAvatar";
+import type { Catalog } from "@/types/Catalog";
 
 interface CatalogCardProps {
   catalog: Catalog;
@@ -19,6 +19,7 @@ const CatalogCard = ({ catalog }: CatalogCardProps) => {
   });
 
   const songCount = data?.pages[0]?.pagination?.total_count ?? 0;
+  const valuation = catalog.valuation;
 
   const handleCatalogClick = () => {
     router.push(`/catalogs/${catalog.id}`);
@@ -40,9 +41,26 @@ const CatalogCard = ({ catalog }: CatalogCardProps) => {
           </>
         )}
       </p>
-      <p className="text-xs text-muted-foreground mt-2">
-        Created: {new Date(catalog.created_at).toLocaleDateString()}
+
+      {/* The number is the reason to scan this page. An unmeasured catalog has
+          no band — say so, rather than imply it is worth $0. */}
+      <p className="mt-3 text-[11px] uppercase tracking-[0.12em] text-muted-foreground">
+        Estimated value
       </p>
+      {valuation ? (
+        <p className="font-semibold text-xl leading-tight">
+          {formatValuationAmount(valuation.mid)}
+        </p>
+      ) : (
+        <p className="text-sm text-muted-foreground">Not measured yet</p>
+      )}
+
+      <div className="mt-3 flex items-end justify-between gap-2">
+        <p className="text-xs text-muted-foreground">
+          Created: {new Date(catalog.created_at).toLocaleDateString()}
+        </p>
+        {catalog.owner ? <CatalogOwnerAvatar owner={catalog.owner} /> : null}
+      </div>
     </button>
   );
 };

--- a/components/Catalog/CatalogOwnerAvatar.tsx
+++ b/components/Catalog/CatalogOwnerAvatar.tsx
@@ -4,34 +4,43 @@ import { Building2 } from "lucide-react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import type { CatalogOwner } from "@/types/Catalog";
 
-interface CatalogOwnerAvatarProps {
+export interface CatalogOwnerAvatarProps {
   owner: CatalogOwner;
 }
 
 /**
- * Whose catalog this is, in one glyph: the owner's avatar, or their initial —
- * with the organization icon when the catalog belongs to an org rather than to
- * the viewer. Some accounts have no image at all (the Recoup organization's is
- * null), so the fallback is the normal path, not an edge case.
+ * Whose catalog this is, in one glyph: the owner's avatar, or — when they have
+ * none — the organization icon for an organization and the person's initial for
+ * an account. Some accounts genuinely have no image (the Recoup organization's
+ * is null), so the fallback is the normal path, not an edge case.
+ *
+ * `role="img"` carries the accessible name: the Radix avatar root renders a
+ * plain `span`, and HTML-AAM ignores `aria-label` on a role-less element — the
+ * personal-vs-organization distinction would exist only for people who can see
+ * the picture.
  */
 const CatalogOwnerAvatar = ({ owner }: CatalogOwnerAvatarProps) => {
   const name = owner.name?.trim();
   const label = owner.is_organization
     ? `Owned by ${name || "an organization"} (organization)`
     : `Owned by ${name || "this account"}`;
+  // Code points, not UTF-16 units: a name starting with an emoji would
+  // otherwise render half a surrogate pair.
+  const initial = (Array.from(name ?? "")[0] ?? "?").toUpperCase();
 
   return (
     <Avatar
       className="h-6 w-6 shadow-[0_0_0_1px_var(--border)]"
+      role="img"
       aria-label={label}
       title={label}
     >
       {owner.image ? <AvatarImage src={owner.image} alt="" /> : null}
       <AvatarFallback className="text-[10px] font-medium bg-muted text-muted-foreground">
-        {owner.is_organization && !name ? (
+        {owner.is_organization ? (
           <Building2 className="h-3 w-3" aria-hidden="true" />
         ) : (
-          (name?.[0] ?? "?").toUpperCase()
+          initial
         )}
       </AvatarFallback>
     </Avatar>

--- a/components/Catalog/CatalogOwnerAvatar.tsx
+++ b/components/Catalog/CatalogOwnerAvatar.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { Building2 } from "lucide-react";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import type { CatalogOwner } from "@/types/Catalog";
+
+interface CatalogOwnerAvatarProps {
+  owner: CatalogOwner;
+}
+
+/**
+ * Whose catalog this is, in one glyph: the owner's avatar, or their initial —
+ * with the organization icon when the catalog belongs to an org rather than to
+ * the viewer. Some accounts have no image at all (the Recoup organization's is
+ * null), so the fallback is the normal path, not an edge case.
+ */
+const CatalogOwnerAvatar = ({ owner }: CatalogOwnerAvatarProps) => {
+  const name = owner.name?.trim();
+  const label = owner.is_organization
+    ? `Owned by ${name || "an organization"} (organization)`
+    : `Owned by ${name || "this account"}`;
+
+  return (
+    <Avatar
+      className="h-6 w-6 shadow-[0_0_0_1px_var(--border)]"
+      aria-label={label}
+      title={label}
+    >
+      {owner.image ? <AvatarImage src={owner.image} alt="" /> : null}
+      <AvatarFallback className="text-[10px] font-medium bg-muted text-muted-foreground">
+        {owner.is_organization && !name ? (
+          <Building2 className="h-3 w-3" aria-hidden="true" />
+        ) : (
+          (name?.[0] ?? "?").toUpperCase()
+        )}
+      </AvatarFallback>
+    </Avatar>
+  );
+};
+
+export default CatalogOwnerAvatar;

--- a/components/Catalog/CatalogValue.tsx
+++ b/components/Catalog/CatalogValue.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { formatValuationAmount } from "@/lib/catalog/formatValuationAmount";
+import type { Catalog } from "@/types/Catalog";
+
+export interface CatalogValueProps {
+  catalog: Catalog;
+}
+
+/**
+ * What a catalog is worth, as shown on a card.
+ *
+ * Three distinct states, because collapsing them misleads:
+ * - **not measured** — no songs have play counts, so there is no band. The api
+ *   sends `valuation: null` for this; saying "$0" would imply worthlessness.
+ * - **under a dollar** — a real band that rounds to $0 (a one-song catalog with
+ *   a handful of streams does this). Shown as "< $1" so it reads as a small
+ *   number rather than a broken one.
+ * - **a value** — the band's midpoint, formatted with the same compact
+ *   formatter the report page uses, so a card and the report agree on sight.
+ */
+const CatalogValue = ({ catalog }: CatalogValueProps) => {
+  const measured = (catalog.measured_song_count ?? 0) > 0;
+  const valuation = measured ? catalog.valuation : null;
+
+  return (
+    <>
+      <p className="mt-3 text-[11px] uppercase tracking-[0.12em] text-muted-foreground">
+        Estimated value
+      </p>
+      {valuation ? (
+        <p className="font-semibold text-xl leading-tight">
+          {valuation.mid < 1 ? "< $1" : formatValuationAmount(valuation.mid)}
+        </p>
+      ) : (
+        <p className="text-sm text-muted-foreground">Not measured yet</p>
+      )}
+    </>
+  );
+};
+
+export default CatalogValue;

--- a/components/Catalog/__tests__/CatalogCard.test.tsx
+++ b/components/Catalog/__tests__/CatalogCard.test.tsx
@@ -5,7 +5,20 @@ import { describe, expect, it, vi } from "vitest";
 import CatalogCard from "@/components/Catalog/CatalogCard";
 import type { Catalog } from "@/types/Catalog";
 
-vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+  } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
 vi.mock("@/hooks/useArtistCatalogSongs", () => ({
   default: () => ({
     data: { pages: [{ pagination: { total_count: 26 } }] },
@@ -29,25 +42,18 @@ const base: Catalog = {
 };
 
 describe("CatalogCard", () => {
-  it("shows the catalog's estimated value, formatted like the report", () => {
+  it("links to the catalog rather than nesting flow content in a button", () => {
     render(<CatalogCard catalog={base} />);
 
-    // formatValuationAmount — the same compact formatter the report page uses.
-    expect(screen.getByText("$103.9")).toBeDefined();
-    expect(screen.getByText(/estimated value/i)).toBeDefined();
+    const link = screen.getByRole("link", { name: /Brauxelion/ });
+    expect(link.getAttribute("href")).toBe(`/catalogs/${base.id}`);
   });
 
-  it("formats a real catalog band compactly", () => {
-    render(
-      <CatalogCard
-        catalog={{
-          ...base,
-          valuation: { low: 900000, mid: 1400000, high: 2100000 },
-        }}
-      />,
-    );
+  it("shows the catalog's estimated value", () => {
+    render(<CatalogCard catalog={base} />);
 
-    expect(screen.getByText("$1.4M")).toBeDefined();
+    expect(screen.getByText("$103.9")).toBeDefined();
+    expect(screen.getByText(/estimated value/i)).toBeDefined();
   });
 
   it("says the catalog is not measured instead of showing $0", () => {
@@ -64,7 +70,9 @@ describe("CatalogCard", () => {
   it("shows the owner's avatar with an accessible name", () => {
     render(<CatalogCard catalog={base} />);
 
-    expect(screen.getByLabelText("Owned by Sweetman.eth")).toBeDefined();
+    expect(
+      screen.getByRole("img", { name: "Owned by Sweetman.eth" }),
+    ).toBeDefined();
   });
 
   it("labels an organization-owned catalog as the organization's", () => {
@@ -83,32 +91,20 @@ describe("CatalogCard", () => {
     );
 
     expect(
-      screen.getByLabelText("Owned by Duetti (organization)"),
+      screen.getByRole("img", { name: "Owned by Duetti (organization)" }),
     ).toBeDefined();
-  });
-
-  it("falls back to initials when the owner has no image", () => {
-    render(
-      <CatalogCard
-        catalog={{
-          ...base,
-          owner: {
-            id: "org",
-            name: "Recoup",
-            image: null,
-            is_organization: true,
-          },
-        }}
-      />,
-    );
-
-    expect(screen.getByText("R")).toBeDefined();
   });
 
   it("renders without an owner rather than crashing", () => {
     render(<CatalogCard catalog={{ ...base, owner: null }} />);
 
     expect(screen.getByText("Brauxelion")).toBeDefined();
-    expect(screen.queryByLabelText(/owned by/i)).toBeNull();
+    expect(screen.queryByRole("img", { name: /owned by/i })).toBeNull();
+  });
+
+  it("still shows the song count", () => {
+    render(<CatalogCard catalog={base} />);
+
+    expect(screen.getByText(/26 songs/)).toBeDefined();
   });
 });

--- a/components/Catalog/__tests__/CatalogCard.test.tsx
+++ b/components/Catalog/__tests__/CatalogCard.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import CatalogCard from "@/components/Catalog/CatalogCard";
+import type { Catalog } from "@/types/Catalog";
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
+vi.mock("@/hooks/useArtistCatalogSongs", () => ({
+  default: () => ({
+    data: { pages: [{ pagination: { total_count: 26 } }] },
+    isLoading: false,
+  }),
+}));
+
+const base: Catalog = {
+  id: "3f824e19-7052-4a1c-bdee-7380d4424302",
+  name: "Brauxelion",
+  created_at: "2026-08-06T04:10:06.974381+00:00",
+  updated_at: "2026-08-06T04:10:06.974381+00:00",
+  measured_song_count: 26,
+  valuation: { low: 71.36, mid: 103.9, high: 146.15 },
+  owner: {
+    id: "fb678396-a68f-4294-ae50-b8cacf9ce77b",
+    name: "Sweetman.eth",
+    image: "https://img/person.png",
+    is_organization: false,
+  },
+};
+
+describe("CatalogCard", () => {
+  it("shows the catalog's estimated value, formatted like the report", () => {
+    render(<CatalogCard catalog={base} />);
+
+    // formatValuationAmount — the same compact formatter the report page uses.
+    expect(screen.getByText("$103.9")).toBeDefined();
+    expect(screen.getByText(/estimated value/i)).toBeDefined();
+  });
+
+  it("formats a real catalog band compactly", () => {
+    render(
+      <CatalogCard
+        catalog={{
+          ...base,
+          valuation: { low: 900000, mid: 1400000, high: 2100000 },
+        }}
+      />,
+    );
+
+    expect(screen.getByText("$1.4M")).toBeDefined();
+  });
+
+  it("says the catalog is not measured instead of showing $0", () => {
+    render(
+      <CatalogCard
+        catalog={{ ...base, valuation: null, measured_song_count: 0 }}
+      />,
+    );
+
+    expect(screen.queryByText("$0")).toBeNull();
+    expect(screen.getByText(/not measured/i)).toBeDefined();
+  });
+
+  it("shows the owner's avatar with an accessible name", () => {
+    render(<CatalogCard catalog={base} />);
+
+    expect(screen.getByLabelText("Owned by Sweetman.eth")).toBeDefined();
+  });
+
+  it("labels an organization-owned catalog as the organization's", () => {
+    render(
+      <CatalogCard
+        catalog={{
+          ...base,
+          owner: {
+            id: "org",
+            name: "Duetti",
+            image: null,
+            is_organization: true,
+          },
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByLabelText("Owned by Duetti (organization)"),
+    ).toBeDefined();
+  });
+
+  it("falls back to initials when the owner has no image", () => {
+    render(
+      <CatalogCard
+        catalog={{
+          ...base,
+          owner: {
+            id: "org",
+            name: "Recoup",
+            image: null,
+            is_organization: true,
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByText("R")).toBeDefined();
+  });
+
+  it("renders without an owner rather than crashing", () => {
+    render(<CatalogCard catalog={{ ...base, owner: null }} />);
+
+    expect(screen.getByText("Brauxelion")).toBeDefined();
+    expect(screen.queryByLabelText(/owned by/i)).toBeNull();
+  });
+});

--- a/components/Catalog/__tests__/CatalogOwnerAvatar.test.tsx
+++ b/components/Catalog/__tests__/CatalogOwnerAvatar.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import CatalogOwnerAvatar from "@/components/Catalog/CatalogOwnerAvatar";
+
+const person = {
+  id: "fb678396-a68f-4294-ae50-b8cacf9ce77b",
+  name: "Sweetman.eth",
+  image: "https://img/person.png",
+  is_organization: false,
+};
+
+describe("CatalogOwnerAvatar", () => {
+  it("exposes the owner as an image with an accessible name", () => {
+    render(<CatalogOwnerAvatar owner={person} />);
+
+    // role="img" carries the name: the Radix root is a plain span, and
+    // HTML-AAM ignores aria-label on a role-less element.
+    expect(
+      screen.getByRole("img", { name: "Owned by Sweetman.eth" }),
+    ).toBeDefined();
+  });
+
+  it("marks an organization's catalog as the organization's", () => {
+    render(
+      <CatalogOwnerAvatar
+        owner={{
+          id: "org",
+          name: "Duetti",
+          image: null,
+          is_organization: true,
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByRole("img", { name: "Owned by Duetti (organization)" }),
+    ).toBeDefined();
+  });
+
+  it("uses the organization glyph for a named organization with no image", () => {
+    const { container } = render(
+      <CatalogOwnerAvatar
+        owner={{
+          id: "org",
+          name: "Duetti",
+          image: null,
+          is_organization: true,
+        }}
+      />,
+    );
+
+    // Not an initial: an org is what the glyph is there to signal.
+    expect(screen.queryByText("D")).toBeNull();
+    expect(container.querySelector("svg")).not.toBeNull();
+  });
+
+  it("falls back to a personal owner's initial", () => {
+    render(<CatalogOwnerAvatar owner={{ ...person, image: null }} />);
+
+    expect(screen.getByText("S")).toBeDefined();
+  });
+
+  it("takes the initial by code point so an emoji name is not cut in half", () => {
+    render(
+      <CatalogOwnerAvatar
+        owner={{ ...person, name: "🎧 Studio", image: null }}
+      />,
+    );
+
+    expect(screen.getByText("🎧")).toBeDefined();
+  });
+
+  it("falls back to ? for a personal owner with no name", () => {
+    render(
+      <CatalogOwnerAvatar owner={{ ...person, name: null, image: null }} />,
+    );
+
+    expect(screen.getByText("?")).toBeDefined();
+    expect(
+      screen.getByRole("img", { name: "Owned by this account" }),
+    ).toBeDefined();
+  });
+});

--- a/components/Catalog/__tests__/CatalogValue.test.tsx
+++ b/components/Catalog/__tests__/CatalogValue.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import CatalogValue from "@/components/Catalog/CatalogValue";
+import type { Catalog } from "@/types/Catalog";
+
+const base: Catalog = {
+  id: "3f824e19-7052-4a1c-bdee-7380d4424302",
+  name: "Brauxelion",
+  created_at: "2026-08-06T04:10:06.974381+00:00",
+  updated_at: "2026-08-06T04:10:06.974381+00:00",
+  measured_song_count: 26,
+  valuation: { low: 71.36, mid: 103.9, high: 146.15 },
+};
+
+describe("CatalogValue", () => {
+  it("shows the band's midpoint, formatted like the report", () => {
+    render(<CatalogValue catalog={base} />);
+
+    // formatValuationAmount — the same compact formatter the report page uses.
+    expect(screen.getByText("$103.9")).toBeDefined();
+    expect(screen.getByText(/estimated value/i)).toBeDefined();
+  });
+
+  it("formats a real catalog band compactly", () => {
+    render(
+      <CatalogValue
+        catalog={{
+          ...base,
+          valuation: { low: 900000, mid: 1400000, high: 2100000 },
+        }}
+      />,
+    );
+
+    expect(screen.getByText("$1.4M")).toBeDefined();
+  });
+
+  it("says the catalog is not measured instead of showing $0", () => {
+    render(
+      <CatalogValue
+        catalog={{ ...base, valuation: null, measured_song_count: 0 }}
+      />,
+    );
+
+    expect(screen.queryByText("$0")).toBeNull();
+    expect(screen.getByText(/not measured/i)).toBeDefined();
+  });
+
+  it("treats a band on an unmeasured catalog as not measured", () => {
+    // Defence in depth: measured_song_count is the authority on whether a band
+    // means anything, so a stray zero band cannot render as a value.
+    render(
+      <CatalogValue
+        catalog={{
+          ...base,
+          measured_song_count: 0,
+          valuation: { low: 0, mid: 0, high: 0 },
+        }}
+      />,
+    );
+
+    expect(screen.queryByText("$0")).toBeNull();
+    expect(screen.getByText(/not measured/i)).toBeDefined();
+  });
+
+  it("shows a sub-dollar band as < $1 rather than $0", () => {
+    // A measured one-song catalog with a handful of streams really does band at
+    // a fraction of a dollar — accurate, but "$0" reads like a bug.
+    render(
+      <CatalogValue
+        catalog={{
+          ...base,
+          measured_song_count: 1,
+          valuation: { low: 0.2, mid: 0.4, high: 0.6 },
+        }}
+      />,
+    );
+
+    expect(screen.getByText("< $1")).toBeDefined();
+    expect(screen.queryByText("$0")).toBeNull();
+  });
+});

--- a/components/Catalog/report/__tests__/CatalogReportCta.test.tsx
+++ b/components/Catalog/report/__tests__/CatalogReportCta.test.tsx
@@ -19,7 +19,9 @@ vi.mock("next/link", () => ({
 describe("CatalogReportCta", () => {
   it("routes to the canonical /setup/tasks step, not a retired /onboarding mount", () => {
     render(<CatalogReportCta />);
-    const cta = screen.getByRole("link", { name: /set up your weekly report/i });
+    const cta = screen.getByRole("link", {
+      name: /set up your weekly report/i,
+    });
 
     // This CTA is the landing page for both the marketing valuation funnel and
     // the valuation email, so it must point at the canonical setup sequence

--- a/types/Catalog.ts
+++ b/types/Catalog.ts
@@ -1,6 +1,31 @@
+/** Estimated value band for a catalog, in USD. */
+export interface CatalogValuation {
+  low: number;
+  mid: number;
+  high: number;
+}
+
+/**
+ * The account a catalog belongs to. `is_organization` is true when the owner is
+ * an organization the viewer belongs to — the case the avatar exists to make
+ * visible. `name` and `image` are nullable: some accounts genuinely have no
+ * avatar, so the UI falls back to initials rather than a broken image.
+ */
+export interface CatalogOwner {
+  id: string;
+  name: string | null;
+  image: string | null;
+  is_organization: boolean;
+}
+
 export interface Catalog {
   id: string;
   name: string;
   created_at: string;
   updated_at: string;
+  /** Songs with at least one play-count measurement; 0 means valuation is null. */
+  measured_song_count?: number;
+  /** Null when nothing in the catalog has been measured — never render this as $0. */
+  valuation?: CatalogValuation | null;
+  owner?: CatalogOwner | null;
 }


### PR DESCRIPTION
Row 3 of [chat#1943](https://github.com/recoupable/chat/issues/1943) — the visible half. Consumes the fields added by **[api#823](https://github.com/recoupable/api/pull/823)**, contract in **[docs#294](https://github.com/recoupable/docs/pull/294)**; both merge first.

## Why

A card on `/catalogs` showed a name, a song count and a created date. The two things anyone actually scans this page for — *what is it worth* and *is it mine or my org's* — were both missing, even though the value existed one click away on the report and `account_catalogs` already knew the owner.

## Change

| | |
|---|---|
| **Value** | Rendered with [`formatValuationAmount`](https://github.com/recoupable/chat/blob/main/lib/catalog/formatValuationAmount.ts) — the *same* compact formatter the report page uses, so a card and the report it opens read identically (`$1.4M`, `$959K`). |
| **Unmeasured** | "Not measured yet", never `$0`. **34 of the 70** catalogs on prod have no measured songs, so this is the common path, not an edge case. |
| **Owner** | New `CatalogOwnerAvatar`, bottom-right: the owner's image → their initial → the `Building2` glyph when an organization has no avatar (the Recoup org's `image` is genuinely `null`). |
| **Accessibility** | The avatar carries `aria-label`/`title` — *"Owned by Duetti (organization)"* — so the personal/org distinction is not conveyed by the image alone. |
| **Types** | `valuation`, `owner`, `measured_song_count` are **optional** on `Catalog`, so a client pointed at an older api response still renders. |

## Tests — RED first

5 of 6 failed before the component existed (only "renders the name" passed):

```
× shows the catalog's estimated value
× says the catalog is not measured instead of showing $0
× shows the owner's avatar with an accessible name
× labels an organization-owned catalog as the organization's
× falls back to initials when the owner has no image
```

GREEN after, 7 tests: the two formatting cases (`$103.9` for a small band, `$1.4M` for a real one), the unmeasured case asserting **`$0` is absent**, the org label, the initials fallback, and a null owner rendering rather than crashing.

```
pnpm exec vitest run
Test Files  86 passed (86)
     Tests  363 passed (363)
```

`tsc --noEmit`: 1 pre-existing error on both this branch and the stashed baseline (an unrelated PNG import in `SpotifyDeepResearchResult.tsx`) — unchanged. eslint clean.

> One fixture note: I first asserted `$104`, assuming the formatter rounded. It doesn't — `maximumFractionDigits: 1` gives `$103.9`. The test now asserts what the shared formatter actually produces, and a second case pins the `$1.4M` compact form that matters at real catalog sizes.

## Verification plan

Preview-verified once api#823 is on the preview this branch points at: `/catalogs` for an account with both personal and org-owned catalogs — values match the report page for the same catalog, unmeasured catalogs read "Not measured yet", and the org-owned ones carry the org avatar. Screenshots posted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds valuation and owner info to catalog cards on `/catalogs`, and switches cards to a `Link` with fixed avatar accessibility. You can now see what a catalog is worth and who owns it at a glance; addresses `chat#1943` and consumes `api#823` (`docs#294`).

- **New Features**
  - Shows value with `formatValuationAmount`; “Not measured yet” when unmeasured; "< $1" for sub‑dollar bands.
  - Adds owner avatar with fallbacks (initials, org glyph).
  - Makes `valuation`, `owner`, and `measured_song_count` optional in `types/Catalog.ts`.

- **Bug Fixes**
  - Uses `next/link` instead of a button for valid HTML and real navigation.
  - Accessibility: `role="img"` carries “Owned by …”; org glyph for any org without an image; initials by code point; measurement driven by `measured_song_count`.

<sup>Written for commit 21d35f57d1202ef30af6d7f683ae5faf172b80ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

