### PR TITLE
fix(music): make the detail dialog closable

### DIFF
--- a/components/MusicPage/MusicGenerationCard.tsx
+++ b/components/MusicPage/MusicGenerationCard.tsx
@@ -20,94 +20,101 @@ const MusicGenerationCard = ({ generation }: { generation: MusicGeneration }) =>
   );
 
   return (
-    // min-w-0 because a grid item defaults to min-width:auto and will not
-    // shrink below its content. Without it this card rendered 719px wide in a
-    // 342px cell on mobile, pushing the player off screen.
-    <div
-      onClick={() => setDetailOpen(true)}
-      className="p-4 border rounded-lg min-w-0 cursor-pointer hover:bg-muted/40 transition-colors"
-    >
-      <div className="flex items-start justify-between gap-2">
-        <div className="min-w-0">
-          {/* A real button, so the dialog is reachable by keyboard. The card's
-              own onClick covers the rest of the surface for pointer users
-              without nesting interactive content inside a role="button". */}
-          <button
-            type="button"
-            aria-label={`View details for ${title}`}
-            className="block w-full text-left"
+    // The dialog is a sibling of the card, never a child of it. Radix portals
+    // it to document.body, but React events travel the React tree rather than
+    // the DOM tree, so as a child every click inside the dialog still reached
+    // this onClick and reopened it in the same tick Radix closed it, which
+    // made the X look inert and click-away reopen instantly.
+    <>
+      {/* min-w-0 because a grid item defaults to min-width:auto and will not
+          shrink below its content. Without it this card rendered 719px wide in
+          a 342px cell on mobile, pushing the player off screen. */}
+      <div
+        onClick={() => setDetailOpen(true)}
+        className="p-4 border rounded-lg min-w-0 cursor-pointer hover:bg-muted/40 transition-colors"
+      >
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0">
+            {/* A real button, so the dialog is reachable by keyboard. The card's
+                own onClick covers the rest of the surface for pointer users
+                without nesting interactive content inside a role="button". */}
+            <button
+              type="button"
+              aria-label={`View details for ${title}`}
+              className="block w-full text-left"
+            >
+              <h2 className="font-semibold text-base truncate">{title}</h2>
+            </button>
+            <p className="text-sm text-muted-foreground mt-0.5">
+              {new Date(generation.created_at).toLocaleDateString()}
+            </p>
+          </div>
+          <MusicStatusPill status={generation.status} />
+        </div>
+
+        {isCompleted && (
+          // The player and the download live inside a clickable card, so their
+          // clicks stop here. Without this, pressing play or saving a song would
+          // also pop the detail dialog open.
+          <div
+            onClick={event => event.stopPropagation()}
+            className="mt-3 flex items-center gap-2 min-w-0"
           >
-            <h2 className="font-semibold text-base truncate">{title}</h2>
-          </button>
-          <p className="text-sm text-muted-foreground mt-0.5">
-            {new Date(generation.created_at).toLocaleDateString()}
+            {/* The native player carries play, seek, and volume, and stays
+                keyboard accessible without us rebuilding any of it.
+                preload="metadata" fetches only the header, a few KB, so the
+                scrubber shows the real length straight away. With "none" it read
+                0:00 / 0:00 next to a Completed pill, which looks like an empty
+                file until you press play.
+
+                flex-1 with a zero basis rather than w-full: a native audio
+                element has a wide intrinsic width and a flex item will not
+                shrink below its content, so w-full rendered the card 719px wide
+                inside a 342px grid cell on mobile. */}
+            <audio
+              controls
+              preload="metadata"
+              src={generation.audio_url ?? undefined}
+              className="h-9 min-w-0 flex-1 basis-0"
+            >
+              <track kind="captions" />
+            </audio>
+            <a
+              href={downloadHref ?? undefined}
+              download
+              aria-label={`Download ${title}`}
+              className="shrink-0 inline-flex items-center justify-center size-9 rounded-xl border hover:bg-muted transition-colors"
+            >
+              <Download className="size-4" />
+            </a>
+          </div>
+        )}
+
+        {generation.status === "processing" || generation.status === "pending" ? (
+          <p className="mt-3 text-xs text-muted-foreground">
+            Generating. This usually takes 1 to 2 minutes.
           </p>
-        </div>
-        <MusicStatusPill status={generation.status} />
+        ) : null}
+
+        {generation.status === "failed" && (
+          <p className="mt-3 text-xs text-destructive">
+            {generation.error_message || "Generation failed."}
+          </p>
+        )}
+
+        {isCompleted && generation.duration_seconds !== null && (
+          <p className="mt-2 text-xs text-muted-foreground">
+            {formatDuration(generation.duration_seconds)}
+          </p>
+        )}
       </div>
-
-      {isCompleted && (
-        // The player and the download live inside a clickable card, so their
-        // clicks stop here. Without this, pressing play or saving a song would
-        // also pop the detail dialog open.
-        <div
-          onClick={event => event.stopPropagation()}
-          className="mt-3 flex items-center gap-2 min-w-0"
-        >
-          {/* The native player carries play, seek, and volume, and stays
-              keyboard accessible without us rebuilding any of it.
-              preload="metadata" fetches only the header, a few KB, so the
-              scrubber shows the real length straight away. With "none" it read
-              0:00 / 0:00 next to a Completed pill, which looks like an empty
-              file until you press play.
-
-              flex-1 with a zero basis rather than w-full: a native audio
-              element has a wide intrinsic width and a flex item will not
-              shrink below its content, so w-full rendered the card 719px wide
-              inside a 342px grid cell on mobile. */}
-          <audio
-            controls
-            preload="metadata"
-            src={generation.audio_url ?? undefined}
-            className="h-9 min-w-0 flex-1 basis-0"
-          >
-            <track kind="captions" />
-          </audio>
-          <a
-            href={downloadHref ?? undefined}
-            download
-            aria-label={`Download ${title}`}
-            className="shrink-0 inline-flex items-center justify-center size-9 rounded-xl border hover:bg-muted transition-colors"
-          >
-            <Download className="size-4" />
-          </a>
-        </div>
-      )}
-
-      {generation.status === "processing" || generation.status === "pending" ? (
-        <p className="mt-3 text-xs text-muted-foreground">
-          Generating. This usually takes 1 to 2 minutes.
-        </p>
-      ) : null}
-
-      {generation.status === "failed" && (
-        <p className="mt-3 text-xs text-destructive">
-          {generation.error_message || "Generation failed."}
-        </p>
-      )}
-
-      {isCompleted && generation.duration_seconds !== null && (
-        <p className="mt-2 text-xs text-muted-foreground">
-          {formatDuration(generation.duration_seconds)}
-        </p>
-      )}
 
       <MusicDetailDialog
         generation={generation}
         open={detailOpen}
         onOpenChange={setDetailOpen}
       />
-    </div>
+    </>
   );
 };
 

--- a/components/MusicPage/__tests__/MusicGenerationCard.test.tsx
+++ b/components/MusicPage/__tests__/MusicGenerationCard.test.tsx
@@ -141,4 +141,40 @@ describe("MusicGenerationCard", () => {
 
     expect(screen.getByRole("dialog")).toBeDefined();
   });
+
+  it("closes when the X is clicked", () => {
+    render(<MusicGenerationCard generation={generation()} />);
+    fireEvent.click(screen.getByRole("button", { name: /view details/i }));
+    expect(screen.queryByRole("dialog")).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /^close$/i }));
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("stays closed after a click inside the dialog", () => {
+    // The dialog used to sit inside the card's clickable div. Radix portals it
+    // to document.body, but React events travel the React tree rather than the
+    // DOM tree, so a click in the dialog still reached the card handler and
+    // reopened it in the same tick. Radix closed it, the card reopened it.
+    render(<MusicGenerationCard generation={generation()} />);
+    fireEvent.click(screen.getByRole("button", { name: /view details/i }));
+
+    fireEvent.click(screen.getByTestId("music-detail-prompt"));
+
+    expect(screen.queryByRole("dialog")).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /^close$/i }));
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("closes on Escape", () => {
+    render(<MusicGenerationCard generation={generation()} />);
+    fireEvent.click(screen.getByRole("button", { name: /view details/i }));
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
 });


### PR DESCRIPTION
Reported on the chat#1992 matrix: the song detail dialog could not be dismissed. The X appeared to do nothing, and clicking away closed it and reopened it instantly.

## Cause

`MusicDetailDialog` was rendered as a **child** of the card `div` that carries `onClick={() => setDetailOpen(true)}`.

Radix portals the dialog to `document.body`, so in the DOM it is nowhere near the card — which is what makes this easy to miss. But **React events propagate along the React tree, not the DOM tree**. Every click inside the portal still reached the card's handler:

1. Click the X → Radix calls `onOpenChange(false)`
2. The same click bubbles up the React tree to the card → `setDetailOpen(true)`
3. Both land in one tick, so the dialog never visibly closes

Click-away was the same sequence, just with the reopen visible as a flash.

## Fix

The dialog is now a **sibling** of the card rather than a descendant, so the propagation path no longer exists. That is preferable to `stopPropagation` on the dialog content, which would have suppressed the symptom while leaving a card that swallows events from a subtree it should have no relationship with.

The bulk of the diff is the re-indent from nesting the card one level deeper inside a fragment; `git diff -w` shows the actual change is about fifteen lines.

## Tests

Three added, 47/47 green. TDD, with the two click paths confirmed RED first:

| Test | Before |
|---|---|
| closes when the X is clicked | **FAIL** |
| stays closed after a click inside the dialog | **FAIL** |
| closes on Escape | passed already |

Escape was never broken, because a keydown on `document` does not travel the React tree from the card. That is worth having as a test anyway, since it is the only close path that worked and a future refactor could take it away.

## Why the existing tests missed it

chat#1996 tested that clicking the download and the player do **not** open the dialog, but never that the dialog closes. I also verified the open path on preview and never tried to dismiss it. Both gaps are the same shape: the feature was checked for what it should not do on the way in, and not at all on the way out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fSvwazBitPfsTQvVqpi8q

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the music detail dialog so it can be dismissed. Previously, clicking the X or outside immediately reopened the dialog; now X, click-away, and Escape close it and it stays closed.

**Review notes**
- Render MusicDetailDialog as a sibling of the card to break React event propagation that reopened it, avoiding stopPropagation on dialog content.
- Preserve player/download behavior by stopping propagation only within the card’s media row.
- Add tests: closes via X; stays closed after a click inside the dialog; closes on Escape.
- Most of the diff is indentation from wrapping the card in a fragment; the functional change is small.

<sup>Written for commit 53753432a0967abca5b147922ab9595d74aab31c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/1997?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

