### PR TITLE
feat(valuation): in-flight run status on home, artists and catalogs

### DIFF
--- a/components/Artists/Artists.tsx
+++ b/components/Artists/Artists.tsx
@@ -1,4 +1,5 @@
 import { useArtistProvider } from "@/providers/ArtistProvider";
+import ValuationRunStatusChip from "@/components/Valuation/ValuationRunStatusChip";
 import Artist from "./Artist";
 import CreateWorkspaceModal from "@/components/CreateWorkspaceModal";
 import { useCreateWorkspaceModal } from "@/hooks/useCreateWorkspaceModal";
@@ -10,7 +11,10 @@ const Artists = () => {
   return (
     <div className="grow h-[calc(100vh-64px)] md:h-screen overflow-hidden md:bg-grey-light-3 md:p-4">
       <div className="size-full bg-card rounded-xl flex flex-col items-center md:items-start gap-3 pt-6 md:pt-10 md:pb-4 px-4 md:px-20">
-        <p className="font-sans font-medium text-[50px]">Artists</p>
+        <div className="flex items-center gap-3">
+          <p className="font-sans font-medium text-[50px]">Artists</p>
+          <ValuationRunStatusChip />
+        </div>
         <p className="text-[19px] md:text-[25px] text-grey-dark text-center md:text-left">
           Choose an artist to dive into their insights and data.
         </p>

--- a/components/Catalog/CatalogsPage.tsx
+++ b/components/Catalog/CatalogsPage.tsx
@@ -1,11 +1,15 @@
 "use client";
 
 import CatalogsPageContent from "./CatalogsPageContent";
+import ValuationRunStatusChip from "@/components/Valuation/ValuationRunStatusChip";
 
 const CatalogsPage = () => {
   return (
     <div className="min-h-screen p-4">
-      <h1 className="text-lg md:text-xl font-medium pb-4">Catalogs</h1>
+      <div className="flex items-center gap-3 pb-4">
+        <h1 className="text-lg md:text-xl font-medium">Catalogs</h1>
+        <ValuationRunStatusChip />
+      </div>
       <CatalogsPageContent />
     </div>
   );

--- a/components/Valuation/ValuationRunStatusChip.tsx
+++ b/components/Valuation/ValuationRunStatusChip.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
 import useValuationRunStatus from "@/hooks/useValuationRunStatus";
 
 /**
@@ -17,7 +18,10 @@ const ValuationRunStatusChip = ({ className }: { className?: string }) => {
   return (
     <span
       role="status"
-      className={`inline-flex items-center gap-2 rounded-full bg-card px-3 py-1 text-xs text-muted-foreground shadow-[0px_0px_0px_1px_var(--border)] ${className ?? ""}`}
+      className={cn(
+        "inline-flex items-center gap-2 rounded-full bg-card px-3 py-1 text-xs text-muted-foreground shadow-[0px_0px_0px_1px_var(--border)]",
+        className,
+      )}
     >
       <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
       Valuation in progress

--- a/components/Valuation/ValuationRunStatusChip.tsx
+++ b/components/Valuation/ValuationRunStatusChip.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+import useValuationRunStatus from "@/hooks/useValuationRunStatus";
+
+/**
+ * In-flight valuation status (chat#1973): a small pill that appears wherever
+ * the customer is standing while a run measures, and disappears on any
+ * terminal state. Renders nothing when no run is in flight, so it can mount
+ * unconditionally on the home, artists and catalog surfaces.
+ */
+const ValuationRunStatusChip = ({ className }: { className?: string }) => {
+  const { run, isInFlight } = useValuationRunStatus();
+
+  if (!isInFlight || !run) return null;
+
+  return (
+    <span
+      role="status"
+      className={`inline-flex items-center gap-2 rounded-full bg-card px-3 py-1 text-xs text-muted-foreground shadow-[0px_0px_0px_1px_var(--border)] ${className ?? ""}`}
+    >
+      <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
+      Valuation in progress
+      {run.album_count ? ` · measuring ${run.album_count} releases` : ""}
+    </span>
+  );
+};
+
+export default ValuationRunStatusChip;

--- a/components/VercelChat/chat.tsx
+++ b/components/VercelChat/chat.tsx
@@ -5,6 +5,7 @@ import { Messages } from "./messages";
 import ChatInput from "./ChatInput";
 import ChatSkeleton from "../Chat/ChatSkeleton";
 import ChatGreeting from "../Chat/ChatGreeting";
+import ValuationRunStatusChip from "@/components/Valuation/ValuationRunStatusChip";
 import useVisibilityDelay from "@/hooks/useVisibilityDelay";
 import { useParams } from "next/navigation";
 import { useArtistFromChat } from "@/hooks/useArtistFromChat";
@@ -124,6 +125,9 @@ function ChatContentMemoized({
 
           {/* Centered greeting and chat input */}
           <div className="w-full max-w-3xl mx-auto">
+            <div className="mb-2 flex justify-center">
+              <ValuationRunStatusChip />
+            </div>
             <ChatGreeting isVisible={isVisible} />
             <div className="mt-1 md:mt-6">
               <ChatInput />

--- a/hooks/useValuationRunStatus.ts
+++ b/hooks/useValuationRunStatus.ts
@@ -32,14 +32,21 @@ const useValuationRunStatus = (): {
     },
     enabled: !!accountId && authenticated,
     refetchInterval: (query) => getRunPollInterval(query.state.data?.runs?.[0]),
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
   });
 
   const run = data?.runs?.[0];
 
   // A run just landed: the catalog reads are stale the moment it is claimed.
+  // Any observed in-flight phase counts — a fast run can jump queued →
+  // claimed between polls. A run first observed already claimed does not
+  // invalidate: nothing this mount showed predates it.
   const previousState = useRef<ValuationRun["state"] | undefined>(undefined);
   useEffect(() => {
-    if (run?.state === "claimed" && previousState.current === "measuring") {
+    const wasInFlight =
+      previousState.current === "measuring" || previousState.current === "queued";
+    if (run?.state === "claimed" && wasInFlight) {
       queryClient.invalidateQueries({ queryKey: ["catalogs"] });
       queryClient.invalidateQueries({ queryKey: ["catalog-measurements"] });
     }

--- a/hooks/useValuationRunStatus.ts
+++ b/hooks/useValuationRunStatus.ts
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { usePrivy } from "@privy-io/react-auth";
+import { useUserProvider } from "@/providers/UserProvder";
+import { getRuns, type ValuationRun } from "@/lib/runs/getRuns";
+import { getRunPollInterval } from "@/lib/runs/getRunPollInterval";
+
+/**
+ * The account's latest valuation run (chat#1973): one shared read of
+ * `GET /api/runs?kind=valuation` behind every status surface. Polls only
+ * while a run is in flight, and refreshes the catalog reads when a run
+ * reaches `claimed` so surfaces settle into the result without a manual
+ * refresh. The hook keys off `run.state` only — never storage details.
+ */
+const useValuationRunStatus = (): {
+  run: ValuationRun | undefined;
+  isInFlight: boolean;
+} => {
+  const { getAccessToken, authenticated } = usePrivy();
+  const { userData } = useUserProvider();
+  const accountId = userData?.account_id || "";
+  const queryClient = useQueryClient();
+
+  const { data } = useQuery({
+    queryKey: ["runs", accountId],
+    queryFn: async () => {
+      const accessToken = await getAccessToken();
+      if (!accessToken) throw new Error("No access token");
+      return getRuns(accessToken);
+    },
+    enabled: !!accountId && authenticated,
+    refetchInterval: (query) => getRunPollInterval(query.state.data?.runs?.[0]),
+  });
+
+  const run = data?.runs?.[0];
+
+  // A run just landed: the catalog reads are stale the moment it is claimed.
+  const previousState = useRef<ValuationRun["state"] | undefined>(undefined);
+  useEffect(() => {
+    if (run?.state === "claimed" && previousState.current === "measuring") {
+      queryClient.invalidateQueries({ queryKey: ["catalogs"] });
+      queryClient.invalidateQueries({ queryKey: ["catalog-measurements"] });
+    }
+    previousState.current = run?.state;
+  }, [run?.state, queryClient]);
+
+  return {
+    run,
+    isInFlight: run?.state === "queued" || run?.state === "measuring",
+  };
+};
+
+export default useValuationRunStatus;

--- a/lib/runs/__tests__/getRunPollInterval.test.ts
+++ b/lib/runs/__tests__/getRunPollInterval.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { getRunPollInterval } from "@/lib/runs/getRunPollInterval";
+import type { ValuationRun } from "@/lib/runs/getRuns";
+
+const run = (state: ValuationRun["state"]): ValuationRun =>
+  ({ id: "r", kind: "valuation", state, album_count: 1, created_at: "t", result: null });
+
+describe("getRunPollInterval", () => {
+  it("polls while a run is queued", () => {
+    expect(getRunPollInterval(run("queued"))).toBe(5000);
+  });
+
+  it("polls while a run is measuring", () => {
+    expect(getRunPollInterval(run("measuring"))).toBe(5000);
+  });
+
+  it("stops polling once claimed", () => {
+    expect(getRunPollInterval(run("claimed"))).toBe(false);
+  });
+
+  it("stops polling on failed", () => {
+    expect(getRunPollInterval(run("failed"))).toBe(false);
+  });
+
+  it("does not poll when the account has no runs", () => {
+    expect(getRunPollInterval(undefined)).toBe(false);
+  });
+});

--- a/lib/runs/__tests__/getRuns.test.ts
+++ b/lib/runs/__tests__/getRuns.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getRuns } from "@/lib/runs/getRuns";
+import { getClientApiBaseUrl } from "@/lib/api/getClientApiBaseUrl";
+
+vi.mock("@/lib/api/getClientApiBaseUrl", () => ({
+  getClientApiBaseUrl: vi.fn(),
+}));
+
+describe("getRuns", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getClientApiBaseUrl).mockReturnValue("https://api.example.com");
+  });
+
+  it("GETs the caller's latest valuation run with bearer auth", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        status: "success",
+        runs: [{ id: "run_1", kind: "valuation", state: "measuring" }],
+      }),
+    }) as unknown as typeof fetch;
+
+    const result = await getRuns("tok");
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://api.example.com/api/runs?kind=valuation&limit=1",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({ Authorization: "Bearer tok" }),
+      }),
+    );
+    expect(result.runs[0].state).toBe("measuring");
+  });
+
+  it("throws on a non-ok response", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: vi.fn().mockResolvedValue("unauthorized"),
+    }) as unknown as typeof fetch;
+
+    await expect(getRuns("tok")).rejects.toThrow("401");
+  });
+});

--- a/lib/runs/__tests__/getRuns.test.ts
+++ b/lib/runs/__tests__/getRuns.test.ts
@@ -33,6 +33,15 @@ describe("getRuns", () => {
     expect(result.runs[0].state).toBe("measuring");
   });
 
+  it("throws when a 2xx envelope carries status error", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ status: "error", error: "backend hiccup" }),
+    }) as unknown as typeof fetch;
+
+    await expect(getRuns("tok")).rejects.toThrow("backend hiccup");
+  });
+
   it("throws on a non-ok response", async () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: false,

--- a/lib/runs/getRunPollInterval.ts
+++ b/lib/runs/getRunPollInterval.ts
@@ -1,0 +1,10 @@
+import type { ValuationRun } from "@/lib/runs/getRuns";
+
+/**
+ * Poll cadence for the run-status query (chat#1973): keep polling while a run
+ * is in flight, stop on any terminal phase (or when the account has never run
+ * one) so idle sessions make no background requests.
+ */
+export function getRunPollInterval(run: ValuationRun | undefined): number | false {
+  return run && (run.state === "queued" || run.state === "measuring") ? 5000 : false;
+}

--- a/lib/runs/getRuns.ts
+++ b/lib/runs/getRuns.ts
@@ -35,5 +35,11 @@ export async function getRuns(accessToken: string): Promise<GetRunsResponse> {
     throw new Error(`HTTP ${res.status}: ${detail}`.trim());
   }
 
-  return res.json();
+  const body: GetRunsResponse & { error?: string } = await res.json();
+  // A 2xx envelope can still carry status "error"; treating it as "no runs"
+  // would hide a real failure and stop the status poll.
+  if (body.status === "error") {
+    throw new Error(body.error || "Failed to fetch runs");
+  }
+  return body;
 }

--- a/lib/runs/getRuns.ts
+++ b/lib/runs/getRuns.ts
@@ -1,0 +1,39 @@
+import { getClientApiBaseUrl } from "@/lib/api/getClientApiBaseUrl";
+
+export type ValuationRun = {
+  id: string;
+  kind: "valuation";
+  state: "queued" | "measuring" | "claimed" | "failed";
+  album_count: number;
+  created_at: string;
+  result: { catalog_id: string } | null;
+};
+
+export interface GetRunsResponse {
+  status: string;
+  runs: ValuationRun[];
+}
+
+/**
+ * The caller's latest valuation run from `GET /api/runs` (chat#1973) — the
+ * generic run-status resource behind in-flight valuation UI. States are
+ * domain phases; ids are opaque.
+ *
+ * @param accessToken - Privy bearer for the signed-in account.
+ */
+export async function getRuns(accessToken: string): Promise<GetRunsResponse> {
+  const res = await fetch(`${getClientApiBaseUrl()}/api/runs?kind=valuation&limit=1`, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "");
+    throw new Error(`HTTP ${res.status}: ${detail}`.trim());
+  }
+
+  return res.json();
+}


### PR DESCRIPTION
Implements the status-hook row of #1973. Merge order: [docs#305](https://github.com/recoupable/docs/pull/305) → [api#844](https://github.com/recoupable/api/pull/844) → this (the hook consumes `GET /api/runs`; until api#844 is live the chip simply never renders — the query errors quietly and nothing mounts).

## What this does

- **`useValuationRunStatus`** — one shared read of `GET /api/runs?kind=valuation&limit=1` (the run resource from the #1973 contract) behind every status surface. Polls at 5s **only while a run is queued/measuring** (`getRunPollInterval`), stops on any terminal phase or when the account has never run one — idle sessions make zero background requests. When a run transitions measuring → claimed it invalidates the catalog reads, so every surface settles into the result without a manual refresh. The hook keys off `run.state` only, never storage details.
- **`ValuationRunStatusChip`** — a status pill ("Valuation in progress · measuring N releases") that renders nothing when no run is in flight, so it mounts unconditionally.
- **Mounted where the customer stands**: the home greeting area (`components/VercelChat/chat.tsx`), the Artists roster page header, and the Catalogs page header. The artist *profile* page chip ships in the artist-page PR, which composes this hook.
- File-disjoint from [#1981](https://github.com/recoupable/chat/pull/1981) (the run-button PR) by construction — the two merge in either order.

## Verification (local)

- TDD red→green: `getRuns` (url/auth/error) and `getRunPollInterval` (all five cadence cases). Full chat suite **99 files / 426 tests green**; `tsc --noEmit` 0 errors; eslint clean.

Preview verification (chip appears during a live run on all three surfaces and settles on completion, screenshots) to follow as a PR comment.

Part of #1973.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows in‑flight valuation run status on Home, Artists, and Catalogs. Previously no status; now a pill appears while a run is queued or measuring, polling stops on terminal states, and pages auto‑refresh into results when the run is claimed.

- `useValuationRunStatus`: shared read of GET `/api/runs?kind=valuation&limit=1` via `@tanstack/react-query`; polls every 5s only while `queued`/`measuring`; no refetch on window focus/reconnect while idle; keys off `run.state` only.
- Completion: invalidates `["catalogs"]` and `["catalog-measurements"]` when a run reaches `claimed` after any observed in‑flight phase; no invalidation if first seen already `claimed`.
- `ValuationRunStatusChip`: spinner + “Valuation in progress · measuring N releases”; merges caller classes with `cn()`; renders nothing when no run or on query error.
- Mounted in Chat greeting, Artists header, and Catalogs header.
- `getRuns`: throws on non‑ok responses and on 2xx envelopes with `status: "error"` so polling does not silently stop. Tests cover request/auth/error handling and poll cadence. Part of #1973.

**Rollout**
- Merge order: `recoupable/docs#305` → `recoupable/api#844` → this. Until the API is live, the chip does not render (the query errors but no UI change).

<sup>Written for commit 829a808253c81f374a76c2db7b151ea6f3acb6a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

