### PR TITLE
feat(catalogs): scope /catalogs to the selected organization (chat#1943)

### DIFF
--- a/components/Catalog/CatalogsPageContent.tsx
+++ b/components/Catalog/CatalogsPageContent.tsx
@@ -8,6 +8,7 @@ import { useOrganization } from "@/providers/OrganizationProvider";
 import useAccountOrganizations from "@/hooks/useAccountOrganizations";
 import { filterCatalogsByOrg } from "@/lib/catalog/filterCatalogsByOrg";
 import { getCatalogsEmptyCopy } from "@/lib/catalog/getCatalogsEmptyCopy";
+import { resolveSelectedOrgId } from "@/lib/catalog/resolveSelectedOrgId";
 
 const CatalogsPageContent = () => {
   const { data, isLoading, error } = useCatalogs();
@@ -15,6 +16,11 @@ const CatalogsPageContent = () => {
   const { selectedOrgId } = useOrganization();
   const { data: organizations } = useAccountOrganizations();
   const accountId = userData?.account_id || "";
+
+  // The stored selection outlives the account that made it, so scope to it only
+  // while this account is actually a member — otherwise the page empties and
+  // names an organization the viewer cannot see.
+  const orgId = resolveSelectedOrgId(selectedOrgId, organizations);
 
   if (isLoading || !accountId) {
     return (
@@ -41,16 +47,16 @@ const CatalogsPageContent = () => {
   // Scoped here, not in `useCatalogs`: that hook is also the "does this account
   // own a catalog" signal for onboarding and first-artist seeding, so an empty
   // org must not read as an account with no catalogs (chat#1943).
-  const catalogs = filterCatalogsByOrg(data?.catalogs || [], selectedOrgId);
+  const catalogs = filterCatalogsByOrg(data?.catalogs || [], orgId);
 
   if (!catalogs.length) {
     const orgName = organizations?.find(
-      (organization) => organization.organization_id === selectedOrgId,
+      (organization) => organization.organization_id === orgId,
     )?.organization_name;
 
     return (
       <p className="text-sm text-muted-foreground">
-        {getCatalogsEmptyCopy(selectedOrgId, orgName)}
+        {getCatalogsEmptyCopy(orgId, orgName)}
       </p>
     );
   }

--- a/components/Catalog/CatalogsPageContent.tsx
+++ b/components/Catalog/CatalogsPageContent.tsx
@@ -4,10 +4,16 @@ import useCatalogs from "@/hooks/useCatalogs";
 import CatalogCard from "./CatalogCard";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useUserProvider } from "@/providers/UserProvder";
+import { useOrganization } from "@/providers/OrganizationProvider";
+import useAccountOrganizations from "@/hooks/useAccountOrganizations";
+import { filterCatalogsByOrg } from "@/lib/catalog/filterCatalogsByOrg";
+import { getCatalogsEmptyCopy } from "@/lib/catalog/getCatalogsEmptyCopy";
 
 const CatalogsPageContent = () => {
   const { data, isLoading, error } = useCatalogs();
   const { userData } = useUserProvider();
+  const { selectedOrgId } = useOrganization();
+  const { data: organizations } = useAccountOrganizations();
   const accountId = userData?.account_id || "";
 
   if (isLoading || !accountId) {
@@ -32,10 +38,21 @@ const CatalogsPageContent = () => {
     );
   }
 
-  const catalogs = data?.catalogs || [];
+  // Scoped here, not in `useCatalogs`: that hook is also the "does this account
+  // own a catalog" signal for onboarding and first-artist seeding, so an empty
+  // org must not read as an account with no catalogs (chat#1943).
+  const catalogs = filterCatalogsByOrg(data?.catalogs || [], selectedOrgId);
 
   if (!catalogs.length) {
-    return <p className="text-sm text-muted-foreground">No catalogs found.</p>;
+    const orgName = organizations?.find(
+      (organization) => organization.organization_id === selectedOrgId,
+    )?.organization_name;
+
+    return (
+      <p className="text-sm text-muted-foreground">
+        {getCatalogsEmptyCopy(selectedOrgId, orgName)}
+      </p>
+    );
   }
 
   return (

--- a/components/Catalog/__tests__/CatalogsPageContent.test.tsx
+++ b/components/Catalog/__tests__/CatalogsPageContent.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import CatalogsPageContent from "@/components/Catalog/CatalogsPageContent";
+import type { Catalog } from "@/types/Catalog";
+
+const DUETTI = "5d511b7e-de11-4566-ae90-b5fd5535d900";
+const RECOUP = "04e3aba9-c130-4fb8-8b92-34e95d43e66b";
+const SWEETS = "fb678396-a68f-4294-ae50-b8cacf9ce77b";
+
+const state = vi.hoisted(() => ({ selectedOrgId: null as string | null }));
+
+vi.mock("@/providers/OrganizationProvider", () => ({
+  useOrganization: () => ({ selectedOrgId: state.selectedOrgId }),
+}));
+vi.mock("@/providers/UserProvder", () => ({
+  useUserProvider: () => ({ userData: { account_id: SWEETS } }),
+}));
+vi.mock("@/hooks/useAccountOrganizations", () => ({
+  default: () => ({
+    data: [
+      { id: "1", organization_id: DUETTI, organization_name: "Duetti" },
+      { id: "2", organization_id: RECOUP, organization_name: "Recoup" },
+    ],
+  }),
+}));
+vi.mock("@/components/Catalog/CatalogCard", () => ({
+  default: ({ catalog }: { catalog: Catalog }) => <div>{catalog.name}</div>,
+}));
+
+const catalog = (name: string, ownerId: string): Catalog => ({
+  id: name,
+  name,
+  created_at: "2026-08-06T04:10:06.974381+00:00",
+  updated_at: "2026-08-06T04:10:06.974381+00:00",
+  owner: {
+    id: ownerId,
+    name: null,
+    image: null,
+    is_organization: ownerId !== SWEETS,
+  },
+});
+
+const catalogs = [
+  catalog("Collie Buddz", SWEETS),
+  catalog("Kevin Gates", DUETTI),
+];
+
+vi.mock("@/hooks/useCatalogs", () => ({
+  default: () => ({
+    data: { status: "success", catalogs },
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+describe("CatalogsPageContent", () => {
+  beforeEach(() => {
+    state.selectedOrgId = null;
+  });
+
+  it("shows every catalog the account can see on the personal account", () => {
+    render(<CatalogsPageContent />);
+
+    expect(screen.getByText("Collie Buddz")).toBeDefined();
+    expect(screen.getByText("Kevin Gates")).toBeDefined();
+  });
+
+  it("shows only the selected organization's catalogs", () => {
+    state.selectedOrgId = DUETTI;
+
+    render(<CatalogsPageContent />);
+
+    expect(screen.getByText("Kevin Gates")).toBeDefined();
+    expect(screen.queryByText("Collie Buddz")).toBeNull();
+  });
+
+  it("names the organization when it owns no catalogs", () => {
+    state.selectedOrgId = RECOUP;
+
+    render(<CatalogsPageContent />);
+
+    expect(screen.getByText("No catalogs in Recoup yet.")).toBeDefined();
+    expect(screen.queryByText("Collie Buddz")).toBeNull();
+  });
+});

--- a/components/Catalog/__tests__/CatalogsPageContent.test.tsx
+++ b/components/Catalog/__tests__/CatalogsPageContent.test.tsx
@@ -9,7 +9,11 @@ const DUETTI = "5d511b7e-de11-4566-ae90-b5fd5535d900";
 const RECOUP = "04e3aba9-c130-4fb8-8b92-34e95d43e66b";
 const SWEETS = "fb678396-a68f-4294-ae50-b8cacf9ce77b";
 
-const state = vi.hoisted(() => ({ selectedOrgId: null as string | null }));
+const state = vi.hoisted(() => ({
+  selectedOrgId: null as string | null,
+  isLoading: false,
+  error: null as Error | null,
+}));
 
 vi.mock("@/providers/OrganizationProvider", () => ({
   useOrganization: () => ({ selectedOrgId: state.selectedOrgId }),
@@ -50,14 +54,16 @@ const catalogs = [
 vi.mock("@/hooks/useCatalogs", () => ({
   default: () => ({
     data: { status: "success", catalogs },
-    isLoading: false,
-    error: null,
+    isLoading: state.isLoading,
+    error: state.error,
   }),
 }));
 
 describe("CatalogsPageContent", () => {
   beforeEach(() => {
     state.selectedOrgId = null;
+    state.isLoading = false;
+    state.error = null;
   });
 
   it("shows every catalog the account can see on the personal account", () => {
@@ -83,5 +89,37 @@ describe("CatalogsPageContent", () => {
 
     expect(screen.getByText("No catalogs in Recoup yet.")).toBeDefined();
     expect(screen.queryByText("Collie Buddz")).toBeNull();
+  });
+
+  it("shows everything when the stored selection is an org this account left", () => {
+    // selectedOrgId is persisted, so it survives an account switch. Scoping to
+    // it would empty the page and name an organization the viewer cannot see.
+    state.selectedOrgId = "an-org-from-a-previous-account";
+
+    render(<CatalogsPageContent />);
+
+    expect(screen.getByText("Collie Buddz")).toBeDefined();
+    expect(screen.getByText("Kevin Gates")).toBeDefined();
+    expect(screen.queryByText(/No catalogs in/)).toBeNull();
+  });
+
+  it("renders skeletons while the catalogs are loading, whatever the org", () => {
+    state.selectedOrgId = DUETTI;
+    state.isLoading = true;
+
+    render(<CatalogsPageContent />);
+
+    expect(screen.queryByText("Kevin Gates")).toBeNull();
+    expect(screen.queryByText(/No catalogs/)).toBeNull();
+  });
+
+  it("surfaces a load failure instead of an empty organization", () => {
+    state.selectedOrgId = DUETTI;
+    state.error = new Error("Failed to fetch");
+
+    render(<CatalogsPageContent />);
+
+    expect(screen.getByText("Failed to fetch")).toBeDefined();
+    expect(screen.queryByText(/No catalogs in/)).toBeNull();
   });
 });

--- a/lib/catalog/__tests__/filterCatalogsByOrg.test.ts
+++ b/lib/catalog/__tests__/filterCatalogsByOrg.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { filterCatalogsByOrg } from "@/lib/catalog/filterCatalogsByOrg";
+import type { Catalog } from "@/types/Catalog";
+
+const DUETTI = "5d511b7e-de11-4566-ae90-b5fd5535d900";
+const SWEETS = "fb678396-a68f-4294-ae50-b8cacf9ce77b";
+
+const catalog = (id: string, ownerId: string | null): Catalog => ({
+  id,
+  name: `Catalog ${id}`,
+  created_at: "2026-08-06T04:10:06.974381+00:00",
+  updated_at: "2026-08-06T04:10:06.974381+00:00",
+  owner: ownerId
+    ? {
+        id: ownerId,
+        name: null,
+        image: null,
+        is_organization: ownerId === DUETTI,
+      }
+    : null,
+});
+
+const personal = catalog("personal", SWEETS);
+const orgOwned = catalog("org", DUETTI);
+const unattributed = catalog("unattributed", null);
+
+describe("filterCatalogsByOrg", () => {
+  it("shows everything the account can see on the personal account", () => {
+    const catalogs = [personal, orgOwned, unattributed];
+
+    expect(filterCatalogsByOrg(catalogs, null)).toEqual(catalogs);
+  });
+
+  it("keeps only the selected organization's catalogs", () => {
+    expect(filterCatalogsByOrg([personal, orgOwned], DUETTI)).toEqual([
+      orgOwned,
+    ]);
+  });
+
+  it("drops a catalog whose owner the API could not attribute", () => {
+    expect(filterCatalogsByOrg([unattributed], DUETTI)).toEqual([]);
+  });
+
+  it("returns nothing for an organization that owns no catalogs", () => {
+    expect(
+      filterCatalogsByOrg([personal], "04e3aba9-c130-4fb8-8b92-34e95d43e66b"),
+    ).toEqual([]);
+  });
+});

--- a/lib/catalog/__tests__/getCatalogReportEmptyCopy.test.ts
+++ b/lib/catalog/__tests__/getCatalogReportEmptyCopy.test.ts
@@ -53,7 +53,9 @@ describe("getCatalogReportEmptyCopy", () => {
   });
 
   it("offers no CTA while measuring, because there is nothing to do", () => {
-    expect(getCatalogReportEmptyCopy("measuring", withCatalogs).cta).toBeUndefined();
+    expect(
+      getCatalogReportEmptyCopy("measuring", withCatalogs).cta,
+    ).toBeUndefined();
   });
 
   // chat#1912 row 6 chain (recoupable/docs#282 -> recoupable/api#802): catalog
@@ -84,13 +86,19 @@ describe("getCatalogReportEmptyCopy", () => {
   });
 
   it("always gives the cross-account state something to click", () => {
-    expect(getCatalogReportEmptyCopy("other-account", withCatalogs).cta).toBeDefined();
-    expect(getCatalogReportEmptyCopy("other-account", withoutCatalogs).cta).toBeDefined();
+    expect(
+      getCatalogReportEmptyCopy("other-account", withCatalogs).cta,
+    ).toBeDefined();
+    expect(
+      getCatalogReportEmptyCopy("other-account", withoutCatalogs).cta,
+    ).toBeDefined();
   });
 
   // The measuring state resolves on its own, so a button would invite exactly
   // the redundant re-run this whole issue exists to stop.
   it("still offers nothing to click while measuring", () => {
-    expect(getCatalogReportEmptyCopy("measuring", withCatalogs).cta).toBeUndefined();
+    expect(
+      getCatalogReportEmptyCopy("measuring", withCatalogs).cta,
+    ).toBeUndefined();
   });
 });

--- a/lib/catalog/__tests__/getCatalogReportState.test.ts
+++ b/lib/catalog/__tests__/getCatalogReportState.test.ts
@@ -19,9 +19,9 @@ describe("getCatalogReportState", () => {
   // measurements", because the measurements query is gated on auth and never
   // runs — a disabled query is not a failure, and must not read as one.
   it("is signed-out for an anonymous visitor rather than an error", () => {
-    expect(
-      getCatalogReportState({ ...base, isAuthenticated: false }),
-    ).toBe("signed-out");
+    expect(getCatalogReportState({ ...base, isAuthenticated: false })).toBe(
+      "signed-out",
+    );
   });
 
   it("stays signed-out even though the disabled query left no error behind", () => {

--- a/lib/catalog/__tests__/getCatalogsEmptyCopy.test.ts
+++ b/lib/catalog/__tests__/getCatalogsEmptyCopy.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { getCatalogsEmptyCopy } from "@/lib/catalog/getCatalogsEmptyCopy";
+
+const DUETTI = "5d511b7e-de11-4566-ae90-b5fd5535d900";
+
+describe("getCatalogsEmptyCopy", () => {
+  it("says no catalogs at all on the personal account", () => {
+    expect(getCatalogsEmptyCopy(null)).toBe("No catalogs found.");
+  });
+
+  it("names the organization whose list is empty", () => {
+    // 8 of the 9 orgs this account belongs to own no catalogs, so this is the
+    // org state users hit most; "No catalogs found." reads as data loss.
+    expect(getCatalogsEmptyCopy(DUETTI, "Duetti")).toBe(
+      "No catalogs in Duetti yet.",
+    );
+  });
+
+  it("falls back when the organization's name has not loaded", () => {
+    expect(getCatalogsEmptyCopy(DUETTI)).toBe(
+      "No catalogs in this organization yet.",
+    );
+  });
+});

--- a/lib/catalog/__tests__/measuringCopy.test.ts
+++ b/lib/catalog/__tests__/measuringCopy.test.ts
@@ -20,14 +20,18 @@ describe("measuringCopy", () => {
   });
 
   it("is used by the catalog report's measuring state", () => {
-    const copy = getCatalogReportEmptyCopy("measuring", { hasOwnCatalogs: true });
+    const copy = getCatalogReportEmptyCopy("measuring", {
+      hasOwnCatalogs: true,
+    });
 
     expect(copy.title).toBe(MEASURING_TITLE);
     expect(copy.body).toContain(MEASURING_ESTIMATE);
   });
 
   it("keeps the report's own reassurance without restating the estimate", () => {
-    const copy = getCatalogReportEmptyCopy("measuring", { hasOwnCatalogs: true });
+    const copy = getCatalogReportEmptyCopy("measuring", {
+      hasOwnCatalogs: true,
+    });
 
     expect(copy.body).toContain("no need to run the valuation again");
     // The estimate must appear once in the sentence, not twice.
@@ -41,7 +45,9 @@ describe("measuringCopy", () => {
     const verb = MEASURING_TITLE.split(" ")[0];
 
     expect(verb).toBe("Measuring");
-    expect(measuringToastLoading("BennyJ504")).toBe(`${verb} BennyJ504's catalog…`);
+    expect(measuringToastLoading("BennyJ504")).toBe(
+      `${verb} BennyJ504's catalog…`,
+    );
   });
 
   it("states the toast outcomes", () => {
@@ -51,7 +57,13 @@ describe("measuringCopy", () => {
 
   // House style: em dashes read as machine-written in product copy.
   it("keeps the shared copy free of em dashes", () => {
-    const all = [MEASURING_TITLE, MEASURING_ESTIMATE, MEASURING_BODY, MEASURING_TOAST_SUCCESS, MEASURING_TOAST_ERROR].join(" ");
+    const all = [
+      MEASURING_TITLE,
+      MEASURING_ESTIMATE,
+      MEASURING_BODY,
+      MEASURING_TOAST_SUCCESS,
+      MEASURING_TOAST_ERROR,
+    ].join(" ");
     expect(all).not.toMatch(/[—–]/);
   });
 });

--- a/lib/catalog/__tests__/resolveSelectedOrgId.test.ts
+++ b/lib/catalog/__tests__/resolveSelectedOrgId.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { resolveSelectedOrgId } from "@/lib/catalog/resolveSelectedOrgId";
+
+const DUETTI = "5d511b7e-de11-4566-ae90-b5fd5535d900";
+const RECOUP = "04e3aba9-c130-4fb8-8b92-34e95d43e66b";
+
+const memberships = [
+  { id: "1", organization_id: DUETTI, organization_name: "Duetti" },
+  { id: "2", organization_id: RECOUP, organization_name: "Recoup" },
+];
+
+describe("resolveSelectedOrgId", () => {
+  it("keeps a selection this account is a member of", () => {
+    expect(resolveSelectedOrgId(DUETTI, memberships)).toBe(DUETTI);
+  });
+
+  it("falls back to personal for a selection this account is not in", () => {
+    // The selection is persisted, so it survives signing in as someone else or
+    // losing membership. Filtering on it would empty the page and name an
+    // organization the viewer cannot see.
+    expect(
+      resolveSelectedOrgId("an-org-from-a-previous-account", memberships),
+    ).toBeNull();
+  });
+
+  it("falls back to personal when the account belongs to no organizations", () => {
+    expect(resolveSelectedOrgId(DUETTI, [])).toBeNull();
+  });
+
+  it("keeps the selection while memberships are still loading", () => {
+    // undefined means "not loaded yet", not "no memberships" — resetting here
+    // would flash the whole union on every mount.
+    expect(resolveSelectedOrgId(DUETTI, undefined)).toBe(DUETTI);
+  });
+
+  it("passes personal through untouched", () => {
+    expect(resolveSelectedOrgId(null, memberships)).toBeNull();
+    expect(resolveSelectedOrgId(null, undefined)).toBeNull();
+  });
+});

--- a/lib/catalog/filterCatalogsByOrg.ts
+++ b/lib/catalog/filterCatalogsByOrg.ts
@@ -1,0 +1,32 @@
+import type { Catalog } from "@/types/Catalog";
+
+/**
+ * Narrows `/catalogs` to the organization selected in the sidebar.
+ *
+ * Personal (`null`) keeps every catalog the account can see, its own and every
+ * organization's, which is the union `GET /api/accounts/{id}/catalogs` returns
+ * and the view an owner wants by default. Selecting an org narrows to that org
+ * alone. Deliberately asymmetric, and deliberately unlike `/api/artists`, where
+ * omitting `org_id` returns personal-only (chat#1943).
+ *
+ * `owner` is already resolved server-side to an owner the caller reads through,
+ * preferring the organization when a catalog carries several links, so matching
+ * on its id is the whole rule. A catalog the API could not attribute is left out
+ * of an org view rather than guessed into it.
+ *
+ * Filtering happens here rather than in `useCatalogs` on purpose: that hook is
+ * also the "does this account own a catalog" signal for onboarding, home
+ * valuation and first-artist seeding, and an empty org would otherwise read as
+ * an account with no catalogs.
+ *
+ * @param catalogs - Every catalog the account can see
+ * @param selectedOrgId - Selected organization, or `null` for personal
+ */
+export function filterCatalogsByOrg(
+  catalogs: Catalog[],
+  selectedOrgId: string | null,
+): Catalog[] {
+  if (!selectedOrgId) return catalogs;
+
+  return catalogs.filter((catalog) => catalog.owner?.id === selectedOrgId);
+}

--- a/lib/catalog/getCatalogsEmptyCopy.ts
+++ b/lib/catalog/getCatalogsEmptyCopy.ts
@@ -1,0 +1,21 @@
+/**
+ * What `/catalogs` says when it has nothing to show.
+ *
+ * An organization that owns no catalogs is the common case, not the exception:
+ * 8 of the 9 organizations the founding account belongs to own none (measured
+ * 2026-08-06). A bare "No catalogs found." there reads as though the account's
+ * catalogs vanished, so an org view names the org it is empty *for*.
+ *
+ * @param selectedOrgId - Selected organization, or `null` for personal
+ * @param orgName - That organization's name, absent until it loads
+ */
+export function getCatalogsEmptyCopy(
+  selectedOrgId: string | null,
+  orgName?: string,
+): string {
+  if (!selectedOrgId) return "No catalogs found.";
+
+  return orgName
+    ? `No catalogs in ${orgName} yet.`
+    : "No catalogs in this organization yet.";
+}

--- a/lib/catalog/resolveSelectedOrgId.ts
+++ b/lib/catalog/resolveSelectedOrgId.ts
@@ -1,0 +1,33 @@
+import type { AccountOrganization } from "@/hooks/useAccountOrganizations";
+
+/**
+ * The organization `/catalogs` should actually scope to, given the sidebar
+ * selection and the account's real memberships.
+ *
+ * `selectedOrgId` is persisted, so it outlives the account that chose it: sign
+ * in as someone else, or lose membership, and the stored id names an
+ * organization this account is not in. Filtering on it would empty the page and
+ * — worse — the empty state would name an organization the viewer cannot see.
+ * An unrecognised selection is therefore treated as personal, which shows the
+ * union rather than nothing.
+ *
+ * The membership list being absent means "still loading", not "no memberships":
+ * the selection is kept so switching orgs doesn't flash the whole union on
+ * every mount.
+ *
+ * @param selectedOrgId - Selected organization, or `null` for personal
+ * @param organizations - The account's organizations, `undefined` while loading
+ * @returns The organization to scope to, or `null` for personal
+ */
+export function resolveSelectedOrgId(
+  selectedOrgId: string | null,
+  organizations: AccountOrganization[] | undefined,
+): string | null {
+  if (!selectedOrgId) return null;
+  if (!organizations) return selectedOrgId;
+
+  const isMember = organizations.some(
+    (organization) => organization.organization_id === selectedOrgId,
+  );
+  return isMember ? selectedOrgId : null;
+}


### PR DESCRIPTION
Implements item 3 of chat#1943. **Stacked on [#1944](https://github.com/recoupable/chat/pull/1944)** — it filters on the `owner` field that PR adds, so this PR targets `feat/catalogs-list-valuation-owner` to keep the diff to just this change. GitHub retargets it to `main` automatically when #1944 merges.

## Why

The sidebar org picker did nothing on `/catalogs`. [`useCatalogs`](https://github.com/recoupable/chat/blob/main/hooks/useCatalogs.ts) reads `userData.account_id` and never touches `useOrganization()`, and `GET /api/accounts/{id}/catalogs` returns the **union** of the account plus every org it belongs to by design (`getCatalogOwnerIds`, chat#1938). Every other org-aware read already threads the selection: `useArtistsRoster` keys on `(userId, orgId)`, `useVercelChat` and `useNewChatBootstrap` pass it, `chat.tsx` remounts on it. Catalogs were the outlier.

Measured on prod 2026-08-06 for `sweetmantech`: **41** visible catalogs = **30** personal + **11** `Duetti`, zero overlap. Selecting `Duetti` showed all 41.

## What changed

- **`lib/catalog/filterCatalogsByOrg.ts`** — Personal (`null`) keeps the whole union; an org narrows to `catalog.owner?.id === selectedOrgId`. A catalog the API could not attribute is left out of an org view rather than guessed into it.
- **`lib/catalog/getCatalogsEmptyCopy.ts`** — an empty org view names the org ("No catalogs in Duetti yet.") instead of the bare "No catalogs found.", which reads as data loss. 8 of the 9 orgs this account belongs to own zero catalogs, so this is the common org state, not an edge case.
- **`CatalogsPageContent`** — applies both.

No api or docs change: `owner` is already resolved server-side to an owner the caller reads through, preferring the organization on a multi-link catalog, so the client needs no ownership logic.

### Two decisions worth reviewing

1. **Personal means everything; an org means only that org.** Asymmetric on purpose, and deliberately unlike [`fetchArtists`](https://github.com/recoupable/chat/blob/main/lib/artists/fetchArtists.ts) where omitting `org_id` returns personal-only artists. Catalogs are few and cross-cutting; a roster is not.
2. **Filtered in the page, never in `useCatalogs`.** Eleven call sites share that hook and several are onboarding gates reading "does this account own a catalog" (`useOwnsCatalog`, `useOnboardingState`, `useSetupValuation`, `useHomeValuation`, `useAddSpotifyArtist`). Filtering at the hook would make an empty org look like an account with no catalogs: onboarding restarts and a duplicate valuation gets kicked. Org switching therefore also costs no extra request, since it re-renders from the cached response.

Rejected: re-pointing the fetch at `GET /api/accounts/{orgId}/catalogs`. That path is authorized by `canAccessAccount`, which requires caller and target to *share* an org, and an org is not a member of itself, so a customer gets **403**. It would look correct in our own testing only because every Recoup teammate is in `RECOUP_ORG`, which grants universal admin.

## Tests

Written RED first, then GREEN. 7 new tests:

| Test | Asserts |
|------|---------|
| `filterCatalogsByOrg` × 4 | personal keeps the union; an org keeps only its own; an unattributed catalog is dropped; an org owning none returns empty |
| `getCatalogsEmptyCopy` × 3 | personal copy unchanged; org copy names the org; fallback before the name loads |
| `CatalogsPageContent` × 3 | personal renders both catalogs; `Duetti` renders only its own; `Recoup` shows "No catalogs in Recoup yet." |

```
pnpm exec vitest run                 → 89 files, 373 tests passed
pnpm exec tsc --noEmit               → no errors in changed files
pnpm exec eslint <changed files>     → clean
```

Preview verification with screenshots (Personal → 41, Duetti → 11, Recoup → named empty state, onboarding gate unaffected) posted as a comment below.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scoped `/catalogs` to the selected organization so the sidebar picker actually filters, and validated the selection against memberships to avoid scoping to an org the account left. Filtered in the page (not in `useCatalogs`), with skeletons/error surfaced on load; aligns with chat#1943 and personal still shows all catalogs the account can see.

- **New Features**
  - Filter catalogs in `CatalogsPageContent` using `resolveSelectedOrgId` and `filterCatalogsByOrg`, matching on `catalog.owner?.id` and falling back to personal when not a member.
  - Update empty state to name the org: "No catalogs in {Org} yet." (fallback: "No catalogs in this organization yet.").

<sup>Written for commit 850b35cb0b710c6e6c468bd15697ddca6bb5d09f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1946?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

