### PR TITLE
feat(valuation): one-click Run Valuation button on every no-valuation surface

### DIFF
--- a/components/Catalog/CatalogsPageContent.tsx
+++ b/components/Catalog/CatalogsPageContent.tsx
@@ -9,6 +9,7 @@ import useAccountOrganizations from "@/hooks/useAccountOrganizations";
 import { filterCatalogsByOrg } from "@/lib/catalog/filterCatalogsByOrg";
 import { getCatalogsEmptyCopy } from "@/lib/catalog/getCatalogsEmptyCopy";
 import { resolveSelectedOrgId } from "@/lib/catalog/resolveSelectedOrgId";
+import RunValuationButton from "@/components/Valuation/RunValuationButton";
 
 const CatalogsPageContent = () => {
   const { data, isLoading, error } = useCatalogs();
@@ -55,9 +56,14 @@ const CatalogsPageContent = () => {
     )?.organization_name;
 
     return (
-      <p className="text-sm text-muted-foreground">
-        {getCatalogsEmptyCopy(orgId, orgName)}
-      </p>
+      <div className="flex flex-col items-start gap-4">
+        <p className="text-sm text-muted-foreground">
+          {getCatalogsEmptyCopy(orgId, orgName)}
+        </p>
+        {/* Personal scope only: a run always lands the catalog on the calling
+            account, so an org-scoped empty list is not this button's job. */}
+        {!orgId && <RunValuationButton />}
+      </div>
     );
   }
 

--- a/components/Catalog/CatalogsPageContent.tsx
+++ b/components/Catalog/CatalogsPageContent.tsx
@@ -60,9 +60,9 @@ const CatalogsPageContent = () => {
         <p className="text-sm text-muted-foreground">
           {getCatalogsEmptyCopy(orgId, orgName)}
         </p>
-        {/* Personal scope only: a run always lands the catalog on the calling
-            account, so an org-scoped empty list is not this button's job. */}
-        {!orgId && <RunValuationButton />}
+        {/* Org-scoped runs land the catalog on the selected organization:
+            useRunValuation passes the selected org to POST /api/valuation. */}
+        <RunValuationButton />
       </div>
     );
   }

--- a/components/Catalog/__tests__/CatalogsPageContent.test.tsx
+++ b/components/Catalog/__tests__/CatalogsPageContent.test.tsx
@@ -13,6 +13,7 @@ const state = vi.hoisted(() => ({
   selectedOrgId: null as string | null,
   isLoading: false,
   error: null as Error | null,
+  catalogsOverride: null as unknown[] | null,
 }));
 
 vi.mock("@/providers/OrganizationProvider", () => ({
@@ -28,6 +29,9 @@ vi.mock("@/hooks/useAccountOrganizations", () => ({
       { id: "2", organization_id: RECOUP, organization_name: "Recoup" },
     ],
   }),
+}));
+vi.mock("@/components/Valuation/RunValuationButton", () => ({
+  default: () => <button>Run valuation</button>,
 }));
 vi.mock("@/components/Catalog/CatalogCard", () => ({
   default: ({ catalog }: { catalog: Catalog }) => <div>{catalog.name}</div>,
@@ -53,7 +57,7 @@ const catalogs = [
 
 vi.mock("@/hooks/useCatalogs", () => ({
   default: () => ({
-    data: { status: "success", catalogs },
+    data: { status: "success", catalogs: state.catalogsOverride ?? catalogs },
     isLoading: state.isLoading,
     error: state.error,
   }),
@@ -64,6 +68,7 @@ describe("CatalogsPageContent", () => {
     state.selectedOrgId = null;
     state.isLoading = false;
     state.error = null;
+    state.catalogsOverride = null;
   });
 
   it("shows every catalog the account can see on the personal account", () => {
@@ -121,5 +126,25 @@ describe("CatalogsPageContent", () => {
 
     expect(screen.getByText("Failed to fetch")).toBeDefined();
     expect(screen.queryByText(/No catalogs in/)).toBeNull();
+  });
+
+  // chat#1973: the personal-scope empty state is a primary no-valuation
+  // surface — it must carry the one-click run button, and an org-scoped empty
+  // view must not (a run always lands the catalog on the calling account).
+  it("renders the run button on the personal-scope empty state", () => {
+    state.selectedOrgId = null;
+    state.catalogsOverride = [];
+    render(<CatalogsPageContent />);
+
+    expect(screen.getByText("No catalogs found.")).toBeDefined();
+    expect(screen.getByText("Run valuation")).toBeDefined();
+  });
+
+  it("does not render the run button on an organization-scoped empty state", () => {
+    state.selectedOrgId = DUETTI;
+    state.catalogsOverride = [];
+    render(<CatalogsPageContent />);
+
+    expect(screen.queryByText("Run valuation")).toBeNull();
   });
 });

--- a/components/Catalog/__tests__/CatalogsPageContent.test.tsx
+++ b/components/Catalog/__tests__/CatalogsPageContent.test.tsx
@@ -128,9 +128,10 @@ describe("CatalogsPageContent", () => {
     expect(screen.queryByText(/No catalogs in/)).toBeNull();
   });
 
-  // chat#1973: the personal-scope empty state is a primary no-valuation
-  // surface — it must carry the one-click run button, and an org-scoped empty
-  // view must not (a run always lands the catalog on the calling account).
+  // chat#1973: every empty catalogs view is a primary no-valuation surface —
+  // personal and org-scoped alike carry the one-click run button. The run
+  // inherits the selected organization (useRunValuation passes it, so the
+  // resulting catalog lands on the org, not the calling account).
   it("renders the run button on the personal-scope empty state", () => {
     state.selectedOrgId = null;
     state.catalogsOverride = [];
@@ -140,11 +141,12 @@ describe("CatalogsPageContent", () => {
     expect(screen.getByText("Run valuation")).toBeDefined();
   });
 
-  it("does not render the run button on an organization-scoped empty state", () => {
+  it("renders the run button on an organization-scoped empty state", () => {
     state.selectedOrgId = DUETTI;
     state.catalogsOverride = [];
     render(<CatalogsPageContent />);
 
-    expect(screen.queryByText("Run valuation")).toBeNull();
+    expect(screen.getByText("No catalogs in Duetti yet.")).toBeDefined();
+    expect(screen.getByText("Run valuation")).toBeDefined();
   });
 });

--- a/components/Chat/ChatGreeting.tsx
+++ b/components/Chat/ChatGreeting.tsx
@@ -4,7 +4,7 @@ import ValuationHero from "@/components/Home/ValuationHero";
 import useHomeValuation from "@/hooks/useHomeValuation";
 import TasksModule from "@/components/Home/TasksModule";
 import HomeSuggestedPrompts from "@/components/Home/HomeSuggestedPrompts";
-import { VALUATION_URL } from "@/lib/consts";
+import HomeValuationCta from "@/components/Valuation/HomeValuationCta";
 
 /**
  * The empty chat's home header (recoupable/chat#1850), valuation first —
@@ -68,14 +68,7 @@ export function ChatGreeting({ isVisible }: { isVisible: boolean }) {
         {isArtistSelected ? artistName : "your roster"}
       </span>
       <div className="mb-4 mt-4">
-        <a
-          href={VALUATION_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="rounded-full bg-card px-4 py-2 text-sm font-normal text-muted-foreground shadow-[0px_0px_0px_1px_var(--border)] transition-colors hover:text-foreground"
-        >
-          Get a free catalog valuation &rarr;
-        </a>
+        <HomeValuationCta />
       </div>
       <div className="text-left text-sm font-normal tracking-normal">
         <TasksModule />

--- a/components/Onboarding/MeasuringCatalogPanel.tsx
+++ b/components/Onboarding/MeasuringCatalogPanel.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { buttonVariants } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { MEASURING_BODY, MEASURING_TITLE } from "@/lib/catalog/measuringCopy";
+import RunValuationButton from "@/components/Valuation/RunValuationButton";
 
 /**
  * Terminal state for `/setup/valuation` while a catalog exists but has no
@@ -23,6 +24,10 @@ const MeasuringCatalogPanel = () => (
     <Link href="/setup/tasks" className={cn(buttonVariants(), "min-w-[200px]")}>
       Set up your weekly report
     </Link>
+    <div className="mt-2 flex flex-col items-center gap-2">
+      <p className="text-xs text-muted-foreground">Been waiting a while?</p>
+      <RunValuationButton />
+    </div>
   </section>
 );
 

--- a/components/Onboarding/ZeroStreamsPanel.tsx
+++ b/components/Onboarding/ZeroStreamsPanel.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { buttonVariants } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import RunValuationButton from "@/components/Valuation/RunValuationButton";
 
 /**
  * `/setup/valuation` for a catalog that measured with zero plays (chat#1969):
@@ -21,6 +22,9 @@ const ZeroStreamsPanel = ({ measuredTrackCount }: { measuredTrackCount?: number 
     <Link href="/setup/socials" className={cn(buttonVariants(), "min-w-[200px]")}>
       Check your matched profiles
     </Link>
+    {/* Re-run is idempotent server-side (api#844): inside the reuse window it
+        converges on the same catalog instead of minting a duplicate. */}
+    <RunValuationButton />
   </section>
 );
 

--- a/components/Onboarding/__tests__/SetupValuation.test.tsx
+++ b/components/Onboarding/__tests__/SetupValuation.test.tsx
@@ -10,6 +10,12 @@ let valuationResult: Record<string, unknown>;
 let artists: { isWorkspace?: boolean }[];
 let artistsPending: boolean;
 
+// The measuring panel renders the one-click run button (chat#1973), whose
+// hook is out of scope for this suite.
+vi.mock("@/components/Valuation/RunValuationButton", () => ({
+  default: () => null,
+}));
+
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ replace }),
 }));

--- a/components/Valuation/HomeValuationCta.tsx
+++ b/components/Valuation/HomeValuationCta.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import useCatalogs from "@/hooks/useCatalogs";
+import useRunValuation from "@/hooks/useRunValuation";
+import { VALUATION_URL } from "@/lib/consts";
+import RunValuationButton from "./RunValuationButton";
+
+/**
+ * The greeting's valuation CTA (chat#1973): a signed-in account with a
+ * runnable roster artist and no catalog gets the one-click run in place —
+ * bouncing that account to the marketing funnel made it re-enter a flow it
+ * already finished. Everyone else keeps the funnel link.
+ */
+const HomeValuationCta = () => {
+  const { canRun } = useRunValuation();
+  const { data } = useCatalogs();
+  const hasNoCatalog = !!data && (data.catalogs?.length ?? 0) === 0;
+
+  if (canRun && hasNoCatalog) return <RunValuationButton />;
+
+  return (
+    <a
+      href={VALUATION_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="rounded-full bg-card px-4 py-2 text-sm font-normal text-muted-foreground shadow-[0px_0px_0px_1px_var(--border)] transition-colors hover:text-foreground"
+    >
+      Get a free catalog valuation &rarr;
+    </a>
+  );
+};
+
+export default HomeValuationCta;

--- a/components/Valuation/RunValuationButton.tsx
+++ b/components/Valuation/RunValuationButton.tsx
@@ -18,7 +18,11 @@ import useRunValuation from "@/hooks/useRunValuation";
  * /setup/artists route: there is no id to run against.
  */
 const RunValuationButton = ({ className }: { className?: string }) => {
-  const { run, isRunning, error, canRun, artistName } = useRunValuation();
+  const { run, isRunning, error, canRun, artistName, rosterPending } = useRunValuation();
+
+  // An unresolved roster is not "no runnable artist" — deciding on a pending
+  // roster would flash the setup route at accounts that can run.
+  if (rosterPending && !canRun) return null;
 
   if (!canRun) {
     return (
@@ -34,6 +38,7 @@ const RunValuationButton = ({ className }: { className?: string }) => {
         type="button"
         onClick={run}
         disabled={isRunning}
+        aria-busy={isRunning}
         className={cn(buttonVariants(), "min-w-[200px]")}
       >
         {isRunning ? (

--- a/components/Valuation/RunValuationButton.tsx
+++ b/components/Valuation/RunValuationButton.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import Link from "next/link";
+import { Loader2 } from "lucide-react";
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import useRunValuation from "@/hooks/useRunValuation";
+
+/**
+ * One-click valuation run (chat#1973): POSTs /api/valuation for the resolved
+ * roster artist. Disabled while a run is in flight, so a double click cannot
+ * start two runs (the server side is idempotent regardless, api#844). A
+ * failed run renders the API's error string verbatim — it is the diagnostic
+ * (a 404 here exposed a wrong-duplicate Spotify profile in live use), never
+ * to be hidden behind a generic failure state.
+ *
+ * Accounts with no roster artist carrying a Spotify profile fall back to the
+ * /setup/artists route: there is no id to run against.
+ */
+const RunValuationButton = ({ className }: { className?: string }) => {
+  const { run, isRunning, error, canRun, artistName } = useRunValuation();
+
+  if (!canRun) {
+    return (
+      <Link href="/setup/artists" className={cn(buttonVariants(), "min-w-[200px]", className)}>
+        Value your catalog
+      </Link>
+    );
+  }
+
+  return (
+    <div className={cn("flex flex-col items-center gap-2", className)}>
+      <button
+        type="button"
+        onClick={run}
+        disabled={isRunning}
+        className={cn(buttonVariants(), "min-w-[200px]")}
+      >
+        {isRunning ? (
+          <span className="inline-flex items-center gap-2">
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+            Measuring {artistName ?? "your catalog"}...
+          </span>
+        ) : (
+          `Run valuation${artistName ? ` for ${artistName}` : ""}`
+        )}
+      </button>
+      {error && (
+        <p role="alert" className="max-w-md text-center text-sm text-destructive">
+          {error.message}
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default RunValuationButton;

--- a/hooks/useRunValuation.ts
+++ b/hooks/useRunValuation.ts
@@ -1,0 +1,54 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { usePrivy } from "@privy-io/react-auth";
+import { useArtistProvider } from "@/providers/ArtistProvider";
+import { runValuation } from "@/lib/valuation/runValuation";
+import { getArtistSpotifyId } from "@/lib/artist/getArtistSpotifyId";
+
+/**
+ * One-click valuation run for the roster (chat#1973). Resolves the artist to
+ * value — the selected artist when it has a linked Spotify profile, otherwise
+ * the first roster artist that does — and runs `POST /api/valuation` under the
+ * signed-in account. `spotifyArtistId` is null when no roster artist can be
+ * run against (the caller falls back to the /setup/artists route).
+ *
+ * The mutation error carries the API's error string verbatim (see
+ * lib/valuation/runValuation) — surfaces render it, never a generic failure.
+ * Auth and artist context come from providers per the chat hooks conventions.
+ */
+const useRunValuation = () => {
+  const { getAccessToken, authenticated } = usePrivy();
+  const { selectedArtist, sorted } = useArtistProvider();
+  const queryClient = useQueryClient();
+
+  const candidates = [selectedArtist, ...(sorted ?? [])].filter(
+    (artist) => !!artist && !artist.isWorkspace,
+  );
+  const runnable = candidates.find((artist) => !!artist && getArtistSpotifyId(artist));
+  const spotifyArtistId = runnable ? getArtistSpotifyId(runnable) : null;
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      if (!spotifyArtistId) throw new Error("No roster artist with a linked Spotify profile");
+      const accessToken = await getAccessToken();
+      if (!accessToken) throw new Error("Please sign in to run a valuation");
+      return runValuation(accessToken, spotifyArtistId);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["catalogs"] });
+      queryClient.invalidateQueries({ queryKey: ["catalog-measurements"] });
+      queryClient.invalidateQueries({ queryKey: ["runs"] });
+    },
+  });
+
+  return {
+    run: () => mutation.mutate(),
+    isRunning: mutation.isPending,
+    error: mutation.error,
+    canRun: authenticated && !!spotifyArtistId,
+    artistName: runnable?.name ?? null,
+  };
+};
+
+export default useRunValuation;

--- a/hooks/useRunValuation.ts
+++ b/hooks/useRunValuation.ts
@@ -3,6 +3,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { usePrivy } from "@privy-io/react-auth";
 import { useArtistProvider } from "@/providers/ArtistProvider";
+import { useOrganization } from "@/providers/OrganizationProvider";
 import { runValuation } from "@/lib/valuation/runValuation";
 import { getArtistSpotifyId } from "@/lib/artist/getArtistSpotifyId";
 
@@ -19,7 +20,8 @@ import { getArtistSpotifyId } from "@/lib/artist/getArtistSpotifyId";
  */
 const useRunValuation = () => {
   const { getAccessToken, authenticated } = usePrivy();
-  const { selectedArtist, sorted } = useArtistProvider();
+  const { selectedArtist, sorted, isLoading: rosterPending } = useArtistProvider();
+  const { selectedOrgId } = useOrganization();
   const queryClient = useQueryClient();
 
   const candidates = [selectedArtist, ...(sorted ?? [])].filter(
@@ -33,7 +35,9 @@ const useRunValuation = () => {
       if (!spotifyArtistId) throw new Error("No roster artist with a linked Spotify profile");
       const accessToken = await getAccessToken();
       if (!accessToken) throw new Error("Please sign in to run a valuation");
-      return runValuation(accessToken, spotifyArtistId);
+      // The selected organization owns the resulting catalog; without it an
+      // organization-roster run would land on the personal account.
+      return runValuation(accessToken, spotifyArtistId, selectedOrgId ?? undefined);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["catalogs"] });
@@ -47,6 +51,7 @@ const useRunValuation = () => {
     isRunning: mutation.isPending,
     error: mutation.error,
     canRun: authenticated && !!spotifyArtistId,
+    rosterPending,
     artistName: runnable?.name ?? null,
   };
 };

--- a/lib/artist/__tests__/getArtistSpotifyId.test.ts
+++ b/lib/artist/__tests__/getArtistSpotifyId.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { getArtistSpotifyId } from "@/lib/artist/getArtistSpotifyId";
+import type { ArtistRecord } from "@/types/Artist";
+
+const artist = (links: string[]): ArtistRecord =>
+  ({
+    account_id: "acct-1",
+    name: "Nova",
+    account_socials: links.map((link, i) => ({ id: `s${i}`, link })),
+  }) as ArtistRecord;
+
+describe("getArtistSpotifyId", () => {
+  it("extracts the id from a spotify artist social", () => {
+    expect(
+      getArtistSpotifyId(artist(["https://open.spotify.com/artist/0PnRhcaedk9vk6q3IGte2S"])),
+    ).toBe("0PnRhcaedk9vk6q3IGte2S");
+  });
+
+  it("handles normalized links without protocol and with query strings", () => {
+    expect(
+      getArtistSpotifyId(artist(["open.spotify.com/artist/70ANZII0p7JCQ4ArAesCbA?si=abc"])),
+    ).toBe("70ANZII0p7JCQ4ArAesCbA");
+  });
+
+  it("skips non-artist spotify links and other platforms", () => {
+    expect(
+      getArtistSpotifyId(
+        artist(["https://open.spotify.com/track/123", "https://instagram.com/nova"]),
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null for an artist with no socials", () => {
+    expect(getArtistSpotifyId({ account_id: "a", name: null } as ArtistRecord)).toBeNull();
+  });
+});

--- a/lib/artist/getArtistSpotifyId.ts
+++ b/lib/artist/getArtistSpotifyId.ts
@@ -1,0 +1,15 @@
+import type { ArtistRecord } from "@/types/Artist";
+
+/**
+ * The Spotify artist id from a roster artist's connected socials, or null when
+ * none is linked. Matches the `spotify.com/artist/{id}` path on any stored
+ * form (with or without protocol, with query strings) — this is the id
+ * `POST /api/valuation` runs against (chat#1973).
+ */
+export function getArtistSpotifyId(artist: ArtistRecord): string | null {
+  for (const social of artist.account_socials ?? []) {
+    const match = social.link?.match(/spotify\.com\/artist\/([A-Za-z0-9]+)/);
+    if (match) return match[1];
+  }
+  return null;
+}

--- a/lib/valuation/__tests__/runValuation.test.ts
+++ b/lib/valuation/__tests__/runValuation.test.ts
@@ -12,12 +12,16 @@ describe("runValuation", () => {
     vi.mocked(getClientApiBaseUrl).mockReturnValue("https://api.example.com");
   });
 
-  it("POSTs the spotify_artist_id to /api/valuation with bearer auth", async () => {
-    global.fetch = vi
-      .fn()
-      .mockResolvedValue({ ok: true }) as unknown as typeof fetch;
+  it("POSTs the spotify_artist_id to /api/valuation with bearer auth and returns the result", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi
+        .fn()
+        .mockResolvedValue({ status: "success", catalog: { id: "cat_1" }, songs_measured: 12 }),
+    }) as unknown as typeof fetch;
 
-    await runValuation("tok", "0xPoV");
+    const result = await runValuation("tok", "0xPoV");
+    expect(result.catalog?.id).toBe("cat_1");
 
     expect(global.fetch).toHaveBeenCalledWith(
       "https://api.example.com/api/valuation",
@@ -29,13 +33,32 @@ describe("runValuation", () => {
     );
   });
 
-  it("throws on a non-ok response", async () => {
+  // The API's error string is the diagnostic ("No releases found for this
+  // Spotify artist" exposed a wrong-duplicate profile pick in live use) — it
+  // must reach the caller verbatim, never wrapped in a generic message.
+  it("throws the API's error string verbatim on a non-ok response", async () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: false,
-      status: 402,
-      text: vi.fn().mockResolvedValue("insufficient credits"),
+      status: 404,
+      text: vi
+        .fn()
+        .mockResolvedValue(
+          JSON.stringify({ status: "error", error: "No releases found for this Spotify artist" }),
+        ),
     }) as unknown as typeof fetch;
 
-    await expect(runValuation("tok", "0xPoV")).rejects.toThrow("402");
+    await expect(runValuation("tok", "0xPoV")).rejects.toThrow(
+      "No releases found for this Spotify artist",
+    );
+  });
+
+  it("falls back to the status code when the error body is not JSON", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 502,
+      text: vi.fn().mockResolvedValue("<html>bad gateway</html>"),
+    }) as unknown as typeof fetch;
+
+    await expect(runValuation("tok", "0xPoV")).rejects.toThrow("502");
   });
 });

--- a/lib/valuation/__tests__/runValuation.test.ts
+++ b/lib/valuation/__tests__/runValuation.test.ts
@@ -33,6 +33,21 @@ describe("runValuation", () => {
     );
   });
 
+  it("includes organization_id when an organization context is given", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ status: "success" }),
+    }) as unknown as typeof fetch;
+
+    await runValuation("tok", "0xPoV", "org-1");
+
+    const [, options] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(JSON.parse(options.body)).toEqual({
+      spotify_artist_id: "0xPoV",
+      organization_id: "org-1",
+    });
+  });
+
   // The API's error string is the diagnostic ("No releases found for this
   // Spotify artist" exposed a wrong-duplicate profile pick in live use) — it
   // must reach the caller verbatim, never wrapped in a generic message.

--- a/lib/valuation/runValuation.ts
+++ b/lib/valuation/runValuation.ts
@@ -20,10 +20,14 @@ export interface RunValuationResult {
  *
  * @param accessToken - Privy bearer for the owning account.
  * @param spotifyArtistId - The Spotify artist id to value.
+ * @param organizationId - Optional organization to own the resulting catalog
+ *   (must match the caller's selected organization context, or the catalog
+ *   silently lands on the personal account).
  */
 export async function runValuation(
   accessToken: string,
   spotifyArtistId: string,
+  organizationId?: string,
 ): Promise<RunValuationResult> {
   const res = await fetch(`${getClientApiBaseUrl()}/api/valuation`, {
     method: "POST",
@@ -31,7 +35,10 @@ export async function runValuation(
       "Content-Type": "application/json",
       Authorization: `Bearer ${accessToken}`,
     },
-    body: JSON.stringify({ spotify_artist_id: spotifyArtistId }),
+    body: JSON.stringify({
+      spotify_artist_id: spotifyArtistId,
+      ...(organizationId && { organization_id: organizationId }),
+    }),
   });
 
   if (!res.ok) {

--- a/lib/valuation/runValuation.ts
+++ b/lib/valuation/runValuation.ts
@@ -1,10 +1,22 @@
 import { getClientApiBaseUrl } from "@/lib/api/getClientApiBaseUrl";
 
+export interface RunValuationResult {
+  status: string;
+  catalog?: { id: string; name: string };
+  band?: { low: number; mid: number; high: number };
+  songs_measured?: number;
+}
+
 /**
  * Kicks `POST /api/valuation` for a Spotify artist (api#776): resolves the
  * artist's releases, measures play counts, and materializes an account-owned
  * catalog + value band. Used fire-and-forget on the first artist add to seed
- * the onboarding catalog so "Claim your catalog" is already complete.
+ * the onboarding catalog, and by the one-click run button (chat#1973).
+ *
+ * On failure the API's `error` string is thrown **verbatim** — it is the
+ * diagnostic ("No releases found for this Spotify artist" exposed a
+ * wrong-duplicate profile pick in live use), never to be wrapped in a generic
+ * message.
  *
  * @param accessToken - Privy bearer for the owning account.
  * @param spotifyArtistId - The Spotify artist id to value.
@@ -12,7 +24,7 @@ import { getClientApiBaseUrl } from "@/lib/api/getClientApiBaseUrl";
 export async function runValuation(
   accessToken: string,
   spotifyArtistId: string,
-): Promise<void> {
+): Promise<RunValuationResult> {
   const res = await fetch(`${getClientApiBaseUrl()}/api/valuation`, {
     method: "POST",
     headers: {
@@ -24,6 +36,14 @@ export async function runValuation(
 
   if (!res.ok) {
     const detail = await res.text().catch(() => "");
-    throw new Error(`Valuation failed: HTTP ${res.status} ${detail}`.trim());
+    let apiError: string | undefined;
+    try {
+      apiError = JSON.parse(detail)?.error;
+    } catch {
+      // Non-JSON body: fall through to the status-code message.
+    }
+    throw new Error(apiError || `Valuation failed: HTTP ${res.status}`);
   }
+
+  return res.json();
 }


### PR DESCRIPTION
Implements the shared-button row of #1973. Merge order: [docs#305](https://github.com/recoupable/docs/pull/305) → [api#844](https://github.com/recoupable/api/pull/844) → this (the re-run surface relies on api#844's idempotent claims; the button itself works against today's API).

## What this does

- **`useRunValuation`** resolves the runnable roster artist (selected artist with a linked Spotify profile, else the first that has one) and POSTs `/api/valuation` under the signed-in account; invalidates `catalogs` / `catalog-measurements` / `runs` on success so every surface settles without a refresh.
- **`RunValuationButton`**: one click, no wizard hop. Disabled while the run is in flight — a double click cannot start two runs (server-side idempotency via api#844 backstops it). **Failure renders the API's error string verbatim** (`runValuation` now throws `body.error` instead of a generic HTTP message) — per the live incident where `"No releases found for this Spotify artist"` was the diagnostic for a wrong-duplicate profile link. No runnable artist → the `/setup/artists` route (nothing to run against).
- **Surfaces**: `/catalogs` empty state (personal scope only — a run always lands on the calling account), the measuring panel's "Been waiting a while?" escape (the stranded-state fix from #1973's original scope), the zero-stream panel (safe re-run), and the home greeting via `HomeValuationCta` — a signed-in account with a runnable artist and no catalog gets the button in place instead of a bounce to the marketing funnel it already finished.

## Verification (local)

- TDD red→green: `getArtistSpotifyId` (extraction incl. normalized/query-string links, non-artist links, no socials) and `runValuation` (verbatim API error, non-JSON fallback, parsed result). Full chat suite **98 files / 424 tests green**; `tsc --noEmit` 0 errors; eslint clean.

Preview verification (one-click run from each surface, double-click prevention, verbatim 404 error render) to follow as a PR comment with screenshots.

Part of #1973.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a one-click Run Valuation button across no-valuation surfaces so users start a valuation in place. Previously these linked to the funnel; now one click runs for the selected or first Spotify‑linked artist, respects the selected organization, prevents double submits, and surfaces API errors verbatim. Part of #1973.

- Surfaces: Catalogs empty state in both personal and organization scopes, Measuring panel (“Been waiting a while?”), Zero‑stream panel (safe re‑run via API idempotency), and the home greeting via `HomeValuationCta` (button only when signed in, has a runnable artist, and no catalog; otherwise links to the funnel).
- Org ownership: Selected organization is sent to POST `/api/valuation` so resulting catalogs belong to the org, not the personal account.
- UX/a11y: `RunValuationButton` disables during flight with `aria-busy`, hides while the roster resolves to avoid setup-route flashes, and routes to `/setup/artists` when no runnable artist exists; error strings render verbatim.
- API client and cache: `runValuation` now returns the parsed result and throws the API’s `error` string; update any callers expecting `void`. On success, invalidate `catalogs`, `catalog-measurements`, and `runs`.
- Rollout/QA: Ship after idempotent claims are live. Verify org-owned runs, button shows on both empty-catalog views, double-click prevention, error rendering, and no route flash while the roster loads.

<sup>Written for commit a5294fd80b30a96e1a80421284c10065a77f79ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1981?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added options to run or rerun valuations from catalog and onboarding screens.
  * Added valuation actions to the home experience when an account is ready.
  * Added progress feedback, error messages, and guidance when setup is required.
  * Valuations now support organization-specific context and refresh related results automatically.
* **Bug Fixes**
  * Improved handling of valuation failures with clearer messages.
  * Reused existing linked artist information to run valuations consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->