### PR TITLE
feat(music): generate form with full fal parameter parity

### DIFF
--- a/components/MusicPage/MusicAdditionalSettings.tsx
+++ b/components/MusicPage/MusicAdditionalSettings.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { ChevronDown, Shuffle } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Input } from "@/components/ui/input";
+import MusicFieldLabel from "./MusicFieldLabel";
+import MusicSliderField from "./MusicSliderField";
+import { MUSIC_DEFAULTS, MUSIC_HINTS, MUSIC_RANGES } from "@/lib/music/const";
+
+export interface MusicSettings {
+  duration: number;
+  seed: string;
+  numInferenceSteps: number;
+  guidanceScale: number;
+}
+
+export interface MusicAdditionalSettingsProps {
+  isOpen: boolean;
+  onToggle: () => void;
+  settings: MusicSettings;
+  onChange: (settings: MusicSettings) => void;
+}
+
+const MusicAdditionalSettings = ({
+  isOpen,
+  onToggle,
+  settings,
+  onChange,
+}: MusicAdditionalSettingsProps) => {
+  const set = <K extends keyof MusicSettings>(key: K, value: MusicSettings[K]) =>
+    onChange({ ...settings, [key]: value });
+
+  return (
+    <div className="border-t pt-3">
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={isOpen}
+        className="flex w-full items-center justify-between gap-2"
+      >
+        <span className="text-sm font-medium">Additional Settings</span>
+        <span className="inline-flex items-center gap-1 text-sm text-muted-foreground">
+          {isOpen ? "Less" : "More"}
+          <ChevronDown
+            className={cn("size-4 transition-transform", isOpen && "rotate-180")}
+          />
+        </span>
+      </button>
+
+      {isOpen && (
+        <div className="mt-3 grid gap-3 sm:grid-cols-2">
+          <MusicSliderField
+            id="music-duration"
+            label="Duration"
+            hint={MUSIC_HINTS.duration}
+            {...MUSIC_RANGES.duration}
+            value={settings.duration}
+            defaultValue={MUSIC_DEFAULTS.duration}
+            format={value => `${value}s`}
+            onChange={value => set("duration", value)}
+          />
+
+          <div className="flex flex-col gap-2 min-w-0">
+            <MusicFieldLabel htmlFor="music-seed" label="Seed" hint={MUSIC_HINTS.seed} />
+            <div className="flex items-center gap-2">
+              <Input
+                id="music-seed"
+                inputMode="numeric"
+                placeholder="random"
+                value={settings.seed}
+                onChange={event =>
+                  set("seed", event.target.value.replace(/[^0-9]/g, ""))
+                }
+                className="min-w-0"
+              />
+              <button
+                type="button"
+                aria-label="Randomize seed"
+                onClick={() =>
+                  set("seed", String(Math.floor(Math.random() * 2_147_483_647)))
+                }
+                className="shrink-0 inline-flex items-center justify-center size-9 rounded-xl border hover:bg-muted transition-colors"
+              >
+                <Shuffle className="size-4" />
+              </button>
+            </div>
+          </div>
+
+          <MusicSliderField
+            id="music-steps"
+            label="Num Inference Steps"
+            hint={MUSIC_HINTS.numInferenceSteps}
+            {...MUSIC_RANGES.numInferenceSteps}
+            value={settings.numInferenceSteps}
+            defaultValue={MUSIC_DEFAULTS.numInferenceSteps}
+            onChange={value => set("numInferenceSteps", value)}
+          />
+
+          <MusicSliderField
+            id="music-guidance"
+            label="Guidance Scale"
+            hint={MUSIC_HINTS.guidanceScale}
+            {...MUSIC_RANGES.guidanceScale}
+            value={settings.guidanceScale}
+            defaultValue={MUSIC_DEFAULTS.guidanceScale}
+            onChange={value => set("guidanceScale", value)}
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MusicAdditionalSettings;

--- a/components/MusicPage/MusicFieldLabel.tsx
+++ b/components/MusicPage/MusicFieldLabel.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { Info } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+export interface MusicFieldLabelProps {
+  htmlFor: string;
+  label: string;
+  hint: string;
+}
+
+/**
+ * A form label with the field's documentation behind an info icon, matching
+ * the fal playground where every input carries one. The hints are the model's
+ * own parameter descriptions, so a user can tell what a setting does without
+ * leaving the page.
+ */
+const MusicFieldLabel = ({ htmlFor, label, hint }: MusicFieldLabelProps) => (
+  <div className="flex items-center gap-1">
+    <label htmlFor={htmlFor} className="text-sm font-medium">
+      {label}
+    </label>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          aria-label={`About ${label}`}
+          className="text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <Info className="size-3.5" />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent className="max-w-[280px]">{hint}</TooltipContent>
+    </Tooltip>
+  </div>
+);
+
+export default MusicFieldLabel;

--- a/components/MusicPage/MusicGenerateForm.tsx
+++ b/components/MusicPage/MusicGenerateForm.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import MusicFieldLabel from "./MusicFieldLabel";
+import MusicAdditionalSettings, { MusicSettings } from "./MusicAdditionalSettings";
+import { useCreateMusicGeneration } from "@/hooks/useCreateMusicGeneration";
+import {
+  MUSIC_DEFAULTS,
+  MUSIC_HINTS,
+  creditCostForDuration,
+  formatCreditCostUsd,
+} from "@/lib/music/const";
+
+const EMPTY_SETTINGS: MusicSettings = {
+  duration: MUSIC_DEFAULTS.duration,
+  seed: "",
+  numInferenceSteps: MUSIC_DEFAULTS.numInferenceSteps,
+  guidanceScale: MUSIC_DEFAULTS.guidanceScale,
+};
+
+const MusicGenerateForm = () => {
+  const [prompt, setPrompt] = useState("");
+  const [lyrics, setLyrics] = useState("");
+  const [settings, setSettings] = useState<MusicSettings>(EMPTY_SETTINGS);
+  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+  const { generate, isPending } = useCreateMusicGeneration();
+
+  const credits = creditCostForDuration(settings.duration);
+  const canGenerate = prompt.trim().length > 0 && lyrics.trim().length > 0 && !isPending;
+
+  const reset = () => {
+    setPrompt("");
+    setLyrics("");
+    setSettings(EMPTY_SETTINGS);
+  };
+
+  const submit = () => {
+    generate({
+      prompt: prompt.trim(),
+      lyrics: lyrics.trim(),
+      duration: settings.duration,
+      num_inference_steps: settings.numInferenceSteps,
+      guidance_scale: settings.guidanceScale,
+      // Blank means "choose one", which the API expresses by omission.
+      ...(settings.seed ? { seed: Number(settings.seed) } : {}),
+    });
+  };
+
+  return (
+    <TooltipProvider delayDuration={200}>
+      <div className="rounded-lg border p-4 md:p-6 flex flex-col gap-4">
+        <h2 className="font-heading text-sm font-semibold">New song</h2>
+
+        <div className="flex flex-col gap-1.5">
+          <MusicFieldLabel htmlFor="music-prompt" label="Prompt" hint={MUSIC_HINTS.prompt} />
+          <Textarea
+            id="music-prompt"
+            value={prompt}
+            onChange={event => setPrompt(event.target.value)}
+            placeholder="Genre: acoustic pop. BPM: 96. Key: C major. Warm and intimate, building gently into the chorus."
+            className="min-h-[84px]"
+          />
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <MusicFieldLabel htmlFor="music-lyrics" label="Lyrics" hint={MUSIC_HINTS.lyrics} />
+          <Textarea
+            id="music-lyrics"
+            value={lyrics}
+            onChange={event => setLyrics(event.target.value)}
+            placeholder={"[verse]\nMorning light filtering through the pine\n[chorus]\nSoftly the world begins to breathe"}
+            className="min-h-[110px]"
+          />
+        </div>
+
+        <MusicAdditionalSettings
+          isOpen={isSettingsOpen}
+          onToggle={() => setIsSettingsOpen(open => !open)}
+          settings={settings}
+          onChange={setSettings}
+        />
+
+        <div className="flex flex-col-reverse gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <span className="text-xs text-muted-foreground">
+            Costs {formatCreditCostUsd(credits)} for {settings.duration}s ({credits} credits)
+          </span>
+          <div className="flex gap-2">
+            <Button variant="ghost" onClick={reset} disabled={isPending} className="flex-1 sm:flex-none">
+              Reset
+            </Button>
+            <Button onClick={submit} disabled={!canGenerate} className="flex-1 sm:flex-none">
+              {isPending ? "Generating" : "Generate"}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </TooltipProvider>
+  );
+};
+
+export default MusicGenerateForm;

--- a/components/MusicPage/MusicPage.tsx
+++ b/components/MusicPage/MusicPage.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import { MusicPageHeader } from "./MusicPageHeader";
+import MusicGenerateForm from "./MusicGenerateForm";
 import MusicGallery from "./MusicGallery";
 
 const MusicPage = () => {
   return (
     <div className="max-w-full md:max-w-[calc(100vw-200px)] grow py-8 px-6 md:px-12">
       <MusicPageHeader />
+      <MusicGenerateForm />
       <MusicGallery />
     </div>
   );

--- a/components/MusicPage/MusicSliderField.tsx
+++ b/components/MusicPage/MusicSliderField.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { Eraser } from "lucide-react";
+import MusicFieldLabel from "./MusicFieldLabel";
+
+export interface MusicSliderFieldProps {
+  id: string;
+  label: string;
+  hint: string;
+  min: number;
+  max: number;
+  step: number;
+  value: number;
+  defaultValue: number;
+  format?: (value: number) => string;
+  onChange: (value: number) => void;
+}
+
+/**
+ * A labelled range input with a reset-to-default button, mirroring the fal
+ * playground's Additional Settings controls.
+ *
+ * A native `input[type=range]` rather than a Radix slider: it is keyboard and
+ * screen-reader accessible out of the box, and adding a dependency for one
+ * control would not earn its weight.
+ */
+const MusicSliderField = ({
+  id,
+  label,
+  hint,
+  min,
+  max,
+  step,
+  value,
+  defaultValue,
+  format,
+  onChange,
+}: MusicSliderFieldProps) => {
+  const isDefault = value === defaultValue;
+
+  return (
+    <div className="flex flex-col gap-2 min-w-0">
+      <div className="flex items-center justify-between gap-2">
+        <MusicFieldLabel htmlFor={id} label={label} hint={hint} />
+        <div className="flex items-center gap-2 shrink-0">
+          <span className="text-sm text-muted-foreground">
+            {format ? format(value) : value}
+          </span>
+          <button
+            type="button"
+            onClick={() => onChange(defaultValue)}
+            disabled={isDefault}
+            aria-label={`Reset ${label} to default`}
+            className="inline-flex items-center justify-center size-9 rounded-xl border hover:bg-muted transition-colors disabled:opacity-40 disabled:pointer-events-none"
+          >
+            <Eraser className="size-4" />
+          </button>
+        </div>
+      </div>
+      <input
+        id={id}
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={event => onChange(Number(event.target.value))}
+        className="w-full accent-foreground"
+      />
+      <div className="flex justify-between text-xs text-muted-foreground">
+        <span>{format ? format(min) : min}</span>
+        <span>{format ? format(max) : max}</span>
+      </div>
+    </div>
+  );
+};
+
+export default MusicSliderField;

--- a/components/MusicPage/__tests__/MusicGenerateForm.test.tsx
+++ b/components/MusicPage/__tests__/MusicGenerateForm.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import MusicGenerateForm from "@/components/MusicPage/MusicGenerateForm";
+import { useCreateMusicGeneration } from "@/hooks/useCreateMusicGeneration";
+
+vi.mock("@/hooks/useCreateMusicGeneration", () => ({
+  useCreateMusicGeneration: vi.fn(),
+}));
+
+const generate = vi.fn();
+
+const setup = (isPending = false) => {
+  vi.mocked(useCreateMusicGeneration).mockReturnValue({ generate, isPending });
+  render(<MusicGenerateForm />);
+};
+
+const fill = () => {
+  fireEvent.change(screen.getByLabelText("Prompt"), {
+    target: { value: "Genre: acoustic pop." },
+  });
+  fireEvent.change(screen.getByLabelText("Lyrics"), {
+    target: { value: "[verse]\nMorning light" },
+  });
+};
+
+describe("MusicGenerateForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("cannot generate until both prompt and lyrics are filled", () => {
+    setup();
+
+    const button = screen.getByRole("button", { name: "Generate" });
+    expect(button.hasAttribute("disabled")).toBe(true);
+
+    fill();
+
+    expect(screen.getByRole("button", { name: "Generate" }).hasAttribute("disabled")).toBe(
+      false,
+    );
+  });
+
+  it("quotes the price in dollars with credits secondary", () => {
+    setup();
+
+    expect(screen.getByText(/Costs \$0\.30 for 60s \(30 credits\)/)).toBeDefined();
+  });
+
+  it("sends the documented defaults and omits a blank seed", () => {
+    setup();
+    fill();
+
+    fireEvent.click(screen.getByRole("button", { name: "Generate" }));
+
+    expect(generate).toHaveBeenCalledWith({
+      prompt: "Genre: acoustic pop.",
+      lyrics: "[verse]\nMorning light",
+      duration: 60,
+      num_inference_steps: 30,
+      guidance_scale: 1.7,
+    });
+  });
+
+  it("keeps Additional Settings collapsed until asked", () => {
+    setup();
+
+    expect(screen.queryByLabelText("Duration")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /Additional Settings/i }));
+
+    expect(screen.getByLabelText("Duration")).toBeDefined();
+    expect(screen.getByLabelText("Seed")).toBeDefined();
+    expect(screen.getByLabelText("Num Inference Steps")).toBeDefined();
+    expect(screen.getByLabelText("Guidance Scale")).toBeDefined();
+  });
+
+  it("reprices when the duration slider moves", () => {
+    setup();
+    fireEvent.click(screen.getByRole("button", { name: /Additional Settings/i }));
+
+    fireEvent.change(screen.getByLabelText("Duration"), { target: { value: "120" } });
+
+    expect(screen.getByText(/Costs \$0\.60 for 120s \(60 credits\)/)).toBeDefined();
+  });
+
+  it("fills the seed from the randomize button", () => {
+    setup();
+    fireEvent.click(screen.getByRole("button", { name: /Additional Settings/i }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Randomize seed" }));
+
+    expect((screen.getByLabelText("Seed") as HTMLInputElement).value).not.toBe("");
+  });
+
+  it("returns a slider to its documented default via reset", () => {
+    setup();
+    fireEvent.click(screen.getByRole("button", { name: /Additional Settings/i }));
+
+    fireEvent.change(screen.getByLabelText("Duration"), { target: { value: "200" } });
+    fireEvent.click(screen.getByRole("button", { name: /Reset Duration to default/i }));
+
+    expect((screen.getByLabelText("Duration") as HTMLInputElement).value).toBe("60");
+  });
+
+  it("disables Generate while one is already in flight", () => {
+    setup(true);
+    fill();
+
+    expect(screen.getByRole("button", { name: "Generating" }).hasAttribute("disabled")).toBe(
+      true,
+    );
+  });
+});

--- a/components/MusicPage/__tests__/musicPricing.test.ts
+++ b/components/MusicPage/__tests__/musicPricing.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { creditCostForDuration, formatCreditCostUsd } from "@/lib/music/const";
+import {
+  creditCostForDuration,
+  formatCreditCostUsd,
+  MUSIC_DEFAULTS,
+  MUSIC_RANGES,
+} from "@/lib/music/const";
 
 describe("music pricing shown in the form", () => {
   it("quotes the same 30 credits for a default song as the API charges", () => {
@@ -17,5 +22,22 @@ describe("music pricing shown in the form", () => {
   it("shows the price in dollars, which is what a customer reasons about", () => {
     expect(formatCreditCostUsd(30)).toBe("$0.30");
     expect(formatCreditCostUsd(150)).toBe("$1.50");
+  });
+});
+
+describe("slider ranges can represent their own defaults", () => {
+  // A range input snaps to its step grid. A default that is not a multiple of
+  // the step leaves the thumb somewhere the readout does not claim, and makes
+  // the default unreachable once the user drags: guidance_scale shipped as
+  // step 0.5 with a 1.7 default and rendered at 1.5.
+  it.each([
+    ["duration", MUSIC_DEFAULTS.duration, MUSIC_RANGES.duration],
+    ["numInferenceSteps", MUSIC_DEFAULTS.numInferenceSteps, MUSIC_RANGES.numInferenceSteps],
+    ["guidanceScale", MUSIC_DEFAULTS.guidanceScale, MUSIC_RANGES.guidanceScale],
+  ])("%s default sits on its step grid", (_name, value, range) => {
+    const steps = (value - range.min) / range.step;
+    expect(Math.abs(steps - Math.round(steps))).toBeLessThan(1e-9);
+    expect(value).toBeGreaterThanOrEqual(range.min);
+    expect(value).toBeLessThanOrEqual(range.max);
   });
 });

--- a/components/MusicPage/__tests__/musicPricing.test.ts
+++ b/components/MusicPage/__tests__/musicPricing.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { creditCostForDuration, formatCreditCostUsd } from "@/lib/music/const";
+
+describe("music pricing shown in the form", () => {
+  it("quotes the same 30 credits for a default song as the API charges", () => {
+    expect(creditCostForDuration(60)).toBe(30);
+  });
+
+  it("applies the same floor as the API", () => {
+    expect(creditCostForDuration(10)).toBe(15);
+  });
+
+  it("scales with duration", () => {
+    expect(creditCostForDuration(300)).toBe(150);
+  });
+
+  it("shows the price in dollars, which is what a customer reasons about", () => {
+    expect(formatCreditCostUsd(30)).toBe("$0.30");
+    expect(formatCreditCostUsd(150)).toBe("$1.50");
+  });
+});

--- a/hooks/useCreateMusicGeneration.ts
+++ b/hooks/useCreateMusicGeneration.ts
@@ -1,0 +1,50 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { usePrivy } from "@privy-io/react-auth";
+import { toast } from "sonner";
+import {
+  createMusicGeneration,
+  CreateMusicGenerationBody,
+} from "@/lib/music/createMusicGeneration";
+import { useUserProvider } from "@/providers/UserProvder";
+import { useOrganization } from "@/providers/OrganizationProvider";
+
+export function useCreateMusicGeneration() {
+  const { getAccessToken } = usePrivy();
+  const { userData } = useUserProvider();
+  const { selectedOrgId } = useOrganization();
+  const queryClient = useQueryClient();
+
+  const { mutate: generate, isPending } = useMutation({
+    mutationFn: async (body: CreateMusicGenerationBody) => {
+      const accessToken = await getAccessToken();
+      if (!accessToken) throw new Error("AUTH_REQUIRED");
+
+      return createMusicGeneration(accessToken, {
+        ...body,
+        // Organizations are accounts, so an org-scoped generation is one whose
+        // account_id is the organization. The API ignores organization_id
+        // outright, so sending that instead would silently produce a personal
+        // song while the user believed they were in an org.
+        ...(selectedOrgId ? { account_id: selectedOrgId } : {}),
+      });
+    },
+    onSuccess: async () => {
+      // Refetch immediately so the pending generation appears in the gallery
+      // and starts the poll, rather than waiting for the next interval.
+      await queryClient.invalidateQueries({
+        queryKey: ["music-generations", userData?.account_id || ""],
+      });
+    },
+    onError: (error: Error) => {
+      if (error.message === "insufficient_credits") {
+        toast.error("Not enough credits to generate this song.");
+        return;
+      }
+      toast.error(error.message || "Could not start the generation.");
+    },
+  });
+
+  return { generate, isPending };
+}

--- a/lib/music/const.ts
+++ b/lib/music/const.ts
@@ -1,0 +1,61 @@
+/**
+ * Generation parameter defaults and ranges.
+ *
+ * These mirror the documented contract (recoupable/docs#308), which in turn
+ * mirrors the fal minimax/music-3 form. The API clamps to the same bounds, so
+ * these are for the UI's benefit, not the source of truth.
+ */
+export const MUSIC_DEFAULTS = {
+  duration: 60,
+  numInferenceSteps: 30,
+  guidanceScale: 1.7,
+} as const;
+
+export const MUSIC_RANGES = {
+  duration: { min: 10, max: 300, step: 5 },
+  numInferenceSteps: { min: 1, max: 100, step: 1 },
+  guidanceScale: { min: 0, max: 20, step: 0.5 },
+} as const;
+
+/** Parameter descriptions, taken from the model's own schema. */
+export const MUSIC_HINTS = {
+  prompt:
+    "Music description: style, mood, vocals, instrumentation and arrangement. Be specific about genre, BPM and key for tighter control.",
+  lyrics:
+    "The lyrics to sing. Structure tags such as [intro], [verse], [chorus] and [outro] must each be on their own line.",
+  duration:
+    "Upper bound on the generated audio length in seconds. The model may stop earlier.",
+  seed: "Seed for reproducibility. Leave blank for a random seed.",
+  numInferenceSteps:
+    "Flow-matching steps per denoising chunk. More steps improve quality at the cost of speed.",
+  guidanceScale: "Classifier-free guidance scale of the flow-matching stage.",
+} as const;
+
+/** Credits charged per second of requested audio, with a floor. Mirrors the API. */
+const CREDITS_PER_SECOND = 0.5;
+const MIN_CREDIT_COST = 15;
+
+/**
+ * Credits a generation of this length will cost.
+ *
+ * Duplicated from the API deliberately: the quote has to render before the
+ * request is made, and a round trip to price a slider drag would be worse than
+ * one shared constant restated. The API stays authoritative and freezes the
+ * real price onto the row.
+ *
+ * @param durationSeconds - Requested length.
+ * @returns Whole credits.
+ */
+export function creditCostForDuration(durationSeconds: number): number {
+  return Math.max(MIN_CREDIT_COST, Math.ceil(durationSeconds * CREDITS_PER_SECOND));
+}
+
+/**
+ * Dollar cost of a generation, for display beside the credit figure.
+ *
+ * @param credits - Credits the generation will cost.
+ * @returns The cost formatted as USD.
+ */
+export function formatCreditCostUsd(credits: number): string {
+  return `$${(credits / 100).toFixed(2)}`;
+}

--- a/lib/music/const.ts
+++ b/lib/music/const.ts
@@ -14,7 +14,11 @@ export const MUSIC_DEFAULTS = {
 export const MUSIC_RANGES = {
   duration: { min: 10, max: 300, step: 5 },
   numInferenceSteps: { min: 1, max: 100, step: 1 },
-  guidanceScale: { min: 0, max: 20, step: 0.5 },
+  // step 0.1, not fal's 0.5: the documented default is 1.7, which is not a
+  // multiple of 0.5, so a coarser step left the thumb snapped to 1.5 while the
+  // readout said 1.7 and made the default unreachable once dragged. fal can
+  // use 0.5 because its control is a number field you can type into.
+  guidanceScale: { min: 0, max: 20, step: 0.1 },
 } as const;
 
 /** Parameter descriptions, taken from the model's own schema. */

--- a/lib/music/createMusicGeneration.ts
+++ b/lib/music/createMusicGeneration.ts
@@ -1,0 +1,52 @@
+import { getClientApiBaseUrl } from "@/lib/api/getClientApiBaseUrl";
+import type { MusicGeneration } from "@/types/Music";
+
+export interface CreateMusicGenerationBody {
+  prompt: string;
+  lyrics: string;
+  duration?: number;
+  seed?: number;
+  num_inference_steps?: number;
+  guidance_scale?: number;
+  account_id?: string;
+}
+
+export interface CreateMusicGenerationResponse {
+  status: string;
+  generation: MusicGeneration;
+  error?: string;
+}
+
+/**
+ * Starts a music generation.
+ *
+ * Resolves as soon as the API accepts the request (202) — the song is not
+ * ready yet, and the caller polls the returned generation.
+ *
+ * @param accessToken - Privy access token for Bearer auth.
+ * @param body - Generation parameters.
+ */
+export async function createMusicGeneration(
+  accessToken: string,
+  body: CreateMusicGenerationBody,
+): Promise<CreateMusicGenerationResponse> {
+  const response = await fetch(`${getClientApiBaseUrl()}/api/music`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+  const data = await response.json().catch(() => null);
+
+  if (!response.ok) {
+    // Surface the API's own message: "insufficient_credits" and a rejected
+    // lyrics field are both things the user can act on, and a generic
+    // "something went wrong" would hide them.
+    throw new Error(data?.error || `HTTP ${response.status}`);
+  }
+
+  return data as CreateMusicGenerationResponse;
+}


### PR DESCRIPTION
The generate form on `/music`: prompt, lyrics, and the full fal parameter set behind an Additional Settings disclosure. Second of two chat PRs for recoupable/chat#1992, and the last row of its PR matrix.

> **Stacked on recoupable/chat#1993** (the nav item and gallery), so its files appear in this diff until it merges. **Full order: recoupable/docs#308 → recoupable/database#60 → recoupable/api#848 → recoupable/api#849 → recoupable/chat#1993 → this.** Also depends on `POST /api/music` from recoupable/api#848.

Designs approved 2026-08-21 and embedded in the issue.

## What a user gets

Type a prompt and lyrics, hit **Generate**, and the new song appears in the gallery below as Queued, then Processing, then playable — without leaving the page. The gallery's own conditional polling (shipped in #1993) does the watching; this PR just invalidates the query on success so the pending row shows up immediately rather than up to five seconds later.

## Parameter parity with fal, deliberately

Additional Settings exposes **all four** parameters the fal playground does — duration, seed, num inference steps, guidance scale — with fal's own ranges and defaults, read off the live form rather than from memory: duration 1–300 (we floor at 10), steps 1–100 default 30, guidance 0–20 step 0.5 default 1.7, seed free text defaulting to random.

The earlier draft hid steps and guidance on the grounds that they are flow-matching internals. That was the wrong call and was reversed on review: hiding two of four means we own a judgment about which knobs matter, and we would re-own it on every model swap. Full parity makes the UI a thin, predictable surface over the model.

Each control carries fal's affordances too: an info tooltip per input (the model's own parameter description), a reset-to-default eraser on each slider, and a randomize button on seed. That asymmetry is fal's, not an inconsistency of ours.

## Notable details

**A native `input[type=range]`, not a Radix slider.** `@radix-ui/react-slider` is not a dependency here, and adding one for a single control would not earn its weight. The native control is keyboard and screen-reader accessible as-is.

**Price is quoted in dollars with credits secondary** (`Costs $0.30 for 60s (30 credits)`) and reprices live as the duration slider moves. This restates the API's pricing constants client-side, which is a deliberate, commented duplication: quoting a price cannot cost a round trip per slider drag, and the API stays authoritative by freezing the real price onto the row at creation.

**API error messages surface verbatim.** `insufficient_credits` becomes a specific toast; a rejected lyrics field shows what the API said. A generic "something went wrong" would hide the two failures a user can actually act on.

**Blank seed is omitted, not sent as null** — the API treats an absent seed as "choose one" and reports back the seed it used.

## Verification

- **8 new tests** on the form: the disabled-until-filled rule, the dollar quote, the exact payload including the omitted blank seed, the collapsed-by-default disclosure, repricing on a slider move ($0.30 → $0.60), the randomize button filling the field, a slider reset returning to its documented default, and Generate disabled while one is in flight. Plus 4 on the shared pricing helpers asserting the client quote matches what the API charges (30 credits at 60s, the 15-credit floor, 150 at 300s).
- `pnpm exec tsc --noEmit` — clean, zero errors in the whole repo.
- `pnpm exec eslint` on every touched path — clean.
- `pnpm build` — the page compiles and is emitted (`.next/server/app/music/page.js`). The full build cannot complete in this checkout: with no local `.env`, `next build` clears compilation and then fails collecting page data for `/api/agent-creator`, `/api/agent-templates`, and `/api/upload`, three routes this PR does not touch that construct clients at module load. Supplying dummy Supabase vars just moved the failure to the next unrelated route, which is the confirmation that it is environmental. Build verification proper happens on the Vercel preview.

**No preview screenshots yet**, and no end-to-end run: `POST /api/music` does not exist until recoupable/api#848 is live, which itself waits on the migration. Once the chain lands I will run a real generation through the preview and post desktop and mobile screenshots plus the observed state transitions, per the house rule for frontend PRs.

Implements the chat(form) row of the PR matrix in recoupable/chat#1992 — the final row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fSvwazBitPfsTQvVqpi8q

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the /music generate form with fal parameter parity and correct org scoping. Previously no on-page generation and org scope used organization_id (ignored); now users generate in place, blank seed is omitted, price quotes live with duration, API errors surface verbatim, the gallery shows rows immediately, and org scope is sent as account_id so items land in the selected org. Guidance slider now uses a 0.1 step so the 1.7 default is reachable.

- Uses fal ranges/defaults with one intentional deviation: guidance scale step 0.1 (fal’s 0.5 made 1.7 unreachable on a range input). Native range inputs instead of `@radix-ui/react-slider`. Pricing is duplicated client-side for responsiveness; the API freezes the authoritative price at creation.
- Verify payload mapping in `useCreateMusicGeneration` and `lib/music/createMusicGeneration.ts`: blank seed omitted; org scope passed as account_id; parameter names match the API (`num_inference_steps`, `guidance_scale`).
- Tests cover disabled-until-filled, payload (including omitted seed), live repricing, reset/randomize controls, collapsed-by-default settings, in-flight disable, pricing parity, and that slider defaults sit on their step grid.

**Rollout**
- Requires POST /api/music and gallery polling via GET /api/music. No client migrations.

<sup>Written for commit 08e83850ec16b41215d6a2253f71cd250ef6b9ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

