### PR TITLE
fix(chat): gate stream resume on auth and a real chat id

### DIFF
--- a/hooks/useVercelChat.ts
+++ b/hooks/useVercelChat.ts
@@ -219,14 +219,11 @@ export function useVercelChat({
       id,
       transport,
       // Re-attach to an in-progress response, so returning to a chat mid-turn
-      // keeps rendering instead of showing a frozen half-message. Gated until
-      // auth and a real chat id exist — unconditionally resuming 401s/404s on
-      // every cold load and surfaces as an error toast (chat#1949 F4a).
-      resume: shouldResumeStream({
-        authenticated,
-        routeChatId: chatId,
-        workflowChatId,
-      }),
+      // keeps rendering instead of showing a frozen half-message. Gated to an
+      // authenticated visit to an existing chat — resuming unconditionally
+      // 401s/404s on every cold load and surfaces as an error toast
+      // (chat#1949 F4a).
+      resume: shouldResumeStream({ authenticated, routeChatId: chatId }),
       experimental_throttle: 100,
       generateId: generateUUID,
       onError: (e) => {

--- a/hooks/useVercelChat.ts
+++ b/hooks/useVercelChat.ts
@@ -26,6 +26,7 @@ import getMimeFromPath from "@/lib/files/getMimeFromPath";
 import { getChatPath } from "@/lib/chat/getChatPath";
 import { useInitialMessageAutoSend } from "./useInitialMessageAutoSend";
 import { usePersistSelectedModel } from "./usePersistSelectedModel";
+import shouldResumeStream from "@/lib/chat/shouldResumeStream";
 
 interface UseVercelChatProps {
   id: string;
@@ -217,9 +218,15 @@ export function useVercelChat({
     useChat({
       id,
       transport,
-      // Re-attach to an in-progress response on mount, so returning to a chat
-      // mid-turn keeps rendering instead of showing a frozen half-message.
-      resume: true,
+      // Re-attach to an in-progress response, so returning to a chat mid-turn
+      // keeps rendering instead of showing a frozen half-message. Gated until
+      // auth and a real chat id exist — unconditionally resuming 401s/404s on
+      // every cold load and surfaces as an error toast (chat#1949 F4a).
+      resume: shouldResumeStream({
+        authenticated,
+        routeChatId: chatId,
+        workflowChatId,
+      }),
       experimental_throttle: 100,
       generateId: generateUUID,
       onError: (e) => {

--- a/lib/chat/__tests__/shouldResumeStream.test.ts
+++ b/lib/chat/__tests__/shouldResumeStream.test.ts
@@ -7,7 +7,6 @@ describe("shouldResumeStream", () => {
       shouldResumeStream({
         authenticated: false,
         routeChatId: undefined,
-        workflowChatId: undefined,
       }),
     ).toBe(false);
   });
@@ -19,7 +18,21 @@ describe("shouldResumeStream", () => {
       shouldResumeStream({
         authenticated: true,
         routeChatId: undefined,
-        workflowChatId: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not resume a freshly bootstrapped chat", () => {
+    // Verified on the preview deployment: gating on the bootstrap-minted id
+    // made `resume` flip false -> true once provisioning resolved, and
+    // `WorkflowChatTransport`'s `while (!gotFinish)` loop then reissued the
+    // resume GET 118 times against a brand-new chat that returns 204. A chat
+    // created seconds ago has no in-flight turn to re-attach to, so the
+    // bootstrap id is deliberately not an input to this decision.
+    expect(
+      shouldResumeStream({
+        authenticated: true,
+        routeChatId: undefined,
       }),
     ).toBe(false);
   });
@@ -31,27 +44,17 @@ describe("shouldResumeStream", () => {
       shouldResumeStream({
         authenticated: false,
         routeChatId: "5c7f1e0a-1111-2222-3333-444455556666",
-        workflowChatId: undefined,
       }),
     ).toBe(false);
   });
 
   it("resumes an existing chat opened from the canonical session route", () => {
+    // The only case a resume is for: you navigated back to a chat that may
+    // still be mid-turn.
     expect(
       shouldResumeStream({
         authenticated: true,
         routeChatId: "5c7f1e0a-1111-2222-3333-444455556666",
-        workflowChatId: undefined,
-      }),
-    ).toBe(true);
-  });
-
-  it("resumes once bootstrap mints a real chat id", () => {
-    expect(
-      shouldResumeStream({
-        authenticated: true,
-        routeChatId: undefined,
-        workflowChatId: "9a8b7c6d-0000-1111-2222-333344445555",
       }),
     ).toBe(true);
   });

--- a/lib/chat/__tests__/shouldResumeStream.test.ts
+++ b/lib/chat/__tests__/shouldResumeStream.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import shouldResumeStream from "../shouldResumeStream";
+
+describe("shouldResumeStream", () => {
+  it("does not resume on a cold home-page load (no auth, no real chat)", () => {
+    expect(
+      shouldResumeStream({
+        authenticated: false,
+        routeChatId: undefined,
+        workflowChatId: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not resume a client placeholder chat once auth resolves", () => {
+    // The home page mounts <Chat> with a locally generated UUID before the
+    // api has minted anything. Resuming it 404s: the row does not exist.
+    expect(
+      shouldResumeStream({
+        authenticated: true,
+        routeChatId: undefined,
+        workflowChatId: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not resume before auth resolves, even on a real chat route", () => {
+    // Privy's session resolves after mount; resuming here sends no
+    // Authorization header and 401s.
+    expect(
+      shouldResumeStream({
+        authenticated: false,
+        routeChatId: "5c7f1e0a-1111-2222-3333-444455556666",
+        workflowChatId: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  it("resumes an existing chat opened from the canonical session route", () => {
+    expect(
+      shouldResumeStream({
+        authenticated: true,
+        routeChatId: "5c7f1e0a-1111-2222-3333-444455556666",
+        workflowChatId: undefined,
+      }),
+    ).toBe(true);
+  });
+
+  it("resumes once bootstrap mints a real chat id", () => {
+    expect(
+      shouldResumeStream({
+        authenticated: true,
+        routeChatId: undefined,
+        workflowChatId: "9a8b7c6d-0000-1111-2222-333344445555",
+      }),
+    ).toBe(true);
+  });
+});

--- a/lib/chat/shouldResumeStream.ts
+++ b/lib/chat/shouldResumeStream.ts
@@ -1,0 +1,32 @@
+interface ShouldResumeStreamArgs {
+  /** Privy session has resolved and the user is signed in. */
+  authenticated: boolean;
+  /** `chatId` route param — present only on `/sessions/[sessionId]/chats/[chatId]`. */
+  routeChatId?: string;
+  /** Api-minted chat id from the new-chat bootstrap, once provisioning resolves. */
+  workflowChatId?: string;
+}
+
+/**
+ * Whether `useChat` may re-attach to an in-progress stream on mount.
+ *
+ * Both conditions guard a request that otherwise 4xxs on every cold load and
+ * surfaces as a "please try again" toast (chat#1949 F4a):
+ *
+ * - **Auth**, because the resume GET beats Privy's session resolution and
+ *   would carry no `Authorization` header (401).
+ * - **A real chat id**, because the home page mounts `<Chat>` with a locally
+ *   generated placeholder UUID that has no row behind it yet (404).
+ *
+ * `useChat` re-runs its resume effect when this flips, so gating only delays
+ * the resume until it can succeed — it does not skip it.
+ */
+function shouldResumeStream({
+  authenticated,
+  routeChatId,
+  workflowChatId,
+}: ShouldResumeStreamArgs): boolean {
+  return authenticated && Boolean(routeChatId ?? workflowChatId);
+}
+
+export default shouldResumeStream;

--- a/lib/chat/shouldResumeStream.ts
+++ b/lib/chat/shouldResumeStream.ts
@@ -3,30 +3,35 @@ interface ShouldResumeStreamArgs {
   authenticated: boolean;
   /** `chatId` route param — present only on `/sessions/[sessionId]/chats/[chatId]`. */
   routeChatId?: string;
-  /** Api-minted chat id from the new-chat bootstrap, once provisioning resolves. */
-  workflowChatId?: string;
 }
 
 /**
- * Whether `useChat` may re-attach to an in-progress stream on mount.
+ * Whether `useChat` may re-attach to an in-progress stream.
  *
- * Both conditions guard a request that otherwise 4xxs on every cold load and
- * surfaces as a "please try again" toast (chat#1949 F4a):
+ * A resume is only ever for one situation: you navigated back to an existing
+ * chat that may still be mid-turn. Both conditions below follow from that, and
+ * each was verified against the preview deployment (chat#1949 F4a):
  *
- * - **Auth**, because the resume GET beats Privy's session resolution and
- *   would carry no `Authorization` header (401).
- * - **A real chat id**, because the home page mounts `<Chat>` with a locally
- *   generated placeholder UUID that has no row behind it yet (404).
+ * - **Auth**, because the resume GET otherwise beats Privy's session
+ *   resolution and carries no `Authorization` header (401).
+ * - **A route `chatId`**, because that is what distinguishes "an existing chat
+ *   I opened" from a new chat. The home page has neither: it mounts `<Chat>`
+ *   with a client-generated placeholder UUID that no row backs (404), and the
+ *   bootstrap-minted id that replaces it belongs to a chat created seconds ago
+ *   with no turn in flight. Resuming that one made `WorkflowChatTransport`'s
+ *   `while (!gotFinish)` loop reissue the GET 118 times against a 204.
+ *
+ * `useMessageLoader` already draws the same line for the same reason — a
+ * bootstrap chat has nothing to load.
  *
  * `useChat` re-runs its resume effect when this flips, so gating only delays
- * the resume until it can succeed — it does not skip it.
+ * the resume until it can succeed; it does not skip it.
  */
 function shouldResumeStream({
   authenticated,
   routeChatId,
-  workflowChatId,
 }: ShouldResumeStreamArgs): boolean {
-  return authenticated && Boolean(routeChatId ?? workflowChatId);
+  return authenticated && Boolean(routeChatId);
 }
 
 export default shouldResumeStream;


### PR DESCRIPTION
Implements item **F4a** of #1949 — the cold-load error toast.

## The bug

`useVercelChat` passed `resume: true` unconditionally to `useChat`, so **every mount** issued `GET /api/chat/{chatId}/stream?startIndex=0`. On a cold load of `/` that request fails two different ways:

| | Cause | Response |
|---|---|---|
| **401** | The GET beats Privy's session resolution, so it carries no `Authorization` header | `Exactly one of x-api-key or Authorization must be provided` |
| **404** | `NewChatBootstrap` mounts `<Chat>` with a client-generated placeholder UUID ([NewChatBootstrap.tsx L34](https://github.com/recoupable/chat/blob/main/components/VercelChat/NewChatBootstrap.tsx#L34)) that has no row behind it until provisioning resolves | `Chat not found` |

Either one hits `onError`, which raises `toast.error("An error occurred, please try again!")`. Reproduced 2/2 in #1949 on an account unrelated to the reporter, so it is global. To a non-technical customer it reads as "the home page is broken and I can't start a chat" — which is exactly how it was reported.

## The fix

Gate resume on **both** preconditions via a new `shouldResumeStream` helper:

- **Auth resolved** (`authenticated` from Privy), so the header is present.
- **A chat id that actually exists** — the route `chatId` param on `/sessions/[sessionId]/chats/[chatId]`, or `workflowChatId` once bootstrap resolves. Never the placeholder.

**This delays the resume, it does not skip it.** `useChat` re-runs its resume effect when the flag changes (`useEffect(() => { if (resume) chatRef.current.resumeStream() }, [resume, chatRef])` in `@ai-sdk/react@3.0.243`), verified against the installed package rather than assumed. So returning to a chat mid-turn on the canonical route still re-attaches once auth lands.

## Why a separate file

One exported function per file (repo principles). It also makes the four-way condition directly testable without mounting the whole chat tree.

## Tests

RED before GREEN. `lib/chat/__tests__/shouldResumeStream.test.ts` covers all five states:

| Scenario | Resume? |
|---|---|
| Cold home load, no auth, no chat | ✗ |
| Auth resolved, still a placeholder chat | ✗ |
| Real chat route, auth not yet resolved | ✗ |
| Real chat route, auth resolved | ✓ |
| Bootstrap minted a real chat id | ✓ |

```
Test Files  93 passed (93)
     Tests  397 passed (397)
```

`tsc --noEmit` clean for the changed files. ESLint on `hooks/useVercelChat.ts`: **4 warnings before, 3 after** — this removes one pre-existing warning and adds none. 0 errors.

## Not in scope

- **F4b** (`/api/accounts/undefined/credits` → 400) is the other half of the same cold load and ships as its own PR — different file, different race, no dependency between them.
- The `console.error` at the `onError` site violates the repo's no-production-logging rule but predates this change.

## Verification status

🔄 Preview verification pending — Done-when for F4a is *a cold load of `/` produces zero 4xx responses and no error toast*, which needs the deployed preview and a DevTools network trace. Results to follow as a comment on this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the cold-load error toast by gating stream resume on a resolved session and an existing route chat id. Implements F4a of chat#1949 and stops 401/404s and post-bootstrap resume loops, while keeping mid-turn re-attach working.

- **Bug Fixes**
  - Added `shouldResumeStream` and wired it into `useVercelChat` to resume only when `authenticated` and a real `routeChatId` exists (never on a bootstrapped chat).
  - Prevents early `GET /api/chat/{id}/stream` calls without `Authorization`, against placeholder ids, and the 204 resume loop after bootstrap.
  - Added unit tests covering five key states.

<sup>Written for commit 77b2c9ab63b4bf995542594ae18abeb3adaeb375. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1950?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

