### PR TITLE
feat(valuation): let the selected organization own a seeded catalog (chat#1943)

### DIFF
--- a/hooks/useAddSpotifyArtist.ts
+++ b/hooks/useAddSpotifyArtist.ts
@@ -26,6 +26,11 @@ import type { SpotifyArtistSearchResult } from "@/types/spotify";
  * fire-and-forget kicks `POST /api/valuation` for that artist's Spotify id —
  * seeding the onboarding catalog in the background so the "Claim your catalog"
  * step is already complete by the time the user reaches it (chat#1867).
+ *
+ * The selected organization owns both the artist and that seeded catalog. The
+ * artist already followed the org; the catalog did not, so a catalog created
+ * while working inside an org was owned by the user and stayed out of the org's
+ * catalogs for every other member (chat#1943).
  */
 export function useAddSpotifyArtist() {
   const { getAccessToken } = usePrivy();
@@ -57,7 +62,7 @@ export function useAddSpotifyArtist() {
       const catalogs = catalogsQuery.data?.catalogs;
       if (catalogs && catalogs.length === 0) {
         toast.promise(
-          runValuation(accessToken, artist.id).then(() => {
+          runValuation(accessToken, artist.id, selectedOrgId).then(() => {
             queryClient.invalidateQueries({ queryKey: ["catalogs"] });
           }),
           {

--- a/lib/valuation/__tests__/runValuation.test.ts
+++ b/lib/valuation/__tests__/runValuation.test.ts
@@ -29,6 +29,41 @@ describe("runValuation", () => {
     );
   });
 
+  it("names the organization as the catalog owner when one is selected", async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue({ ok: true }) as unknown as typeof fetch;
+
+    await runValuation("tok", "0xPoV", "5d511b7e-de11-4566-ae90-b5fd5535d900");
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://api.example.com/api/valuation",
+      expect.objectContaining({
+        body: JSON.stringify({
+          spotify_artist_id: "0xPoV",
+          organization_id: "5d511b7e-de11-4566-ae90-b5fd5535d900",
+        }),
+      }),
+    );
+  });
+
+  // `null` is the personal-account state of `selectedOrgId`, and the api 403s a
+  // null organization_id rather than treating it as absent.
+  it("omits organization_id on the personal account", async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue({ ok: true }) as unknown as typeof fetch;
+
+    await runValuation("tok", "0xPoV", null);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://api.example.com/api/valuation",
+      expect.objectContaining({
+        body: JSON.stringify({ spotify_artist_id: "0xPoV" }),
+      }),
+    );
+  });
+
   it("throws on a non-ok response", async () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: false,

--- a/lib/valuation/runValuation.ts
+++ b/lib/valuation/runValuation.ts
@@ -8,10 +8,15 @@ import { getClientApiBaseUrl } from "@/lib/api/getClientApiBaseUrl";
  *
  * @param accessToken - Privy bearer for the owning account.
  * @param spotifyArtistId - The Spotify artist id to value.
+ * @param organizationId - Organization to own the resulting catalog, or `null`
+ *   on the personal account. Without it the catalog is owned by the caller even
+ *   when they are working inside an org, so it never appears in that org's
+ *   catalogs (chat#1943). The api authorizes membership and 403s a non-member.
  */
 export async function runValuation(
   accessToken: string,
   spotifyArtistId: string,
+  organizationId?: string | null,
 ): Promise<void> {
   const res = await fetch(`${getClientApiBaseUrl()}/api/valuation`, {
     method: "POST",
@@ -19,7 +24,10 @@ export async function runValuation(
       "Content-Type": "application/json",
       Authorization: `Bearer ${accessToken}`,
     },
-    body: JSON.stringify({ spotify_artist_id: spotifyArtistId }),
+    body: JSON.stringify({
+      spotify_artist_id: spotifyArtistId,
+      ...(organizationId ? { organization_id: organizationId } : {}),
+    }),
   });
 
   if (!res.ok) {


### PR DESCRIPTION
Implements item 4 of chat#1943.

## Why

A first-artist add fire-and-forget kicks `POST /api/valuation`, which materializes a catalog owned by whoever the request names. [`runValuation`](https://github.com/recoupable/chat/blob/main/lib/valuation/runValuation.ts) posted only `{ spotify_artist_id }`, even though the endpoint accepts `organization_id` and authorizes it against the caller's membership ([`validateRunValuationRequest`](https://github.com/recoupable/api/blob/main/lib/valuation/validateRunValuationRequest.ts)), and `createCatalogHandler` uses it as the `account_catalogs` owner.

So with an org selected the artist landed in the org and the catalog did not: it was owned by the user personally and never appeared in that org's `/catalogs` for any other member. Its one caller, `useAddSpotifyArtist`, already held `selectedOrgId` and already passed it to `addSpotifyArtist` on the line above. [`createRosterArtist` L31](https://github.com/recoupable/chat/blob/main/lib/artists/createRosterArtist.ts#L31) is the pattern this mirrors.

Measured on prod 2026-08-06: of the 9 organizations `sweetmantech` belongs to, 8 own **0** catalogs; platform-wide exactly **1** org owns any (`Duetti`, 11). This write path is why.

## What changed

- `runValuation(accessToken, spotifyArtistId, organizationId?)` adds `organization_id` to the body only when an org is selected. `null` (the personal-account state of `selectedOrgId`) omits the key rather than sending null, which the api 403s.
- `useAddSpotifyArtist` passes `selectedOrgId`.

No api or docs change: the endpoint already accepts and authorizes the field.

## Tests

Written RED first, then GREEN:

| Test | Asserts |
|------|---------|
| `names the organization as the catalog owner when one is selected` | body carries `organization_id` |
| `omits organization_id on the personal account` | `null` sends `{ spotify_artist_id }` only |

```
pnpm exec vitest run                 → 85 files, 358 tests passed
pnpm exec tsc --noEmit               → no errors in changed files
pnpm exec eslint <changed files>     → clean
```

Preview verification (org-owned `account_catalogs` row after a real first-artist add) posted as a comment below.

## Sequencing

Independent of [#1944](https://github.com/recoupable/chat/pull/1944) and [api#823](https://github.com/recoupable/api/pull/823), but it should land **before** org-scoped filtering (item 3) so a catalog seeded in org context is visible in that org's list.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Seeded catalogs now belong to the selected organization when adding a first Spotify artist, so they appear in that org’s catalog list for all members. Addresses item 4 of chat#1943.

- **Bug Fixes**
  - `runValuation(accessToken, spotifyArtistId, organizationId?)` includes `organization_id` when an org is selected; omits it on personal accounts to avoid 403s.
  - `useAddSpotifyArtist` passes `selectedOrgId` to `runValuation`.
  - Tests cover both cases: with org ownership and personal account (omitted key).

<sup>Written for commit bdd920b5d4079106ca96d69585a10cf727c56ca6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

