### PR TITLE
refactor(chat): close the credits manual-refetch path and drop the unsafe cast

### DIFF
--- a/hooks/useCredits.ts
+++ b/hooks/useCredits.ts
@@ -11,11 +11,18 @@ const useCredits = (): UseQueryResult<AccountCredits> => {
   return useQuery({
     queryKey: ["credits", userData?.account_id],
     queryFn: async () => {
+      const accountId = userData?.account_id;
+      // `enabled` below covers render-driven fetches, but `refetch()` bypasses
+      // it — `usePayment` exposes `refetchCredits` and `useVercelChat` calls it
+      // on finish, which can land before the account resolves (chat#1949 F4b).
+      if (!accountId) {
+        throw new Error("Cannot load credits without a resolved account id");
+      }
       const accessToken = await getAccessToken();
       if (!accessToken) {
         throw new Error("Please sign in to load credits");
       }
-      return getAccountCredits(userData?.account_id as string, accessToken);
+      return getAccountCredits(accountId, accessToken);
     },
     enabled: authenticated && !!userData?.account_id,
     staleTime: 5 * 60 * 1000, // 5 minutes

--- a/hooks/useCredits.ts
+++ b/hooks/useCredits.ts
@@ -1,4 +1,4 @@
-import { useQuery, UseQueryResult } from "@tanstack/react-query";
+import { skipToken, useQuery, UseQueryResult } from "@tanstack/react-query";
 import { usePrivy } from "@privy-io/react-auth";
 import getAccountCredits, {
   AccountCredits,
@@ -8,23 +8,25 @@ import { useUserProvider } from "@/providers/UserProvder";
 const useCredits = (): UseQueryResult<AccountCredits> => {
   const { userData } = useUserProvider();
   const { getAccessToken, authenticated } = usePrivy();
+  const accountId = userData?.account_id;
   return useQuery({
-    queryKey: ["credits", userData?.account_id],
-    queryFn: async () => {
-      const accountId = userData?.account_id;
-      // `enabled` below covers render-driven fetches, but `refetch()` bypasses
-      // it — `usePayment` exposes `refetchCredits` and `useVercelChat` calls it
-      // on finish, which can land before the account resolves (chat#1949 F4b).
-      if (!accountId) {
-        throw new Error("Cannot load credits without a resolved account id");
-      }
-      const accessToken = await getAccessToken();
-      if (!accessToken) {
-        throw new Error("Please sign in to load credits");
-      }
-      return getAccountCredits(accountId, accessToken);
-    },
-    enabled: authenticated && !!userData?.account_id,
+    queryKey: ["credits", accountId],
+    // Two different paths have to be closed. `enabled` stops react-query from
+    // fetching on its own, but it does not apply to `refetch()` — `usePayment`
+    // exposes that as `refetchCredits` and `useVercelChat` calls it on finish.
+    // `skipToken` is what covers the manual path, and narrowing `accountId`
+    // here is what lets the id reach `getAccountCredits` without a cast
+    // asserting a value we may not have (chat#1949 F4b).
+    queryFn: accountId
+      ? async () => {
+          const accessToken = await getAccessToken();
+          if (!accessToken) {
+            throw new Error("Please sign in to load credits");
+          }
+          return getAccountCredits(accountId, accessToken);
+        }
+      : skipToken,
+    enabled: authenticated && !!accountId,
     staleTime: 5 * 60 * 1000, // 5 minutes
     refetchOnWindowFocus: true,
   });

--- a/lib/recoup/__tests__/getAccountCredits.test.ts
+++ b/lib/recoup/__tests__/getAccountCredits.test.ts
@@ -39,6 +39,24 @@ describe("getAccountCredits", () => {
     expect(result).toEqual(apiResponse);
   });
 
+  // chat#1949 F4b: `useCredits` gates its query with react-query's `enabled`,
+  // but `refetch()` ignores `enabled`. `usePayment` exposes `refetchCredits`
+  // and `useVercelChat` calls it, so on a cold load the request fired with
+  // `account_id` still undefined and produced GET
+  // /api/accounts/undefined/credits -> 400. Guard where the URL is built, so
+  // no caller can interpolate a missing id again.
+  it.each([
+    ["undefined", undefined],
+    ["the literal string 'undefined'", "undefined"],
+    ["an empty string", ""],
+  ])("refuses to build a request when accountId is %s", async (_label, id) => {
+    await expect(
+      getAccountCredits(id as unknown as string, "test-token"),
+    ).rejects.toThrow(/account id/i);
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
   it("throws on a non-ok response", async () => {
     mockFetch.mockResolvedValueOnce({
       ok: false,

--- a/lib/recoup/getAccountCredits.ts
+++ b/lib/recoup/getAccountCredits.ts
@@ -17,6 +17,13 @@ async function getAccountCredits(
   accountId: string,
   accessToken: string,
 ): Promise<AccountCredits> {
+  // react-query's `enabled` does not apply to `refetch()`, so callers can
+  // reach here before the account resolves. Without this the id interpolates
+  // as the string "undefined" and the api 400s (chat#1949 F4b).
+  if (!accountId || accountId === "undefined") {
+    throw new Error("Cannot load credits without a resolved account id");
+  }
+
   const response = await fetch(
     `${getClientApiBaseUrl()}/api/accounts/${accountId}/credits`,
     {


### PR DESCRIPTION
Implements item **F4b** of #1949 — the second 4xx on every cold page load.

## The bug

`GET api.recoupable.dev/api/accounts/undefined/credits` → **400** `{"error":"id must be a valid UUID"}`, reproduced on both cold loads in #1949. Unlike F4a this request *does* carry a valid bearer token, so it is a distinct race: auth had resolved, `accountId` had not.

The chain:

1. [`useCredits.ts` L20](https://github.com/recoupable/chat/blob/main/hooks/useCredits.ts#L20) gates the query with react-query's `enabled: authenticated && !!userData?.account_id` — correct, but **`refetch()` deliberately ignores `enabled`**.
2. [`usePayment.tsx` L10](https://github.com/recoupable/chat/blob/main/hooks/usePayment.tsx#L10) exposes that refetch as `refetchCredits`.
3. [`useVercelChat.ts`](https://github.com/recoupable/chat/blob/main/hooks/useVercelChat.ts) calls `await refetchCredits()` in `onFinish`.
4. When it lands before `userData.account_id` resolves, the `userData?.account_id as string` cast lets `undefined` interpolate straight into the URL.

The cast is what made this invisible: it asserts a value the code does not have, so the type system had nothing to say about the exact case that fails.

## The fix

Two lines of defense, matching where the two problems actually are:

- **`getAccountCredits`** refuses to build the request when the id is missing or the literal string `"undefined"`. This is where the interpolation happens, so guarding here means no future caller can reintroduce it.
- **`useCredits`** drops the `as string` cast and handles the missing id explicitly, so the failure is a typed guard rather than a lie to the compiler.

The request is refused *before* `fetch`, so the api never sees it. Behaviour for callers is unchanged: an errored query leaves `creditsData` undefined and `usePayment` already falls back to `credits: 0` (`creditsData?.remaining_credits || 0`), which is what the 400 produced anyway — minus the failed request.

## Tests

RED before GREEN — 3 new cases failed with `Cannot read properties of undefined` before the guard existed, extending the existing `getAccountCredits` suite:

| accountId | Behaviour |
|---|---|
| `undefined` | throws, `fetch` never called |
| `"undefined"` (literal) | throws, `fetch` never called |
| `""` | throws, `fetch` never called |

Each asserts `expect(mockFetch).not.toHaveBeenCalled()` — the point is not that it throws, it is that no request goes out.

```
Test Files  92 passed (92)
     Tests  395 passed (395)
```

`tsc --noEmit` clean for the changed files. ESLint clean, 0 problems.

## Relationship to #1950

Same cold load, same issue, **independent fixes in different files** — no dependency, no shared lines, either can merge first. #1950 removes the 401/404 from stream resume; this removes the 400 from credits. Both are needed for #1949's F4 Done-when (*a cold load of `/` produces zero 4xx responses and no error toast*).

## Verification status

🔄 Preview verification pending — needs a DevTools network trace on the deployed preview confirming no `/credits` request carries `undefined`. Results to follow as a comment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops sending `/credits` requests with an unresolved account id to remove the 400 on cold page loads. Fixes F4b in #1949 by guarding both the API helper and the query hook.

- **Bug Fixes**
  - `getAccountCredits`: validate `accountId`; throw if missing or the string "undefined" so no fetch occurs.
  - `useCredits`: use `skipToken` with `enabled` from `@tanstack/react-query` to block both automatic and manual refetches when `accountId` is missing; remove the `as string` cast.
  - Tests: add cases for `undefined`, "undefined", and empty string; assert `fetch` is not called.

<sup>Written for commit 7d409cd178ff2e86d0cb05b4dfaef30f05a418d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

