### PR TITLE
fix(music): make the download button actually download

### DIFF
--- a/components/MusicPage/MusicGenerationCard.tsx
+++ b/components/MusicPage/MusicGenerationCard.tsx
@@ -3,6 +3,7 @@
 import { Download } from "lucide-react";
 import MusicStatusPill from "./MusicStatusPill";
 import { formatDuration } from "@/lib/music/formatDuration";
+import { musicDownloadFilename, musicDownloadUrl } from "@/lib/music/musicDownloadUrl";
 import type { MusicGeneration } from "@/types/Music";
 
 const MusicGenerationCard = ({ generation }: { generation: MusicGeneration }) => {
@@ -10,6 +11,12 @@ const MusicGenerationCard = ({ generation }: { generation: MusicGeneration }) =>
   // The API returns no title: the prompt is what the user wrote and what
   // identifies the song to them.
   const title = generation.prompt;
+  const downloadHref = generation.audio_url
+    ? musicDownloadUrl(
+        generation.audio_url,
+        musicDownloadFilename(generation.prompt, generation.audio_url),
+      )
+    : null;
 
   return (
     // min-w-0 because a grid item defaults to min-width:auto and will not
@@ -48,7 +55,7 @@ const MusicGenerationCard = ({ generation }: { generation: MusicGeneration }) =>
             <track kind="captions" />
           </audio>
           <a
-            href={generation.audio_url ?? undefined}
+            href={downloadHref ?? undefined}
             download
             aria-label={`Download ${title}`}
             className="shrink-0 inline-flex items-center justify-center size-9 rounded-xl border hover:bg-muted transition-colors"

--- a/components/MusicPage/__tests__/MusicGenerationCard.test.tsx
+++ b/components/MusicPage/__tests__/MusicGenerationCard.test.tsx
@@ -24,8 +24,32 @@ describe("MusicGenerationCard", () => {
     render(<MusicGenerationCard generation={generation()} />);
 
     const download = screen.getByRole("link", { name: /download genre: acoustic pop/i });
-    expect(download.getAttribute("href")).toBe("https://cdn.example/music/abc.wav");
     expect(download.hasAttribute("download")).toBe(true);
+  });
+
+  // The download attribute alone shipped broken: browsers ignore it
+  // cross-origin, and our audio is on Supabase while the app is not, so the
+  // link navigated the tab to a bare audio file. Asserting the attribute
+  // exists is what let that through, so assert the url does the work.
+  it("asks storage for an attachment so the download survives being cross-origin", () => {
+    render(<MusicGenerationCard generation={generation()} />);
+
+    const href = screen
+      .getByRole("link", { name: /download genre: acoustic pop/i })
+      .getAttribute("href") as string;
+
+    expect(href).toContain("download=");
+    expect(href.startsWith("https://cdn.example/music/abc.wav")).toBe(true);
+  });
+
+  it("saves under a name taken from the prompt, not the generation id", () => {
+    render(<MusicGenerationCard generation={generation()} />);
+
+    const href = screen
+      .getByRole("link", { name: /download genre: acoustic pop/i })
+      .getAttribute("href") as string;
+
+    expect(href).toContain("download=genre-acoustic-pop.wav");
   });
 
   it("offers no download while a song is still generating", () => {

--- a/lib/music/__tests__/musicDownloadUrl.test.ts
+++ b/lib/music/__tests__/musicDownloadUrl.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { musicDownloadUrl, musicDownloadFilename } from "@/lib/music/musicDownloadUrl";
+
+const AUDIO =
+  "https://proj.supabase.co/storage/v1/object/public/public-uploads/music/abc-123.wav";
+
+describe("musicDownloadFilename", () => {
+  it("names the file after the prompt so a saved song is recognisable", () => {
+    expect(musicDownloadFilename("Genre: dream pop. BPM: 104.", AUDIO)).toBe(
+      "genre-dream-pop-bpm-104.wav",
+    );
+  });
+
+  it("keeps the extension of the stored object", () => {
+    expect(musicDownloadFilename("song", "https://x/y/abc.mp3")).toBe("song.mp3");
+  });
+
+  it("falls back to wav when the url carries no extension", () => {
+    expect(musicDownloadFilename("song", "https://x/y/abc")).toBe("song.wav");
+  });
+
+  it("truncates a long prompt rather than producing an unusable filename", () => {
+    const name = musicDownloadFilename("word ".repeat(60), AUDIO);
+    expect(name.length).toBeLessThanOrEqual(64);
+    expect(name.endsWith(".wav")).toBe(true);
+  });
+
+  it("never yields a bare extension when the prompt has nothing usable", () => {
+    expect(musicDownloadFilename("!!! ???", AUDIO)).toBe("generated-song.wav");
+  });
+});
+
+describe("musicDownloadUrl", () => {
+  it("asks storage for an attachment, which is what makes a cross-origin download work", () => {
+    const url = musicDownloadUrl(AUDIO, "my-song.wav");
+
+    expect(url).toContain("download=my-song.wav");
+    expect(url?.startsWith(AUDIO)).toBe(true);
+  });
+
+  it("appends to an href that already carries a query", () => {
+    const url = musicDownloadUrl(`${AUDIO}?token=abc`, "my-song.wav") as string;
+
+    expect(url).toContain("token=abc");
+    expect(url).toContain("download=my-song.wav");
+    expect(url.split("?").length).toBe(2);
+  });
+
+  it("encodes a filename with characters that would break the query", () => {
+    expect(musicDownloadUrl(AUDIO, "a b&c.wav")).toContain("download=a%20b%26c.wav");
+  });
+
+  it("returns null when there is nothing to download", () => {
+    expect(musicDownloadUrl(null, "x.wav")).toBeNull();
+  });
+});

--- a/lib/music/musicDownloadUrl.ts
+++ b/lib/music/musicDownloadUrl.ts
@@ -1,0 +1,50 @@
+/** Longest filename we will hand the browser, extension included. */
+const MAX_FILENAME_LENGTH = 64;
+
+/**
+ * A readable filename for a downloaded song.
+ *
+ * Named after the prompt because that is what the user wrote and the only
+ * thing that identifies a song to them; the generation uuid would save as an
+ * unrecognisable blob. The extension is taken from the stored object rather
+ * than assumed, so a future model returning mp3 still saves correctly.
+ *
+ * @param prompt - The prompt the song was generated from.
+ * @param audioUrl - The stored audio url, used only for its extension.
+ * @returns A slugified filename with an extension.
+ */
+export function musicDownloadFilename(prompt: string, audioUrl: string): string {
+  const extension = /\.([a-z0-9]{2,4})(?:$|\?)/i.exec(audioUrl)?.[1]?.toLowerCase() ?? "wav";
+  const slug = prompt
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  if (!slug) return `generated-song.${extension}`;
+
+  const room = MAX_FILENAME_LENGTH - extension.length - 1;
+  return `${slug.slice(0, room).replace(/-+$/, "")}.${extension}`;
+}
+
+/**
+ * The url to hang off a download link.
+ *
+ * The `download` attribute alone is not enough: browsers ignore it for
+ * cross-origin urls, and our audio is served from Supabase Storage while the
+ * app runs on its own domain. The attribute was therefore dropped and the link
+ * behaved like ordinary navigation, replacing the page with a bare audio file.
+ *
+ * Supabase honours a `download` query parameter by returning
+ * `Content-Disposition: attachment`, which forces a real download whatever the
+ * origin, so the fix belongs in the url rather than the markup.
+ *
+ * @param audioUrl - The stored audio url, or null when nothing is ready.
+ * @param filename - Name to save the file as.
+ * @returns The download url, or null when there is nothing to download.
+ */
+export function musicDownloadUrl(audioUrl: string | null, filename: string): string | null {
+  if (!audioUrl) return null;
+
+  const separator = audioUrl.includes("?") ? "&" : "?";
+  return `${audioUrl}${separator}download=${encodeURIComponent(filename)}`;
+}


### PR DESCRIPTION
Reported in use: clicking the download button on a completed song **navigated the current tab to the audio file** instead of saving it, dumping the user out of `/music` onto a bare audio player.

## Cause

The card rendered `<a href={audio_url} download>`, and **the `download` attribute is ignored for cross-origin URLs**. Our audio is served from Supabase Storage (`…supabase.co`) while the app runs on its own domain, so the browser drops the attribute and treats the link as ordinary navigation. No amount of markup fixes this.

## Fix

Supabase Storage honours a `download` query parameter by returning `Content-Disposition: attachment`, which forces a real download regardless of origin — so the fix belongs in the URL, not the markup. Verified against a live object rather than taken from docs:

```
plain URL                  → content-type: audio/wav
?download=my-song.wav      → content-disposition: attachment; filename=my-song.wav
```

Because a real download is achievable, the `target="_blank"` fallback the reporter offered is not needed — the tab is never navigated at all.

Files also now save under a name slugified from the prompt (`genre-dream-pop-bpm-104.wav`) rather than the generation uuid, keeping whatever extension the stored object actually has so a future model returning mp3 still saves correctly.

## The test that let this ship

The original assertion was:

```ts
expect(download.hasAttribute("download")).toBe(true);
```

Which passed, and always would have — the attribute *was* present. It just does nothing cross-origin. That assertion is replaced with ones about what the URL actually does, so the same class of bug cannot pass again:

```ts
expect(href).toContain("download=");
expect(href).toContain("download=genre-acoustic-pop.wav");
```

## Verification

- **9 new tests** on `musicDownloadUrl` / `musicDownloadFilename`, each RED before GREEN: attachment param, appending to a URL that already has a query, filename encoding, extension preserved from the object, long-prompt truncation, the no-usable-characters fallback, and the null case.
- **3 card tests** covering the rendered href.
- Full chat suite: **471 tests / 105 files pass**.
- `tsc --noEmit` and `eslint` clean.

Preview verification to follow in a comment: clicking download saves the file and leaves `/music` on screen.

Fixes the download row of the PR matrix in recoupable/chat#1992.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fSvwazBitPfsTQvVqpi8q


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Music “Download” button trigger a real file download and keep users on /music. Previously, clicking “Download” navigated to the audio file (browsers ignored the cross‑origin download attribute); now we append a Supabase `download` query to force `Content-Disposition: attachment`. Files also save under a readable, prompt‑derived name with the correct extension.

- Updates the card to build `href` with `musicDownloadUrl(audioUrl, musicDownloadFilename(prompt, audioUrl))`; still hides the link when not completed.
- Adds `lib/music/musicDownloadUrl.ts`:
  - `musicDownloadUrl` appends `?download=<encoded>` (or `&download=`) to the storage URL.
  - `musicDownloadFilename` slugifies the prompt, preserves the object’s extension, truncates to 64 chars, and falls back to `generated-song.<ext>`.
- Replaces brittle tests that only checked for a `download` attribute with assertions on the generated URL and filename; adds unit tests for edge cases (existing query params, encoding, long/empty prompts).

<sup>Written for commit 896844325d0d755d8097b63f3c4eb5b74e5826a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Music downloads now use readable filenames based on the generation prompt.
  * Downloaded audio files use the correct file extension, defaulting to WAV when unavailable.
  * Download links now include the generated filename for a clearer download experience.

* **Bug Fixes**
  * Improved handling of missing or invalid audio URLs when preparing downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->