### PR TITLE
feat(music): quote the price as an upper bound at fal's rate

### DIFF
--- a/components/MusicPage/MusicGenerateForm.tsx
+++ b/components/MusicPage/MusicGenerateForm.tsx
@@ -85,7 +85,8 @@ const MusicGenerateForm = () => {
 
         <div className="flex flex-col-reverse gap-2 sm:flex-row sm:items-center sm:justify-between">
           <span className="text-xs text-muted-foreground">
-            Costs {formatCreditCostUsd(credits)} for {settings.duration}s ({credits} credits)
+            Up to {formatCreditCostUsd(credits)} for {settings.duration}s ({credits} credits).
+            You are charged for the audio actually generated.
           </span>
           <div className="flex gap-2">
             <Button variant="ghost" onClick={reset} disabled={isPending} className="flex-1 sm:flex-none">

--- a/components/MusicPage/__tests__/MusicGenerateForm.test.tsx
+++ b/components/MusicPage/__tests__/MusicGenerateForm.test.tsx
@@ -43,10 +43,14 @@ describe("MusicGenerateForm", () => {
     );
   });
 
-  it("quotes the price in dollars with credits secondary", () => {
+  it("quotes the price as an upper bound, in dollars with credits secondary", () => {
+    // "Up to", because the API charges for the audio fal actually produced and
+    // the model routinely stops short (recoupable/api#853). A fixed "Costs"
+    // would overstate what most generations are billed.
     setup();
 
-    expect(screen.getByText(/Costs \$0\.30 for 60s \(30 credits\)/)).toBeDefined();
+    expect(screen.getByText(/Up to \$0\.12 for 60s \(12 credits\)/)).toBeDefined();
+    expect(screen.getByText(/charged for the audio actually generated/i)).toBeDefined();
   });
 
   it("sends the documented defaults and omits a blank seed", () => {
@@ -83,7 +87,7 @@ describe("MusicGenerateForm", () => {
 
     fireEvent.change(screen.getByLabelText("Duration"), { target: { value: "120" } });
 
-    expect(screen.getByText(/Costs \$0\.60 for 120s \(60 credits\)/)).toBeDefined();
+    expect(screen.getByText(/Up to \$0\.24 for 120s \(24 credits\)/)).toBeDefined();
   });
 
   it("fills the seed from the randomize button", () => {

--- a/components/MusicPage/__tests__/musicPricing.test.ts
+++ b/components/MusicPage/__tests__/musicPricing.test.ts
@@ -7,21 +7,24 @@ import {
 } from "@/lib/music/const";
 
 describe("music pricing shown in the form", () => {
-  it("quotes the same 30 credits for a default song as the API charges", () => {
-    expect(creditCostForDuration(60)).toBe(30);
+  // Must track recoupable/api#853: fal charges $0.002/s and a credit is $0.01,
+  // so 0.2 credits/s is fal's rate with no markup. A quote that disagrees with
+  // the API is worse than no quote.
+  it("quotes the same 12 credits for a default song as the API charges", () => {
+    expect(creditCostForDuration(60)).toBe(12);
   });
 
-  it("applies the same floor as the API", () => {
-    expect(creditCostForDuration(10)).toBe(15);
+  it("applies no floor, matching the API", () => {
+    expect(creditCostForDuration(10)).toBe(2);
   });
 
   it("scales with duration", () => {
-    expect(creditCostForDuration(300)).toBe(150);
+    expect(creditCostForDuration(300)).toBe(60);
   });
 
   it("shows the price in dollars, which is what a customer reasons about", () => {
-    expect(formatCreditCostUsd(30)).toBe("$0.30");
-    expect(formatCreditCostUsd(150)).toBe("$1.50");
+    expect(formatCreditCostUsd(12)).toBe("$0.12");
+    expect(formatCreditCostUsd(60)).toBe("$0.60");
   });
 });
 

--- a/lib/music/const.ts
+++ b/lib/music/const.ts
@@ -36,11 +36,16 @@ export const MUSIC_HINTS = {
 } as const;
 
 /** Credits charged per second of requested audio, with a floor. Mirrors the API. */
-const CREDITS_PER_SECOND = 0.5;
-const MIN_CREDIT_COST = 15;
+const CREDITS_PER_SECOND = 0.2;
 
 /**
- * Credits a generation of this length will cost.
+ * Most a generation of this length will cost.
+ *
+ * An upper bound, not a price. The API charges for the audio fal actually
+ * produces, and the model routinely stops short of the requested length, so
+ * the real deduction is usually lower (recoupable/api#853). Quoting the
+ * maximum keeps the promise safe in the only direction that matters: a
+ * customer is never charged more than they were shown.
  *
  * Duplicated from the API deliberately: the quote has to render before the
  * request is made, and a round trip to price a slider drag would be worse than
@@ -48,10 +53,12 @@ const MIN_CREDIT_COST = 15;
  * real price onto the row.
  *
  * @param durationSeconds - Requested length.
- * @returns Whole credits.
+ * @returns Whole credits, at fal's own rate.
  */
 export function creditCostForDuration(durationSeconds: number): number {
-  return Math.max(MIN_CREDIT_COST, Math.ceil(durationSeconds * CREDITS_PER_SECOND));
+  if (durationSeconds <= 0) return 0;
+
+  return Math.max(1, Math.ceil(durationSeconds * CREDITS_PER_SECOND));
 }
 
 /**


### PR DESCRIPTION
Row 8 of the chat#1999 matrix. The client half of recoupable/api#853.

## Two changes

**Rate.** `CREDITS_PER_SECOND` 0.5 → 0.2 and the 15-credit floor removed, matching the API exactly. fal charges $0.002/s and a credit is $0.01, so 0.2/s is fal's rate with no markup.

| duration | before | after |
|---|---|---|
| 10s | $0.15 | **$0.02** |
| 60s | $0.30 | **$0.12** |
| 120s | $0.60 | **$0.24** |
| 300s | $1.50 | **$0.60** |

**Wording.** `Costs $0.12 for 60s (12 credits)` → `Up to $0.12 for 60s (12 credits). You are charged for the audio actually generated.`

api#853 charges for the audio fal actually produced, and the model routinely stops short — our first songs averaged 39.9s against a 60s default. A fixed "Costs" would overstate what most generations are billed. An upper bound is safe in the only direction that matters: nobody is charged more than they were shown.

This is why the earlier "the quoted price must be final" reasoning no longer applies. It existed to stop the quote being a lie; the charge now only ever moves in the customer's favour.

## On the duplicated constant

`lib/music/const.ts` restates the API's rate rather than fetching it, because the quote has to re-render on every slider drag. That was a deliberate call when the pricing shipped and it still holds — but it means **this PR and api#853 have to land together or the form lies**. The tests now name api#853 so the next person changing one finds the other.

## Tests

47/47 green, both suites updated first and confirmed RED. `tsc` and `eslint` clean.

The form test now asserts the "up to" phrasing and the explanatory line, not just the number, so dropping the caveat while keeping the price would fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fSvwazBitPfsTQvVqpi8q

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Quotes music generation as an upper bound at fal’s rate and aligns the UI with the API. Previously: “Costs $X” at 0.5 credits/s with a 15-credit floor; now: “Up to $X” at 0.2 credits/s with no floor, and we state billing is for audio actually generated (e.g., 60s now shows $0.12).

- Rollout
  - Deploy together with the API change (recoupable/api#853); otherwise the form quote will not match charges.
  - The rate is duplicated in `lib/music/const.ts` for responsive quoting; keep it in sync with the API when pricing changes.
  - Tests now assert the “Up to …” wording and the explanatory line.

<sup>Written for commit 02f4e81be618f01d9826db3f50ab29aae7e7d1d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/recoupable/chat/pull/2003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

