### PR TITLE
feat(valuation): honest zero-stream states for catalog report and setup payoff

### DIFF
--- a/components/Catalog/report/CatalogReportContent.tsx
+++ b/components/Catalog/report/CatalogReportContent.tsx
@@ -54,6 +54,17 @@ const CatalogReportContent = ({ catalogId }: CatalogReportContentProps) => {
     totalStreams,
     catalogAgeYears: measurements.catalog_age_years,
   });
+  // Measured with zero plays (chat#1969): a $0 valuation card is not a report.
+  if (measuredSongCount > 0 && totalStreams === 0) {
+    return (
+      <CatalogReportEmptyState
+        state="no_streams"
+        hasOwnCatalogs={hasOwnCatalogs}
+        measuredSongCount={measuredSongCount}
+      />
+    );
+  }
+
   const insights = buildReportInsights({
     totalSongs: totalSongs ?? measuredSongCount,
     measuredSongCount,

--- a/components/Catalog/report/CatalogReportEmptyState.tsx
+++ b/components/Catalog/report/CatalogReportEmptyState.tsx
@@ -18,12 +18,14 @@ const CTA_CLASS =
 const CatalogReportEmptyState = ({
   state,
   hasOwnCatalogs,
+  measuredSongCount,
 }: {
   state: EmptyState;
   hasOwnCatalogs: boolean;
+  measuredSongCount?: number;
 }) => {
   const { login } = useUserProvider();
-  const copy = getCatalogReportEmptyCopy(state, { hasOwnCatalogs });
+  const copy = getCatalogReportEmptyCopy(state, { hasOwnCatalogs }, { measuredSongCount });
 
   return (
     <div className="max-w-3xl rounded-2xl bg-card p-6 sm:p-8 shadow-[0_0_0_1px_var(--border)]">

--- a/components/Onboarding/SetupValuation.tsx
+++ b/components/Onboarding/SetupValuation.tsx
@@ -5,6 +5,7 @@ import { buttonVariants } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import ValuationHero from "@/components/Home/ValuationHero";
 import MeasuringCatalogPanel from "@/components/Onboarding/MeasuringCatalogPanel";
+import ZeroStreamsPanel from "@/components/Onboarding/ZeroStreamsPanel";
 import useSetupValuation from "@/hooks/useSetupValuation";
 import { cn } from "@/lib/utils";
 
@@ -26,6 +27,15 @@ const SetupValuation = () => {
         <Skeleton className="h-8 w-1/2 rounded-lg" />
         <Skeleton className="h-[168px] w-full rounded-xl" />
       </div>
+    );
+  }
+
+  // Measured with zero plays: a terminal answer, never "measuring" (chat#1969).
+  if (status === "no_streams") {
+    return (
+      <ZeroStreamsPanel
+        measuredTrackCount={!valuation.show ? valuation.noStreams?.measuredTrackCount : undefined}
+      />
     );
   }
 

--- a/components/Onboarding/ZeroStreamsPanel.tsx
+++ b/components/Onboarding/ZeroStreamsPanel.tsx
@@ -15,11 +15,11 @@ const ZeroStreamsPanel = ({ measuredTrackCount }: { measuredTrackCount?: number 
     </h1>
     <p className="text-sm text-muted-foreground">
       We measured {measuredTrackCount ? `${measuredTrackCount} tracks in ` : ""}your catalog
-      and found no Spotify plays yet. Your baseline valuation will appear as plays start
-      logging; connecting your artist profiles helps future measurements pick them up.
+      and found no Spotify plays yet. If that looks wrong, check that we matched the right
+      artist profiles. Your baseline valuation will appear as plays start logging.
     </p>
     <Link href="/setup/socials" className={cn(buttonVariants(), "min-w-[200px]")}>
-      Connect your profiles
+      Check your matched profiles
     </Link>
   </section>
 );

--- a/components/Onboarding/ZeroStreamsPanel.tsx
+++ b/components/Onboarding/ZeroStreamsPanel.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link";
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+/**
+ * `/setup/valuation` for a catalog that measured with zero plays (chat#1969):
+ * a terminal, honest answer instead of a $0 band or an eternal "measuring"
+ * spinner. The valuation email is not sent for this case either, so this panel
+ * is the signup's only explanation of what happened.
+ */
+const ZeroStreamsPanel = ({ measuredTrackCount }: { measuredTrackCount?: number }) => (
+  <section className="mx-auto flex w-full max-w-xl flex-col items-center gap-4 px-6 py-8 text-center">
+    <h1 className="font-heading text-2xl font-semibold text-foreground">
+      No streams found yet
+    </h1>
+    <p className="text-sm text-muted-foreground">
+      We measured {measuredTrackCount ? `${measuredTrackCount} tracks in ` : ""}your catalog
+      and found no Spotify plays yet. Your baseline valuation will appear as plays start
+      logging; connecting your artist profiles helps future measurements pick them up.
+    </p>
+    <Link href="/setup/socials" className={cn(buttonVariants(), "min-w-[200px]")}>
+      Connect your profiles
+    </Link>
+  </section>
+);
+
+export default ZeroStreamsPanel;

--- a/hooks/useHomeValuation.ts
+++ b/hooks/useHomeValuation.ts
@@ -5,7 +5,7 @@ import { getValuationHeroState } from "@/lib/home/getValuationHeroState";
 import type { CatalogValuationBand } from "@/lib/catalog/getCatalogMeasurements";
 
 export type HomeValuationState =
-  | { show: false }
+  | { show: false; noStreams?: { measuredTrackCount: number } }
   | {
       show: true;
       artistName: string;
@@ -51,7 +51,7 @@ const useHomeValuation = (): HomeValuationState => {
     selectedArtistAccountId,
   });
 
-  if (!state.show) return { show: false };
+  if (!state.show) return state;
 
   return {
     show: true,

--- a/hooks/useSetupValuation.ts
+++ b/hooks/useSetupValuation.ts
@@ -39,6 +39,7 @@ const useSetupValuation = (): {
     hasCatalog: !!data?.catalogs?.length,
     hasArtists: (sorted ?? []).some(artist => !artist.isWorkspace),
     valuationReady: valuation.show,
+    measuredButNoStreams: !valuation.show && !!valuation.noStreams,
   });
 
   useEffect(() => {

--- a/lib/catalog/__tests__/getCatalogReportEmptyCopy.test.ts
+++ b/lib/catalog/__tests__/getCatalogReportEmptyCopy.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { getCatalogReportEmptyCopy } from "@/lib/catalog/getCatalogReportEmptyCopy";
 
-const states = ["signed-out", "measuring", "other-account", "error"] as const;
+const states = ["signed-out", "measuring", "other-account", "error", "no_streams"] as const;
 
 const withCatalogs = { hasOwnCatalogs: true };
 const withoutCatalogs = { hasOwnCatalogs: false };
@@ -38,6 +38,26 @@ describe("getCatalogReportEmptyCopy", () => {
     // The old copy claimed no valuation existed, which was false: the catalog
     // is measured, just not by this viewer.
     expect(copy.title.toLowerCase()).not.toContain("no valuation found");
+  });
+
+  // chat#1969: with the zero-stream shell email gone, this page is where a
+  // zero-stream signup learns what happened. Honest, with a next step.
+  it("tells a zero-stream viewer the catalog was measured with no plays yet", () => {
+    const copy = getCatalogReportEmptyCopy("no_streams", withCatalogs, {
+      measuredSongCount: 29,
+    });
+
+    expect(copy.title).toBe("No streams found yet");
+    expect(copy.body).toContain("29 tracks");
+    expect(copy.body.toLowerCase()).toContain("no spotify plays");
+    expect(copy.cta).toEqual({ label: "Connect your profiles", href: "/setup/socials" });
+  });
+
+  it("keeps the zero-stream copy honest without a track count", () => {
+    const copy = getCatalogReportEmptyCopy("no_streams", withCatalogs);
+
+    expect(copy.body).not.toContain("undefined");
+    expect(copy.body.toLowerCase()).toContain("no spotify plays");
   });
 
   it("offers a signed-out visitor a way in", () => {

--- a/lib/catalog/__tests__/getCatalogReportEmptyCopy.test.ts
+++ b/lib/catalog/__tests__/getCatalogReportEmptyCopy.test.ts
@@ -53,6 +53,15 @@ describe("getCatalogReportEmptyCopy", () => {
     expect(copy.cta).toEqual({ label: "Connect your profiles", href: "/setup/socials" });
   });
 
+  it("pluralizes the zero-stream track count correctly for one track", () => {
+    const copy = getCatalogReportEmptyCopy("no_streams", withCatalogs, {
+      measuredSongCount: 1,
+    });
+
+    expect(copy.body).toContain("1 track ");
+    expect(copy.body).not.toContain("1 tracks");
+  });
+
   it("keeps the zero-stream copy honest without a track count", () => {
     const copy = getCatalogReportEmptyCopy("no_streams", withCatalogs);
 

--- a/lib/catalog/__tests__/getCatalogReportEmptyCopy.test.ts
+++ b/lib/catalog/__tests__/getCatalogReportEmptyCopy.test.ts
@@ -50,7 +50,13 @@ describe("getCatalogReportEmptyCopy", () => {
     expect(copy.title).toBe("No streams found yet");
     expect(copy.body).toContain("29 tracks");
     expect(copy.body.toLowerCase()).toContain("no spotify plays");
-    expect(copy.cta).toEqual({ label: "Connect your profiles", href: "/setup/socials" });
+    // Honest mechanism (chat#1972 review): measurements read the matched
+    // artist's releases, not connected socials — so the next step is checking
+    // the match, not "connecting" something. A wrong Spotify match is a real
+    // cause of a zero-stream verdict.
+    expect(copy.body.toLowerCase()).toContain("check that we matched the right artist");
+    expect(copy.body).not.toContain("Connect your artist profiles");
+    expect(copy.cta).toEqual({ label: "Check your matched profiles", href: "/setup/socials" });
   });
 
   it("pluralizes the zero-stream track count correctly for one track", () => {

--- a/lib/catalog/getCatalogReportEmptyCopy.ts
+++ b/lib/catalog/getCatalogReportEmptyCopy.ts
@@ -67,7 +67,7 @@ export function getCatalogReportEmptyCopy(
       ...copy,
       body: copy.body.replace(
         "We measured this catalog",
-        `We measured ${scope.measuredSongCount} tracks in this catalog`,
+        `We measured ${scope.measuredSongCount} track${scope.measuredSongCount === 1 ? "" : "s"} in this catalog`,
       ),
     };
   }

--- a/lib/catalog/getCatalogReportEmptyCopy.ts
+++ b/lib/catalog/getCatalogReportEmptyCopy.ts
@@ -45,8 +45,11 @@ const COPY: Record<CatalogReportEmptyState, CatalogReportEmptyCopy> = {
   },
   no_streams: {
     title: "No streams found yet",
-    body: "We measured this catalog and found no Spotify plays yet. Connect your artist profiles so future measurements can pick up your streams, and your valuation will appear as plays start logging.",
-    cta: { label: "Connect your profiles", href: "/setup/socials" },
+    // Measurements read the matched artist's releases, not connected socials,
+    // so the honest next step is checking the match: a wrong Spotify match is
+    // a real cause of a zero-stream verdict.
+    body: "We measured this catalog and found no Spotify plays yet. If that looks wrong, check that we matched the right artist profiles. Your valuation will appear as plays start logging.",
+    cta: { label: "Check your matched profiles", href: "/setup/socials" },
   },
 };
 

--- a/lib/catalog/getCatalogReportEmptyCopy.ts
+++ b/lib/catalog/getCatalogReportEmptyCopy.ts
@@ -1,10 +1,11 @@
 import type { CatalogReportState } from "./getCatalogReportState";
 import { MEASURING_BODY, MEASURING_TITLE } from "./measuringCopy";
 
-export type CatalogReportEmptyState = Exclude<
-  CatalogReportState,
-  "loading" | "ready"
->;
+export type CatalogReportEmptyState =
+  | Exclude<CatalogReportState, "loading" | "ready">
+  // Measured fine, zero plays: not a load/auth state, decided by the report
+  // body itself (chat#1969).
+  | "no_streams";
 
 export interface CatalogReportEmptyCopy {
   title: string;
@@ -16,6 +17,11 @@ export interface CatalogReportEmptyCopy {
 export interface CatalogReportViewer {
   /** Whether the signed-in viewer has any catalog of their own. */
   hasOwnCatalogs: boolean;
+}
+
+export interface CatalogReportMeasuredScope {
+  /** Tracks measured in scope, when the caller knows it. */
+  measuredSongCount?: number;
 }
 
 const COPY: Record<CatalogReportEmptyState, CatalogReportEmptyCopy> = {
@@ -37,6 +43,11 @@ const COPY: Record<CatalogReportEmptyState, CatalogReportEmptyCopy> = {
     title: "Couldn't load this report",
     body: "Something went wrong loading the measurements. Refresh to try again; your songs are still available in the Manage songs tab.",
   },
+  no_streams: {
+    title: "No streams found yet",
+    body: "We measured this catalog and found no Spotify plays yet. Connect your artist profiles so future measurements can pick up your streams, and your valuation will appear as plays start logging.",
+    cta: { label: "Connect your profiles", href: "/setup/socials" },
+  },
 };
 
 /**
@@ -47,8 +58,19 @@ const COPY: Record<CatalogReportEmptyState, CatalogReportEmptyCopy> = {
 export function getCatalogReportEmptyCopy(
   state: CatalogReportEmptyState,
   viewer: CatalogReportViewer,
+  scope: CatalogReportMeasuredScope = {},
 ): CatalogReportEmptyCopy {
   const copy = COPY[state];
+
+  if (state === "no_streams" && scope.measuredSongCount) {
+    return {
+      ...copy,
+      body: copy.body.replace(
+        "We measured this catalog",
+        `We measured ${scope.measuredSongCount} tracks in this catalog`,
+      ),
+    };
+  }
 
   // A viewer who cannot see this catalog still needs somewhere to go, and
   // "your catalogs" is only somewhere for people who have one. A stranger

--- a/lib/home/__tests__/getValuationHeroState.test.ts
+++ b/lib/home/__tests__/getValuationHeroState.test.ts
@@ -31,6 +31,40 @@ const artistScopedMeasurements: CatalogMeasurementsResponse = {
 };
 
 describe("getValuationHeroState", () => {
+  // chat#1969: with the zero-stream shell email deleted, the app must not show
+  // a $0 band either. The hero hides (homepage falls back to the chat
+  // greeting) and reports why, so /setup/valuation can render its honest state.
+  it("hides the hero for a measured catalog with zero streams and says why", () => {
+    const state = getValuationHeroState({
+      catalog,
+      catalogsFailed: false,
+      measurements: {
+        ...wholeCatalogMeasurements,
+        total_streams: 0,
+        valuation: { low: 0, mid: 0, high: 0 },
+        measured_song_count: 29,
+      },
+      measurementsFailed: false,
+      selectedArtistName: null,
+      selectedArtistAccountId: null,
+    });
+
+    expect(state).toEqual({ show: false, noStreams: { measuredTrackCount: 29 } });
+  });
+
+  it("still shows the hero when total_streams is absent (pre-v2 response shape)", () => {
+    const state = getValuationHeroState({
+      catalog,
+      catalogsFailed: false,
+      measurements: wholeCatalogMeasurements,
+      measurementsFailed: false,
+      selectedArtistName: null,
+      selectedArtistAccountId: null,
+    });
+
+    expect(state.show).toBe(true);
+  });
+
   it("hides the hero while catalogs are still loading / the account has none", () => {
     expect(
       getValuationHeroState({

--- a/lib/home/__tests__/getValuationHeroState.test.ts
+++ b/lib/home/__tests__/getValuationHeroState.test.ts
@@ -52,6 +52,28 @@ describe("getValuationHeroState", () => {
     expect(state).toEqual({ show: false, noStreams: { measuredTrackCount: 29 } });
   });
 
+  it("does not trust a zero-stream verdict from a response outside the selected artist scope", () => {
+    // Artist selected, but the response does not echo that scope (pre-v2 api
+    // or unscoped read): whole-catalog zeros must not become a terminal
+    // no-streams verdict for the artist. Plain hide, no noStreams.
+    const state = getValuationHeroState({
+      catalog,
+      catalogsFailed: false,
+      measurements: {
+        ...wholeCatalogMeasurements,
+        total_streams: 0,
+        valuation: { low: 0, mid: 0, high: 0 },
+        measured_song_count: 29,
+        artist_account_id: null,
+      },
+      measurementsFailed: false,
+      selectedArtistName: "Nova",
+      selectedArtistAccountId: artistAccountId,
+    });
+
+    expect(state).toEqual({ show: false });
+  });
+
   it("still shows the hero when total_streams is absent (pre-v2 response shape)", () => {
     const state = getValuationHeroState({
       catalog,

--- a/lib/home/getValuationHeroState.ts
+++ b/lib/home/getValuationHeroState.ts
@@ -52,21 +52,23 @@ export function getValuationHeroState({
 
   if (!measurements.measured_song_count) return { show: false };
 
-  // Measured fine, zero plays (chat#1969): a $0 band is not a valuation. Hide
-  // the hero and say why, so /setup/valuation can render its honest zero state.
-  // Only an explicit 0 counts; an absent total_streams is the pre-v2 shape.
-  if (measurements.total_streams === 0) {
-    return {
-      show: false,
-      noStreams: { measuredTrackCount: measurements.measured_song_count },
-    };
-  }
-
   if (
     selectedArtistAccountId &&
     measurements.artist_account_id !== selectedArtistAccountId
   ) {
     return { show: false };
+  }
+
+  // Measured fine, zero plays (chat#1969): a $0 band is not a valuation. Hide
+  // the hero and say why, so /setup/valuation can render its honest zero state.
+  // Only an explicit 0 counts; an absent total_streams is the pre-v2 shape.
+  // After the scope check above, so an unscoped response can never mint a
+  // terminal zero-stream verdict for a selected artist.
+  if (measurements.total_streams === 0) {
+    return {
+      show: false,
+      noStreams: { measuredTrackCount: measurements.measured_song_count },
+    };
   }
 
   return {

--- a/lib/home/getValuationHeroState.ts
+++ b/lib/home/getValuationHeroState.ts
@@ -14,7 +14,7 @@ interface GetValuationHeroStateParams {
 }
 
 export type ValuationHeroState =
-  | { show: false }
+  | { show: false; noStreams?: { measuredTrackCount: number } }
   | {
       show: true;
       showArtist: boolean;
@@ -51,6 +51,16 @@ export function getValuationHeroState({
   if (!measurements?.valuation) return { show: false };
 
   if (!measurements.measured_song_count) return { show: false };
+
+  // Measured fine, zero plays (chat#1969): a $0 band is not a valuation. Hide
+  // the hero and say why, so /setup/valuation can render its honest zero state.
+  // Only an explicit 0 counts; an absent total_streams is the pre-v2 shape.
+  if (measurements.total_streams === 0) {
+    return {
+      show: false,
+      noStreams: { measuredTrackCount: measurements.measured_song_count },
+    };
+  }
 
   if (
     selectedArtistAccountId &&

--- a/lib/onboarding/__tests__/getSetupValuationStatus.test.ts
+++ b/lib/onboarding/__tests__/getSetupValuationStatus.test.ts
@@ -8,9 +8,23 @@ const base = {
   hasCatalog: true,
   hasArtists: true,
   valuationReady: false,
+  measuredButNoStreams: false,
 };
 
 describe("getSetupValuationStatus", () => {
+  // chat#1969: measured with zero plays is a terminal answer, not a pending
+  // one. Rendering "measuring" forever for a zero-stream catalog is the same
+  // dishonesty as the deleted shell email.
+  it("is no_streams when the catalog measured with zero plays", () => {
+    expect(
+      getSetupValuationStatus({ ...base, measuredButNoStreams: true }),
+    ).toBe("no_streams");
+  });
+
+  it("stays measuring when the valuation is pending without a zero-stream verdict", () => {
+    expect(getSetupValuationStatus({ ...base })).toBe("measuring");
+  });
+
   // `isPending`, not `isLoading`: useCatalogs is enabled: !!accountId &&
   // authenticated, and a disabled TanStack v5 query reports isPending true /
   // isFetching false. Redirecting on isLoading bounced every cold load of the

--- a/lib/onboarding/getSetupValuationStatus.ts
+++ b/lib/onboarding/getSetupValuationStatus.ts
@@ -1,4 +1,9 @@
-export type SetupValuationStatus = "loading" | "redirect" | "measuring" | "ready";
+export type SetupValuationStatus =
+  | "loading"
+  | "redirect"
+  | "measuring"
+  | "ready"
+  | "no_streams";
 
 interface SetupValuationStatusInput {
   /** The roster loads asynchronously; empty-while-loading is not "no artists". */
@@ -9,6 +14,8 @@ interface SetupValuationStatusInput {
   /** Seeding fires on the first artist add, so an artist means a catalog is coming. */
   hasArtists: boolean;
   valuationReady: boolean;
+  /** Measured with zero plays (chat#1969) — a terminal verdict, not pending. */
+  measuredButNoStreams: boolean;
 }
 
 /**
@@ -31,6 +38,7 @@ export function getSetupValuationStatus({
   hasCatalog,
   hasArtists,
   valuationReady,
+  measuredButNoStreams,
 }: SetupValuationStatusInput): SetupValuationStatus {
   if (catalogsPending || artistsPending) return "loading";
   if (catalogsFailed) return "redirect";
@@ -39,5 +47,8 @@ export function getSetupValuationStatus({
   // signup who followed the flow to an empty /catalogs, which is a worse dead
   // end than the static panel this row set out to fix.
   if (!hasCatalog) return hasArtists ? "measuring" : "redirect";
+  // A measured-zero catalog must not spin as "measuring" forever — that is the
+  // same dishonesty as the shell email chat#1969 deleted.
+  if (measuredButNoStreams) return "no_streams";
   return valuationReady ? "ready" : "measuring";
 }


### PR DESCRIPTION
Implements the in-app zero-state item of #1969 (chat-repo side; pairs with [recoupable/api#843](https://github.com/recoupable/api/pull/843)). With the zero-stream shell email deleted, the app is the customer's only explanation of a zero-stream valuation — and today it renders a **$0 band**: verified live against prod data (`measured_song_count: 29, total_streams: 0, valuation: {0,0,0}` for catalog `e1d71075`), which `/catalogs/{id}` shows as a $0 valuation card and the hero behind `/setup/valuation` as a $0 headline.

## What changed

- **`getValuationHeroState`**: an explicit `total_streams === 0` on a measured catalog hides the hero (homepage falls back to the chat greeting, the documented fallback) and returns `noStreams: { measuredTrackCount }` so the setup payoff can say why. Absent `total_streams` (pre-v2 response shape) keeps today's behavior.
- **`getSetupValuationStatus`**: new terminal `no_streams` status — a measured-zero catalog must not spin as "measuring" forever. `SetupValuation` renders the new `ZeroStreamsPanel`: "No streams found yet … we measured N tracks … Connect your profiles" → `/setup/socials`.
- **Catalog report tab**: `measuredSongCount > 0 && totalStreams === 0` renders a new `no_streams` entry in `getCatalogReportEmptyCopy` (honest copy + `Connect your profiles` CTA) instead of the $0 `CatalogValuationCard` stack.

## Verification (local)

- TDD red→green on the three logic units (`getCatalogReportEmptyCopy`, `getValuationHeroState`, `getSetupValuationStatus`), including the pre-v2 no-regression case and copy rules (no em dashes, no off-app links, no "undefined" without a count).
- Full chat suite: **95 files / 412 tests green**; `tsc --noEmit` 0 errors; eslint clean.

Preview verification with screenshots of the zero-state (fixture: the operator account's zero-stream catalog `e1d71075`) to follow as a PR comment.

Merge note: independent of api#843 in code, but they ship the story together — merge both before calling #1969 done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show honest zero-stream states instead of a $0 valuation or endless “measuring,” so users understand why no valuation appears. With the zero‑stream email removed (Linear #1969), the app now explains this case in‑product.

- Home hero: if a measured catalog has total_streams === 0, hide the hero and return noStreams { measuredTrackCount } for the setup payoff. If an artist is selected, only trust a zero‑stream verdict when measurements echo that artist scope; unscoped responses just hide the hero (no noStreams). Pre‑v2 responses without total_streams keep current behavior.
- Setup: getSetupValuationStatus adds a terminal no_streams status; SetupValuation renders ZeroStreamsPanel (“No streams found yet… measured N track(s)… check that we matched the right artist profiles”) with a “Check your matched profiles” CTA to /setup/socials instead of “measuring.”
- Catalog report: when measuredSongCount > 0 && totalStreams === 0, render a no_streams empty state from getCatalogReportEmptyCopy (pluralizes track count) with a “Check your matched profiles” CTA to /setup/socials, instead of a $0 CatalogValuationCard.

**Rollout**
- Ship with `recoupable/api#843`. No migrations. Pre‑v2 measurement shape remains unchanged.

<sup>Written for commit b70027b73b4a0b53534ea7b750986c4535310c88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1972?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clear no-streams empty states for catalogs with measured songs but no recorded plays.
  * Reports now display the measured track count and explain when valuation will become available.
  * Added guidance to connect artist profiles to begin recording plays.
  * Improved onboarding messaging for catalogs without Spotify plays while preserving track-count details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->