### PR TITLE
feat(music): Music nav item and the /music gallery

### DIFF
--- a/app/music/page.tsx
+++ b/app/music/page.tsx
@@ -1,0 +1,5 @@
+import MusicPage from "@/components/MusicPage/MusicPage";
+
+const Music = () => <MusicPage />;
+
+export default Music;

--- a/components/MusicPage/MusicGallery.tsx
+++ b/components/MusicPage/MusicGallery.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { Skeleton } from "@/components/ui/skeleton";
+import MusicGenerationCard from "./MusicGenerationCard";
+import useMusicGenerations from "@/hooks/useMusicGenerations";
+import { useOrganization } from "@/providers/OrganizationProvider";
+
+const MusicGallery = () => {
+  const { data, isLoading, error } = useMusicGenerations();
+  const { selectedOrgId } = useOrganization();
+  const generations = data?.generations ?? [];
+
+  return (
+    <section className="mt-8">
+      <div className="mb-3 flex items-baseline justify-between gap-2">
+        <h2 className="font-heading text-xl font-bold">Your music</h2>
+        {!isLoading && !error && generations.length > 0 && (
+          <p className="text-sm text-muted-foreground">
+            {generations.length} {generations.length === 1 ? "song" : "songs"}
+          </p>
+        )}
+      </div>
+
+      {isLoading && (
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 3 }, (_, index) => (
+            <Skeleton key={index} className="h-32 w-full rounded-lg" />
+          ))}
+        </div>
+      )}
+
+      {!isLoading && error && (
+        <p className="text-sm text-destructive">
+          Could not load your music. Refresh to try again.
+        </p>
+      )}
+
+      {!isLoading && !error && generations.length === 0 && (
+        <p className="text-sm text-muted-foreground">
+          {selectedOrgId
+            ? "No songs generated in this organization yet."
+            : "No songs yet. Generate one to get started."}
+        </p>
+      )}
+
+      {!isLoading && !error && generations.length > 0 && (
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {generations.map(generation => (
+            <MusicGenerationCard key={generation.id} generation={generation} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+};
+
+export default MusicGallery;

--- a/components/MusicPage/MusicGenerationCard.tsx
+++ b/components/MusicPage/MusicGenerationCard.tsx
@@ -24,14 +24,23 @@ const MusicGenerationCard = ({ generation }: { generation: MusicGeneration }) =>
       </div>
 
       {isCompleted && (
-        <div className="mt-3 flex items-center gap-2">
+        <div className="mt-3 flex items-center gap-2 min-w-0">
           {/* The native player carries play, seek, and volume, and stays
-              keyboard accessible without us rebuilding any of it. */}
+              keyboard accessible without us rebuilding any of it.
+              preload="metadata" fetches only the header, a few KB, so the
+              scrubber shows the real length straight away. With "none" it read
+              0:00 / 0:00 next to a Completed pill, which looks like an empty
+              file until you press play.
+
+              flex-1 with a zero basis rather than w-full: a native audio
+              element has a wide intrinsic width and a flex item will not
+              shrink below its content, so w-full rendered the card 719px wide
+              inside a 342px grid cell on mobile. */}
           <audio
             controls
-            preload="none"
+            preload="metadata"
             src={generation.audio_url ?? undefined}
-            className="h-9 w-full min-w-0"
+            className="h-9 min-w-0 flex-1 basis-0"
           >
             <track kind="captions" />
           </audio>

--- a/components/MusicPage/MusicGenerationCard.tsx
+++ b/components/MusicPage/MusicGenerationCard.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { Download } from "lucide-react";
+import MusicStatusPill from "./MusicStatusPill";
+import { formatDuration } from "@/lib/music/formatDuration";
+import type { MusicGeneration } from "@/types/Music";
+
+const MusicGenerationCard = ({ generation }: { generation: MusicGeneration }) => {
+  const isCompleted = generation.status === "completed" && !!generation.audio_url;
+  const title = generation.title || generation.prompt;
+
+  return (
+    <div className="p-4 border rounded-lg">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <h2 className="font-semibold text-base truncate">{title}</h2>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            {new Date(generation.created_at).toLocaleDateString()}
+          </p>
+        </div>
+        <MusicStatusPill status={generation.status} />
+      </div>
+
+      {isCompleted && (
+        <div className="mt-3 flex items-center gap-2">
+          {/* The native player carries play, seek, and volume, and stays
+              keyboard accessible without us rebuilding any of it. */}
+          <audio
+            controls
+            preload="none"
+            src={generation.audio_url ?? undefined}
+            className="h-9 w-full min-w-0"
+          >
+            <track kind="captions" />
+          </audio>
+          <a
+            href={generation.audio_url ?? undefined}
+            download
+            aria-label={`Download ${title}`}
+            className="shrink-0 inline-flex items-center justify-center size-9 rounded-xl border hover:bg-muted transition-colors"
+          >
+            <Download className="size-4" />
+          </a>
+        </div>
+      )}
+
+      {generation.status === "processing" || generation.status === "pending" ? (
+        <p className="mt-3 text-xs text-muted-foreground">
+          Generating. This usually takes 1 to 2 minutes.
+        </p>
+      ) : null}
+
+      {generation.status === "failed" && (
+        <p className="mt-3 text-xs text-destructive">
+          {generation.error_message || "Generation failed."}
+        </p>
+      )}
+
+      {isCompleted && generation.duration_seconds !== null && (
+        <p className="mt-2 text-xs text-muted-foreground">
+          {formatDuration(generation.duration_seconds)}
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default MusicGenerationCard;

--- a/components/MusicPage/MusicGenerationCard.tsx
+++ b/components/MusicPage/MusicGenerationCard.tsx
@@ -12,7 +12,10 @@ const MusicGenerationCard = ({ generation }: { generation: MusicGeneration }) =>
   const title = generation.prompt;
 
   return (
-    <div className="p-4 border rounded-lg">
+    // min-w-0 because a grid item defaults to min-width:auto and will not
+    // shrink below its content. Without it this card rendered 719px wide in a
+    // 342px cell on mobile, pushing the player off screen.
+    <div className="p-4 border rounded-lg min-w-0">
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0">
           <h2 className="font-semibold text-base truncate">{title}</h2>

--- a/components/MusicPage/MusicGenerationCard.tsx
+++ b/components/MusicPage/MusicGenerationCard.tsx
@@ -7,7 +7,9 @@ import type { MusicGeneration } from "@/types/Music";
 
 const MusicGenerationCard = ({ generation }: { generation: MusicGeneration }) => {
   const isCompleted = generation.status === "completed" && !!generation.audio_url;
-  const title = generation.title || generation.prompt;
+  // The API returns no title: the prompt is what the user wrote and what
+  // identifies the song to them.
+  const title = generation.prompt;
 
   return (
     <div className="p-4 border rounded-lg">

--- a/components/MusicPage/MusicPage.tsx
+++ b/components/MusicPage/MusicPage.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { MusicPageHeader } from "./MusicPageHeader";
+import MusicGallery from "./MusicGallery";
+
+const MusicPage = () => {
+  return (
+    <div className="max-w-full md:max-w-[calc(100vw-200px)] grow py-8 px-6 md:px-12">
+      <MusicPageHeader />
+      <MusicGallery />
+    </div>
+  );
+};
+
+export default MusicPage;

--- a/components/MusicPage/MusicPageHeader.tsx
+++ b/components/MusicPage/MusicPageHeader.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+export function MusicPageHeader() {
+  return (
+    <div className="mb-6">
+      <h1 className="text-left font-heading text-3xl font-bold dark:text-white mb-4">
+        Music
+      </h1>
+      <p className="text-lg text-muted-foreground text-left font-light font-sans max-w-2xl">
+        Generate songs and listen back to everything you have created.
+      </p>
+    </div>
+  );
+}

--- a/components/MusicPage/MusicStatusPill.tsx
+++ b/components/MusicPage/MusicStatusPill.tsx
@@ -1,0 +1,32 @@
+import { cn } from "@/lib/utils";
+import type { MusicGenerationStatus } from "@/types/Music";
+
+const LABELS: Record<MusicGenerationStatus, string> = {
+  pending: "Queued",
+  processing: "Processing",
+  completed: "Completed",
+  failed: "Failed",
+};
+
+// Tints, not solid fills, per DESIGN.md. Dark mode gets a stronger tint and a
+// brighter text colour because the light-mode 8% wash is invisible on the
+// near-black card.
+const STYLES: Record<MusicGenerationStatus, string> = {
+  pending: "bg-[#0070f3]/10 text-[#0060d3] dark:bg-[#0070f3]/20 dark:text-[#5aa9ff]",
+  processing: "bg-[#f59e0b]/10 text-[#b45309] dark:bg-[#f59e0b]/20 dark:text-[#f59e0b]",
+  completed: "bg-[#22c55e]/10 text-[#15803d] dark:bg-[#22c55e]/20 dark:text-[#22c55e]",
+  failed: "bg-destructive/10 text-destructive dark:bg-destructive/20 dark:text-[#f87171]",
+};
+
+const MusicStatusPill = ({ status }: { status: MusicGenerationStatus }) => (
+  <span
+    className={cn(
+      "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium whitespace-nowrap",
+      STYLES[status],
+    )}
+  >
+    {LABELS[status]}
+  </span>
+);
+
+export default MusicStatusPill;

--- a/components/MusicPage/__tests__/MusicGenerationCard.test.tsx
+++ b/components/MusicPage/__tests__/MusicGenerationCard.test.tsx
@@ -10,16 +10,9 @@ const generation = (over: Partial<MusicGeneration> = {}): MusicGeneration => ({
   status: "completed",
   prompt: "Genre: acoustic pop.",
   lyrics: "[verse]\nMorning light",
-  title: "Midnight Interstate",
   model: "minimax/music-3",
   duration_seconds: 60,
-  seed: 42,
-  num_inference_steps: 30,
-  guidance_scale: 1.7,
   audio_url: "https://cdn.example/music/abc.wav",
-  mime_type: "audio/wav",
-  file_size_bytes: 100,
-  organization_id: null,
   error_message: null,
   created_at: "2026-08-21T12:00:00.000Z",
   updated_at: "2026-08-21T12:00:00.000Z",
@@ -30,7 +23,7 @@ describe("MusicGenerationCard", () => {
   it("offers a download beside a completed song", () => {
     render(<MusicGenerationCard generation={generation()} />);
 
-    const download = screen.getByRole("link", { name: /download midnight interstate/i });
+    const download = screen.getByRole("link", { name: /download genre: acoustic pop/i });
     expect(download.getAttribute("href")).toBe("https://cdn.example/music/abc.wav");
     expect(download.hasAttribute("download")).toBe(true);
   });
@@ -61,8 +54,8 @@ describe("MusicGenerationCard", () => {
     expect(screen.queryByRole("link", { name: /download/i })).toBeNull();
   });
 
-  it("falls back to the prompt when a generation has no title", () => {
-    render(<MusicGenerationCard generation={generation({ title: null })} />);
+  it("identifies a song by its prompt, which is what the API returns", () => {
+    render(<MusicGenerationCard generation={generation()} />);
 
     expect(screen.getByText("Genre: acoustic pop.")).toBeDefined();
   });

--- a/components/MusicPage/__tests__/MusicGenerationCard.test.tsx
+++ b/components/MusicPage/__tests__/MusicGenerationCard.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import MusicGenerationCard from "@/components/MusicPage/MusicGenerationCard";
+import type { MusicGeneration } from "@/types/Music";
+
+const generation = (over: Partial<MusicGeneration> = {}): MusicGeneration => ({
+  id: "11111111-2222-4333-8444-555555555555",
+  status: "completed",
+  prompt: "Genre: acoustic pop.",
+  lyrics: "[verse]\nMorning light",
+  title: "Midnight Interstate",
+  model: "minimax/music-3",
+  duration_seconds: 60,
+  seed: 42,
+  num_inference_steps: 30,
+  guidance_scale: 1.7,
+  audio_url: "https://cdn.example/music/abc.wav",
+  mime_type: "audio/wav",
+  file_size_bytes: 100,
+  organization_id: null,
+  error_message: null,
+  created_at: "2026-08-21T12:00:00.000Z",
+  updated_at: "2026-08-21T12:00:00.000Z",
+  ...over,
+});
+
+describe("MusicGenerationCard", () => {
+  it("offers a download beside a completed song", () => {
+    render(<MusicGenerationCard generation={generation()} />);
+
+    const download = screen.getByRole("link", { name: /download midnight interstate/i });
+    expect(download.getAttribute("href")).toBe("https://cdn.example/music/abc.wav");
+    expect(download.hasAttribute("download")).toBe(true);
+  });
+
+  it("offers no download while a song is still generating", () => {
+    render(
+      <MusicGenerationCard
+        generation={generation({ status: "processing", audio_url: null })}
+      />,
+    );
+
+    expect(screen.queryByRole("link", { name: /download/i })).toBeNull();
+    expect(screen.getByText(/1 to 2 minutes/i)).toBeDefined();
+  });
+
+  it("shows the failure reason verbatim rather than a generic message", () => {
+    render(
+      <MusicGenerationCard
+        generation={generation({
+          status: "failed",
+          audio_url: null,
+          error_message: "Lyrics structure tags were rejected.",
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Lyrics structure tags were rejected.")).toBeDefined();
+    expect(screen.queryByRole("link", { name: /download/i })).toBeNull();
+  });
+
+  it("falls back to the prompt when a generation has no title", () => {
+    render(<MusicGenerationCard generation={generation({ title: null })} />);
+
+    expect(screen.getByText("Genre: acoustic pop.")).toBeDefined();
+  });
+});

--- a/components/SideMenu/SideMenu.tsx
+++ b/components/SideMenu/SideMenu.tsx
@@ -15,6 +15,7 @@ import { usePathname } from "next/navigation";
 import TasksNavItem from "../Sidebar/TasksNavItem";
 import FilesNavItem from "../Sidebar/FilesNavItem";
 import CatalogsNavItem from "../Sidebar/CatalogsNavItem";
+import MusicNavItem from "../Sidebar/MusicNavItem";
 import ArtistsNavItem from "../Sidebar/ArtistsNavItem";
 
 const SideMenu = ({
@@ -35,6 +36,7 @@ const SideMenu = ({
   const isFiles = pathname.includes("/files");
   const isCatalogs = pathname.includes("/catalogs");
   const isArtists = pathname.includes("/artists");
+  const isMusic = pathname.includes("/music");
 
   const goToItem = (link?: string) => {
     if (isPrepared()) {
@@ -95,6 +97,7 @@ const SideMenu = ({
             isActive={isCatalogs}
             onClick={() => goToItem("catalogs")}
           />
+          <MusicNavItem isActive={isMusic} onClick={() => goToItem("music")} />
           <AgentsNavItem
             isActive={isAgents}
             onClick={() => goToItem("agents")}

--- a/components/Sidebar/Menu.tsx
+++ b/components/Sidebar/Menu.tsx
@@ -26,6 +26,7 @@ const Menu = ({ isExpanded, isPinned = false, onTogglePin }: MenuProps) => {
   const isFiles = pathname.includes("/files");
   const isCatalogs = pathname.includes("/catalogs");
   const isArtists = pathname.includes("/artists");
+  const isMusic = pathname.includes("/music");
 
   const goToItem = (link?: string) => {
     if (isPrepared()) {
@@ -51,6 +52,7 @@ const Menu = ({ isExpanded, isPinned = false, onTogglePin }: MenuProps) => {
         isFiles={isFiles}
         isCatalogs={isCatalogs}
         isArtists={isArtists}
+        isMusic={isMusic}
         onNavigate={goToItem}
       />
 

--- a/components/Sidebar/MusicNavItem.tsx
+++ b/components/Sidebar/MusicNavItem.tsx
@@ -1,0 +1,22 @@
+import NavButton from "./NavButton";
+
+export interface MusicNavItemProps {
+  isActive: boolean;
+  isExpanded?: boolean;
+  onClick: () => void;
+}
+
+const MusicNavItem = ({ isActive, isExpanded, onClick }: MusicNavItemProps) => {
+  return (
+    <NavButton
+      icon="audio"
+      label="Music"
+      isActive={isActive}
+      isExpanded={isExpanded}
+      onClick={onClick}
+      aria-label="View music"
+    />
+  );
+};
+
+export default MusicNavItem;

--- a/components/Sidebar/SecondaryNav.tsx
+++ b/components/Sidebar/SecondaryNav.tsx
@@ -2,6 +2,7 @@ import AgentsNavItem from "./AgentsNavItem";
 import TasksNavItem from "./TasksNavItem";
 import FilesNavItem from "./FilesNavItem";
 import CatalogsNavItem from "./CatalogsNavItem";
+import MusicNavItem from "./MusicNavItem";
 import ArtistsNavItem from "./ArtistsNavItem";
 
 interface SecondaryNavProps {
@@ -11,6 +12,7 @@ interface SecondaryNavProps {
   isFiles: boolean;
   isCatalogs: boolean;
   isArtists: boolean;
+  isMusic: boolean;
   onNavigate: (path: string) => void;
 }
 
@@ -21,11 +23,13 @@ const SecondaryNav = ({
   isFiles,
   isCatalogs,
   isArtists,
+  isMusic,
   onNavigate,
 }: SecondaryNavProps) => (
   <div className="flex flex-col gap-1 w-full mt-3">
     <ArtistsNavItem isActive={isArtists} isExpanded={isExpanded} onClick={() => onNavigate("artists")} />
     <CatalogsNavItem isActive={isCatalogs} isExpanded={isExpanded} onClick={() => onNavigate("catalogs")} />
+    <MusicNavItem isActive={isMusic} isExpanded={isExpanded} onClick={() => onNavigate("music")} />
     <AgentsNavItem isActive={isAgents} isExpanded={isExpanded} onClick={() => onNavigate("agents")} />
     <TasksNavItem isActive={isTasks} isExpanded={isExpanded} onClick={() => onNavigate("tasks")} />
     <FilesNavItem isActive={isFiles} isExpanded={isExpanded} onClick={() => onNavigate("files")} />

--- a/components/Sidebar/__tests__/SecondaryNav.test.tsx
+++ b/components/Sidebar/__tests__/SecondaryNav.test.tsx
@@ -18,6 +18,7 @@ const renderNav = (overrides = {}) => {
       isFiles={false}
       isCatalogs={false}
       isArtists={false}
+      isMusic={false}
       onNavigate={onNavigate}
       {...overrides}
     />,
@@ -61,5 +62,15 @@ describe("SecondaryNav", () => {
     expect(screen.getByRole("button", { name: /view agents/i })).toBeDefined();
     expect(screen.getByRole("button", { name: /view tasks/i })).toBeDefined();
     expect(screen.getByRole("button", { name: /view files/i })).toBeDefined();
+  });
+
+  // chat#1992: /music is the generation surface; without a nav item it is
+  // reachable only by typing the URL, which is how /catalogs was stranded.
+  it("links Music and navigates to the music route", () => {
+    const { onNavigate } = renderNav();
+
+    fireEvent.click(screen.getByRole("button", { name: /view music/i }));
+
+    expect(onNavigate).toHaveBeenCalledWith("music");
   });
 });

--- a/hooks/useMusicGenerations.ts
+++ b/hooks/useMusicGenerations.ts
@@ -1,0 +1,39 @@
+import { useQuery, UseQueryResult } from "@tanstack/react-query";
+import { usePrivy } from "@privy-io/react-auth";
+import {
+  getMusicGenerations,
+  MusicGenerationsResponse,
+} from "@/lib/music/getMusicGenerations";
+import { useUserProvider } from "@/providers/UserProvder";
+
+/** How often to re-read while any generation is still rendering. */
+const IN_FLIGHT_POLL_MS = 5000;
+
+const useMusicGenerations = (): UseQueryResult<MusicGenerationsResponse> => {
+  const { getAccessToken, authenticated } = usePrivy();
+  const { userData } = useUserProvider();
+  const accountId = userData?.account_id || "";
+
+  return useQuery({
+    queryKey: ["music-generations", accountId],
+    queryFn: async () => {
+      const accessToken = await getAccessToken();
+      if (!accessToken) throw new Error("No access token");
+      return getMusicGenerations(accessToken);
+    },
+    enabled: !!accountId && authenticated,
+    // Poll only while something is actually rendering, then stop. A gallery of
+    // finished songs is static, and polling it forever would bill every idle
+    // tab a request every five seconds.
+    refetchInterval: query => {
+      const generations = query.state.data?.generations ?? [];
+      const inFlight = generations.some(
+        generation => generation.status === "pending" || generation.status === "processing",
+      );
+      return inFlight ? IN_FLIGHT_POLL_MS : false;
+    },
+    refetchOnWindowFocus: false,
+  });
+};
+
+export default useMusicGenerations;

--- a/lib/music/formatDuration.ts
+++ b/lib/music/formatDuration.ts
@@ -1,0 +1,15 @@
+/**
+ * Format a duration in seconds as m:ss.
+ *
+ * @param seconds - Duration in seconds, or null before a generation finishes.
+ * @returns The formatted duration, or an em-free placeholder when unknown.
+ */
+export function formatDuration(seconds: number | null): string {
+  if (seconds === null || !Number.isFinite(seconds)) return "0:00";
+
+  const whole = Math.max(0, Math.round(seconds));
+  const minutes = Math.floor(whole / 60);
+  const remainder = whole % 60;
+
+  return `${minutes}:${String(remainder).padStart(2, "0")}`;
+}

--- a/lib/music/getMusicGenerations.ts
+++ b/lib/music/getMusicGenerations.ts
@@ -1,0 +1,36 @@
+import { getClientApiBaseUrl } from "@/lib/api/getClientApiBaseUrl";
+import type { MusicGeneration } from "@/types/Music";
+
+export interface MusicGenerationsResponse {
+  status: string;
+  generations: MusicGeneration[];
+  error?: string;
+}
+
+/**
+ * Fetches the account's music generations from the Recoup API.
+ *
+ * @param accessToken - Privy access token for Bearer auth.
+ * @param accountId - Optional account override, for reading an account other
+ *   than the caller's own.
+ */
+export async function getMusicGenerations(
+  accessToken: string,
+  accountId?: string,
+): Promise<MusicGenerationsResponse> {
+  const query = accountId ? `?account_id=${encodeURIComponent(accountId)}` : "";
+  const response = await fetch(`${getClientApiBaseUrl()}/api/music${query}`, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`HTTP ${response.status}: ${errorText}`);
+  }
+
+  return response.json();
+}

--- a/types/Music.ts
+++ b/types/Music.ts
@@ -1,20 +1,21 @@
 export type MusicGenerationStatus = "pending" | "processing" | "completed" | "failed";
 
+/**
+ * A music generation as the API returns it (recoupable/docs#308).
+ *
+ * Ten fields, matching the shipped `music_generations` table. Anything another
+ * system already knows is not stored and so is not returned: generation
+ * parameters, the resolved seed, and the storage key all live with fal, the
+ * workflow run, or the bucket.
+ */
 export interface MusicGeneration {
   id: string;
   status: MusicGenerationStatus;
   prompt: string;
   lyrics: string;
-  title: string | null;
   model: string;
   duration_seconds: number | null;
-  seed: number | null;
-  num_inference_steps: number | null;
-  guidance_scale: number | null;
   audio_url: string | null;
-  mime_type: string | null;
-  file_size_bytes: number | null;
-  organization_id: string | null;
   error_message: string | null;
   created_at: string;
   updated_at: string;
@@ -25,7 +26,10 @@ export interface MusicGenerationLogEntry {
   message: string;
 }
 
-/** The single-generation read adds the workflow timeline. */
+/**
+ * The single-generation read adds the progress timeline, which the API fetches
+ * live from fal rather than storing.
+ */
 export interface MusicGenerationDetail extends MusicGeneration {
   logs: MusicGenerationLogEntry[];
 }

--- a/types/Music.ts
+++ b/types/Music.ts
@@ -1,0 +1,31 @@
+export type MusicGenerationStatus = "pending" | "processing" | "completed" | "failed";
+
+export interface MusicGeneration {
+  id: string;
+  status: MusicGenerationStatus;
+  prompt: string;
+  lyrics: string;
+  title: string | null;
+  model: string;
+  duration_seconds: number | null;
+  seed: number | null;
+  num_inference_steps: number | null;
+  guidance_scale: number | null;
+  audio_url: string | null;
+  mime_type: string | null;
+  file_size_bytes: number | null;
+  organization_id: string | null;
+  error_message: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface MusicGenerationLogEntry {
+  at: string;
+  message: string;
+}
+
+/** The single-generation read adds the workflow timeline. */
+export interface MusicGenerationDetail extends MusicGeneration {
+  logs: MusicGenerationLogEntry[];
+}


### PR DESCRIPTION
The `/music` entry point: a **Music** item in the left nav and a page that lists everything the account has generated. First of two chat PRs for recoupable/chat#1992.

> **Depends on recoupable/api#849** (`GET /api/music`). Until that ships the page renders its empty state rather than breaking, but it has nothing to list. **Review order: recoupable/docs#308 → recoupable/database#60 → recoupable/api#848 → recoupable/api#849 → this.**

Designs approved 2026-08-21 and embedded in the issue.

## What a user gets

Click **Music** in the rail (or the mobile drawer) → `/music` → every song they have generated, newest first, with a status pill, an inline player, and a per-card download. In-flight generations show as Queued or Processing and the list refreshes itself until they land.

The generate form is deliberately **not** in this PR; it is the second one. This PR is still a complete slice on its own: the nav item, the route, and the gallery are all user-visible and testable.

## Notable details

**Polling stops when nothing is rendering.** `refetchInterval` is a function of the query data: 5s while any generation is `pending` or `processing`, `false` otherwise. A gallery of finished songs is static, and a fixed interval would bill every idle tab a request every five seconds forever.

**The nav item is wired in both places.** `Sidebar/Menu.tsx` and `SideMenu/SideMenu.tsx` are separate components that each re-import the nav items and compute their own active flags. Adding to only one is how a nav item ends up missing on mobile.

**A native `<audio controls>`, not a custom player.** It carries play, seek, and volume, is keyboard accessible, and needs no state from us. Rebuilding it would be a lot of surface for no gain.

**Status pills get a stronger tint in dark mode.** The light-mode 8% wash specified in DESIGN.md is effectively invisible on the near-black card, so dark uses 20% with the brighter hue.

**Empty-state copy is org-aware**, using `selectedOrgId` from `useOrganization` — "no songs in this organization yet" reads very differently from "no songs yet" when you have just switched context.

## Verification

- `pnpm exec tsc --noEmit` — clean, zero errors in the whole repo.
- `pnpm exec eslint` on every touched path — clean.
- **Tests**: the existing `SecondaryNav` test gains a Music case (RED first: it failed on the missing `view music` button before the component existed), plus 4 new tests on `MusicGenerationCard` covering the download link on a completed song, its absence while generating, the verbatim failure message, and the prompt-as-title fallback.
- `pnpm build` — **this page compiles and is emitted** (`.next/server/app/music/page.js`), but the full build cannot complete in this checkout. There is no local `.env`, so `next build` gets past compilation and then fails collecting page data for `/api/agent-creator`, `/api/agent-templates`, and `/api/upload` — three routes this PR does not touch, each of which constructs a Supabase or Blob client at module load. Supplying dummy Supabase vars moved the failure to the next unrelated route, which is the confirmation that it is environmental. Build verification proper happens on the Vercel preview.

**No preview screenshots yet.** The gallery cannot render real rows until recoupable/database#60 and recoupable/api#849 are live, so a screenshot today would only show the empty state. I will post desktop and mobile screenshots of real generations against the preview once the chain lands, per the house rule that frontend PRs carry screenshots of the visible change.

Implements the chat(gallery) row of the PR matrix in recoupable/chat#1992.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fSvwazBitPfsTQvVqpi8q

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Music nav item and a `/music` gallery that lists an account’s generated songs with status, inline playback, and per-card download. Previously there was no music entry point; now users can browse and monitor generations in one place. Also fixes mobile overflow by allowing both the audio player and its card to shrink inside grid cells.

- Depends on recoupable/api#849 (`GET /api/music`); until live, the page shows an org-aware empty state without errors.
- Polls every 5s only while any generation is `pending`/`processing`; stops otherwise.
- Adds Music to both `components/Sidebar/Menu.tsx` and `components/SideMenu/SideMenu.tsx`; verify active state on desktop and mobile.
- Uses the native <audio controls> with `preload="metadata"`; the player and its containing card use shrink/flex/min-width fixes to prevent overflow on small screens. Completed items include a download link, failures show the server message, and durations render as m:ss.
- Aligns types and UI with the API’s 10-field resource: removed title/seed/etc.; songs are identified by prompt; `MusicGenerationDetail` keeps logs.
- Tests: adds a Music case to `components/Sidebar/__tests__/SecondaryNav.test.tsx` and 4 unit tests for `components/MusicPage/__tests__/MusicGenerationCard.test.tsx` covering download on completed, no download in-flight, verbatim failure message, and prompt as identifier.

<sup>Written for commit 64468f179d6c7de236e06041433299c0a6cbed36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1993?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Music page with sidebar navigation.
  * Browse music generations in a responsive gallery with loading, error, and empty states.
  * View generation counts, metadata, status badges, and processing or failure messages.
  * Play and download completed audio tracks.
  * Added formatted audio durations and automatic updates while tracks are processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->