### PR TITLE
feat(artists): View profile link on the roster card

### DIFF
--- a/components/Artists/Artist.tsx
+++ b/components/Artists/Artist.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { useArtistProvider } from "@/providers/ArtistProvider";
 import { ArtistRecord } from "@/types/Artist";
 import ImageWithFallback from "../ImageWithFallback";
@@ -38,6 +39,26 @@ const Artist = ({
           {artist.name}
         </div>
       </button>
+      {artist.id && (
+        <Link
+          href={`/artists/${artist.id}`}
+          onClick={(e) => e.stopPropagation()}
+          className="absolute right-3 bottom-3 flex items-center gap-1.5 rounded-full bg-black/60 px-3 py-1.5 text-xs font-medium text-white opacity-90 transition-opacity hover:opacity-100"
+        >
+          <span>View profile</span>
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 16 16"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            aria-hidden
+          >
+            <path d="M3 8h9M8.5 4.5L12 8l-3.5 3.5" />
+          </svg>
+        </Link>
+      )}
       {isVisibleDropDown && <DropDown artist={artist} />}
     </div>
   );


### PR DESCRIPTION
Row 5 of [recoupable/chat#1968](https://github.com/recoupable/chat/issues/1968) — the roster integration per the [Roster → Profile flow artboard](https://claude.ai/code/artifact/1ec40b7e-7615-4943-ae9b-9f1a886c6f3c).

One file: `components/Artists/Artist.tsx`. Each roster card gains a **View profile →** pill (bottom-right, over the card image) linking to `/artists/{id}` — the v1 page already live on prod, so this PR has no dependency on the rest of the v2 fleet. The card's existing click (select as workspace artist) is untouched; the link `stopPropagation`s so the two actions never collide, and it renders only when the artist has an id.

Lint clean, `tsc` at the 1-error worktree baseline (pre-existing png artifact). **Not yet done:** signed-in preview check per the issue's Done-when (View profile lands on the public page while a plain card click still switches the workspace artist) + screenshot. Flagging rather than implying it.

## Merge order

Independent of rows 1–4: needs only v1, which is live. Can merge any time.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “View profile” pill to each roster artist card that links to /artists/{id}. Previously, clicking the card only selected the workspace artist; now the card still selects as before, while the pill opens the public profile without triggering selection (via event stopPropagation). The pill renders only when the artist has an id.

- File touched: components/Artists/Artist.tsx; uses `next/link`.
- Destination `/artists/{id}` is already live; safe to merge independently of other roster work.
- Verify: clicking the pill navigates to the profile; clicking elsewhere on the card still switches the workspace artist; pill is hidden when no id.

<sup>Written for commit ba06df58610fefd6eabf544a80359d94b086d41b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

